### PR TITLE
feat: add AI video analysis for ad copy generation

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -46,4 +46,4 @@ RUN mkdir -p uploads
 EXPOSE 8000
 
 # Start the application (migrations managed separately)
-CMD uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     libpq-dev \
+    ffmpeg \
     # Playwright Chromium dependencies
     libnss3 \
     libnspr4 \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -45,5 +45,5 @@ RUN mkdir -p uploads
 # Expose port (Railway uses dynamic $PORT)
 EXPOSE 8000
 
-# Run migrations and start the application
-CMD alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}
+# Start the application (migrations managed separately)
+CMD uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}

--- a/backend/app/api/v1/ads_library.py
+++ b/backend/app/api/v1/ads_library.py
@@ -1,0 +1,143 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+from typing import List, Optional
+from app.database import get_db
+from app.models import AdLibraryItem, Brand, User
+from app.schemas.ads_library import AdLibraryItemCreate, AdLibraryItemUpdate, AdLibraryItemResponse
+from app.core.deps import get_current_active_user
+from app.core.config import settings
+
+router = APIRouter()
+
+
+def _to_response(item: AdLibraryItem) -> dict:
+    """Convert model to response dict with brand_name."""
+    data = {
+        "id": item.id,
+        "brand_id": item.brand_id,
+        "brand_name": item.brand.name if item.brand else None,
+        "name": item.name,
+        "media_type": item.media_type,
+        "media_url": item.media_url,
+        "thumbnail_url": item.thumbnail_url,
+        "file_size": item.file_size,
+        "headline": item.headline,
+        "body": item.body,
+        "cta": item.cta,
+        "tags": item.tags,
+        "funnel_stage": item.funnel_stage,
+        "ad_format": item.ad_format,
+        "status": item.status,
+        "created_at": item.created_at,
+        "updated_at": item.updated_at,
+    }
+    return data
+
+
+@router.get("", response_model=List[AdLibraryItemResponse])
+def list_items(
+    brand_id: Optional[str] = None,
+    media_type: Optional[str] = None,
+    funnel_stage: Optional[str] = None,
+    status: Optional[str] = None,
+    skip: int = 0,
+    limit: int = 100,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    query = db.query(AdLibraryItem)
+    if brand_id:
+        query = query.filter(AdLibraryItem.brand_id == brand_id)
+    if media_type:
+        query = query.filter(AdLibraryItem.media_type == media_type)
+    if funnel_stage:
+        query = query.filter(AdLibraryItem.funnel_stage == funnel_stage)
+    if status:
+        query = query.filter(AdLibraryItem.status == status)
+    items = query.order_by(AdLibraryItem.created_at.desc()).offset(skip).limit(limit).all()
+    return [_to_response(item) for item in items]
+
+
+@router.get("/stats")
+def get_stats(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    total = db.query(func.count(AdLibraryItem.id)).scalar()
+    images = db.query(func.count(AdLibraryItem.id)).filter(AdLibraryItem.media_type == "image").scalar()
+    videos = db.query(func.count(AdLibraryItem.id)).filter(AdLibraryItem.media_type == "video").scalar()
+    return {"total": total, "images": images, "videos": videos}
+
+
+@router.get("/{item_id}", response_model=AdLibraryItemResponse)
+def get_item(
+    item_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    item = db.query(AdLibraryItem).filter(AdLibraryItem.id == item_id).first()
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return _to_response(item)
+
+
+@router.post("", response_model=AdLibraryItemResponse)
+def create_item(
+    item: AdLibraryItemCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    db_item = AdLibraryItem(**item.dict())
+    db.add(db_item)
+    db.commit()
+    db.refresh(db_item)
+    return _to_response(db_item)
+
+
+@router.put("/{item_id}", response_model=AdLibraryItemResponse)
+def update_item(
+    item_id: str,
+    item: AdLibraryItemUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    db_item = db.query(AdLibraryItem).filter(AdLibraryItem.id == item_id).first()
+    if not db_item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    for key, value in item.dict(exclude_unset=True).items():
+        setattr(db_item, key, value)
+    db.commit()
+    db.refresh(db_item)
+    return _to_response(db_item)
+
+
+@router.delete("/{item_id}")
+def delete_item(
+    item_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    db_item = db.query(AdLibraryItem).filter(AdLibraryItem.id == item_id).first()
+    if not db_item:
+        raise HTTPException(status_code=404, detail="Item not found")
+
+    # Delete from R2 if configured
+    if settings.r2_enabled and db_item.media_url and settings.R2_PUBLIC_URL in db_item.media_url:
+        try:
+            import boto3
+            s3_client = boto3.client(
+                's3',
+                endpoint_url=settings.r2_endpoint_url,
+                aws_access_key_id=settings.R2_ACCESS_KEY_ID,
+                aws_secret_access_key=settings.R2_SECRET_ACCESS_KEY,
+                region_name='auto'
+            )
+            key = db_item.media_url.replace(f"{settings.R2_PUBLIC_URL}/", "")
+            s3_client.delete_object(Bucket=settings.R2_BUCKET_NAME, Key=key)
+        except Exception as e:
+            print(f"Error deleting from R2: {e}")
+
+    db.delete(db_item)
+    db.commit()
+    return {"message": "Item deleted"}

--- a/backend/app/api/v1/ads_library.py
+++ b/backend/app/api/v1/ads_library.py
@@ -119,6 +119,70 @@ async def generate_ai_name(
         raise HTTPException(status_code=500, detail=f"AI naming failed: {str(e)}")
 
 
+class VideoThumbnailRequest(BaseModel):
+    video_url: str
+
+
+@router.post("/video-thumbnail")
+async def extract_video_thumbnail(
+    request: VideoThumbnailRequest,
+    current_user: User = Depends(get_current_active_user),
+):
+    """Extract a thumbnail frame from a video URL using ffmpeg with direct URL streaming."""
+    import tempfile
+    import subprocess
+    import uuid
+
+    tmp_thumb_path = None
+    try:
+        # Use ffmpeg directly with the video URL (handles HTTP streaming/seeking)
+        tmp_thumb_path = tempfile.mktemp(suffix=".jpg")
+        result = subprocess.run([
+            "ffmpeg", "-y",
+            "-ss", "1",           # seek to 1 second (before -i for fast seek)
+            "-i", request.video_url,
+            "-vframes", "1",      # extract 1 frame
+            "-q:v", "3",          # quality (2-5, lower=better)
+            tmp_thumb_path
+        ], capture_output=True, timeout=30)
+
+        if result.returncode != 0 or not os.path.exists(tmp_thumb_path):
+            # Fallback: try at 0 seconds
+            result = subprocess.run([
+                "ffmpeg", "-y",
+                "-i", request.video_url,
+                "-vframes", "1",
+                "-q:v", "3",
+                tmp_thumb_path
+            ], capture_output=True, timeout=30)
+
+        if not os.path.exists(tmp_thumb_path) or os.path.getsize(tmp_thumb_path) < 1000:
+            stderr = result.stderr.decode() if result.stderr else "unknown error"
+            raise Exception(f"ffmpeg failed to extract frame: {stderr[-200:]}")
+
+        # Upload thumbnail to R2
+        with open(tmp_thumb_path, "rb") as f:
+            thumb_bytes = f.read()
+
+        filename = f"thumb_{uuid.uuid4()}.jpg"
+        if settings.r2_enabled:
+            from app.api.v1.uploads import upload_to_r2
+            thumb_url = await upload_to_r2(thumb_bytes, filename, "image/jpeg")
+        else:
+            from app.api.v1.uploads import upload_to_local
+            thumb_url = await upload_to_local(thumb_bytes, filename)
+
+        # Cleanup
+        os.unlink(tmp_thumb_path)
+
+        return {"thumbnail_url": thumb_url}
+
+    except Exception as e:
+        if tmp_thumb_path and os.path.exists(tmp_thumb_path):
+            os.unlink(tmp_thumb_path)
+        raise HTTPException(status_code=500, detail=f"Thumbnail extraction failed: {str(e)}")
+
+
 @router.post("", response_model=AdLibraryItemResponse)
 def create_item(
     item: AdLibraryItemCreate,

--- a/backend/app/api/v1/ads_library.py
+++ b/backend/app/api/v1/ads_library.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 from typing import List, Optional
+import os
 from app.database import get_db
 from app.models import AdLibraryItem, Brand, User
 from app.schemas.ads_library import AdLibraryItemCreate, AdLibraryItemUpdate, AdLibraryItemResponse
@@ -21,6 +23,7 @@ def _to_response(item: AdLibraryItem) -> dict:
         "media_type": item.media_type,
         "media_url": item.media_url,
         "thumbnail_url": item.thumbnail_url,
+        "variants": item.variants,
         "file_size": item.file_size,
         "headline": item.headline,
         "body": item.body,
@@ -141,3 +144,47 @@ def delete_item(
     db.delete(db_item)
     db.commit()
     return {"message": "Item deleted"}
+
+
+class AiNameRequest(BaseModel):
+    image_url: str
+
+
+@router.post("/ai-name")
+async def generate_ai_name(
+    request: AiNameRequest,
+    current_user: User = Depends(get_current_active_user),
+):
+    """Use Gemini Flash to generate a short descriptive name for an ad image."""
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        raise HTTPException(status_code=503, detail="Gemini API not configured")
+
+    try:
+        import google.generativeai as genai
+        genai.configure(api_key=api_key)
+        model = genai.GenerativeModel('gemini-2.0-flash')
+
+        # Fetch image bytes
+        import httpx
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(request.image_url, timeout=15)
+            resp.raise_for_status()
+            image_bytes = resp.content
+            content_type = resp.headers.get("content-type", "image/jpeg")
+
+        response = model.generate_content([
+            {
+                "mime_type": content_type,
+                "data": image_bytes,
+            },
+            "Look at this ad creative image. Generate a short descriptive name (3-6 words max) that describes what's shown. "
+            "Examples: 'Woman Holding Product Bottle', 'Before After Skin Results', 'Social Media Comments Collage', "
+            "'Family Beach Scene', 'Product Flat Lay White BG'. "
+            "Return ONLY the name, nothing else. No quotes, no punctuation at the end."
+        ])
+
+        name = response.text.strip().strip('"\'.')
+        return {"name": name}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"AI naming failed: {str(e)}")

--- a/backend/app/api/v1/ads_library.py
+++ b/backend/app/api/v1/ads_library.py
@@ -73,78 +73,7 @@ def get_stats(
     return {"total": total, "images": images, "videos": videos}
 
 
-@router.get("/{item_id}", response_model=AdLibraryItemResponse)
-def get_item(
-    item_id: str,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_active_user),
-):
-    item = db.query(AdLibraryItem).filter(AdLibraryItem.id == item_id).first()
-    if not item:
-        raise HTTPException(status_code=404, detail="Item not found")
-    return _to_response(item)
-
-
-@router.post("", response_model=AdLibraryItemResponse)
-def create_item(
-    item: AdLibraryItemCreate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_active_user),
-):
-    db_item = AdLibraryItem(**item.dict())
-    db.add(db_item)
-    db.commit()
-    db.refresh(db_item)
-    return _to_response(db_item)
-
-
-@router.put("/{item_id}", response_model=AdLibraryItemResponse)
-def update_item(
-    item_id: str,
-    item: AdLibraryItemUpdate,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_active_user),
-):
-    db_item = db.query(AdLibraryItem).filter(AdLibraryItem.id == item_id).first()
-    if not db_item:
-        raise HTTPException(status_code=404, detail="Item not found")
-    for key, value in item.dict(exclude_unset=True).items():
-        setattr(db_item, key, value)
-    db.commit()
-    db.refresh(db_item)
-    return _to_response(db_item)
-
-
-@router.delete("/{item_id}")
-def delete_item(
-    item_id: str,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_active_user),
-):
-    db_item = db.query(AdLibraryItem).filter(AdLibraryItem.id == item_id).first()
-    if not db_item:
-        raise HTTPException(status_code=404, detail="Item not found")
-
-    # Delete from R2 if configured
-    if settings.r2_enabled and db_item.media_url and settings.R2_PUBLIC_URL in db_item.media_url:
-        try:
-            import boto3
-            s3_client = boto3.client(
-                's3',
-                endpoint_url=settings.r2_endpoint_url,
-                aws_access_key_id=settings.R2_ACCESS_KEY_ID,
-                aws_secret_access_key=settings.R2_SECRET_ACCESS_KEY,
-                region_name='auto'
-            )
-            key = db_item.media_url.replace(f"{settings.R2_PUBLIC_URL}/", "")
-            s3_client.delete_object(Bucket=settings.R2_BUCKET_NAME, Key=key)
-        except Exception as e:
-            print(f"Error deleting from R2: {e}")
-
-    db.delete(db_item)
-    db.commit()
-    return {"message": "Item deleted"}
-
+# --- Static POST routes MUST come before /{item_id} routes ---
 
 class AiNameRequest(BaseModel):
     image_url: str
@@ -188,3 +117,79 @@ async def generate_ai_name(
         return {"name": name}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"AI naming failed: {str(e)}")
+
+
+@router.post("", response_model=AdLibraryItemResponse)
+def create_item(
+    item: AdLibraryItemCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    data = item.model_dump()
+    db_item = AdLibraryItem(**data)
+    db.add(db_item)
+    db.commit()
+    db.refresh(db_item)
+    return _to_response(db_item)
+
+
+# --- Parameterized routes ---
+
+@router.get("/{item_id}", response_model=AdLibraryItemResponse)
+def get_item(
+    item_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    item = db.query(AdLibraryItem).filter(AdLibraryItem.id == item_id).first()
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return _to_response(item)
+
+
+@router.put("/{item_id}", response_model=AdLibraryItemResponse)
+def update_item(
+    item_id: str,
+    item: AdLibraryItemUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    db_item = db.query(AdLibraryItem).filter(AdLibraryItem.id == item_id).first()
+    if not db_item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    for key, value in item.model_dump(exclude_unset=True).items():
+        setattr(db_item, key, value)
+    db.commit()
+    db.refresh(db_item)
+    return _to_response(db_item)
+
+
+@router.delete("/{item_id}")
+def delete_item(
+    item_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    db_item = db.query(AdLibraryItem).filter(AdLibraryItem.id == item_id).first()
+    if not db_item:
+        raise HTTPException(status_code=404, detail="Item not found")
+
+    # Delete from R2 if configured
+    if settings.r2_enabled and db_item.media_url and settings.R2_PUBLIC_URL in db_item.media_url:
+        try:
+            import boto3
+            s3_client = boto3.client(
+                's3',
+                endpoint_url=settings.r2_endpoint_url,
+                aws_access_key_id=settings.R2_ACCESS_KEY_ID,
+                aws_secret_access_key=settings.R2_SECRET_ACCESS_KEY,
+                region_name='auto'
+            )
+            key = db_item.media_url.replace(f"{settings.R2_PUBLIC_URL}/", "")
+            s3_client.delete_object(Bucket=settings.R2_BUCKET_NAME, Key=key)
+        except Exception as e:
+            print(f"Error deleting from R2: {e}")
+
+    db.delete(db_item)
+    db.commit()
+    return {"message": "Item deleted"}

--- a/backend/app/api/v1/ads_library.py
+++ b/backend/app/api/v1/ads_library.py
@@ -5,8 +5,11 @@ from sqlalchemy import func
 from typing import List, Optional
 import os
 from app.database import get_db
-from app.models import AdLibraryItem, Brand, User
-from app.schemas.ads_library import AdLibraryItemCreate, AdLibraryItemUpdate, AdLibraryItemResponse
+from app.models import AdLibraryItem, AdLibraryFolder, Brand, User
+from app.schemas.ads_library import (
+    AdLibraryItemCreate, AdLibraryItemUpdate, AdLibraryItemResponse,
+    AdLibraryFolderCreate, AdLibraryFolderUpdate, AdLibraryFolderResponse,
+)
 from app.core.deps import get_current_active_user
 from app.core.config import settings
 
@@ -14,11 +17,13 @@ router = APIRouter()
 
 
 def _to_response(item: AdLibraryItem) -> dict:
-    """Convert model to response dict with brand_name."""
+    """Convert model to response dict with brand_name and folder_name."""
     data = {
         "id": item.id,
         "brand_id": item.brand_id,
         "brand_name": item.brand.name if item.brand else None,
+        "folder_id": item.folder_id,
+        "folder_name": item.folder.name if item.folder else None,
         "name": item.name,
         "media_type": item.media_type,
         "media_url": item.media_url,
@@ -42,6 +47,7 @@ def _to_response(item: AdLibraryItem) -> dict:
 def list_items(
     brand_id: Optional[str] = None,
     media_type: Optional[str] = None,
+    folder_id: Optional[str] = None,
     funnel_stage: Optional[str] = None,
     status: Optional[str] = None,
     skip: int = 0,
@@ -54,6 +60,10 @@ def list_items(
         query = query.filter(AdLibraryItem.brand_id == brand_id)
     if media_type:
         query = query.filter(AdLibraryItem.media_type == media_type)
+    if folder_id == "__none__":
+        query = query.filter(AdLibraryItem.folder_id.is_(None))
+    elif folder_id:
+        query = query.filter(AdLibraryItem.folder_id == folder_id)
     if funnel_stage:
         query = query.filter(AdLibraryItem.funnel_stage == funnel_stage)
     if status:
@@ -64,13 +74,146 @@ def list_items(
 
 @router.get("/stats")
 def get_stats(
+    brand_id: Optional[str] = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
 ):
-    total = db.query(func.count(AdLibraryItem.id)).scalar()
-    images = db.query(func.count(AdLibraryItem.id)).filter(AdLibraryItem.media_type == "image").scalar()
-    videos = db.query(func.count(AdLibraryItem.id)).filter(AdLibraryItem.media_type == "video").scalar()
+    query = db.query(AdLibraryItem)
+    if brand_id:
+        query = query.filter(AdLibraryItem.brand_id == brand_id)
+    total = query.count()
+    images = query.filter(AdLibraryItem.media_type == "image").count()
+    videos = query.filter(AdLibraryItem.media_type == "video").count()
     return {"total": total, "images": images, "videos": videos}
+
+
+# --- Folder endpoints (BEFORE parameterized /{item_id} routes) ---
+
+@router.get("/folders", response_model=List[AdLibraryFolderResponse])
+def list_folders(
+    brand_id: Optional[str] = None,
+    media_type: Optional[str] = None,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    query = db.query(AdLibraryFolder)
+    if brand_id:
+        query = query.filter(AdLibraryFolder.brand_id == brand_id)
+    if media_type:
+        query = query.filter(AdLibraryFolder.media_type == media_type)
+    folders = query.order_by(AdLibraryFolder.position, AdLibraryFolder.name).all()
+
+    results = []
+    for folder in folders:
+        count = db.query(func.count(AdLibraryItem.id)).filter(
+            AdLibraryItem.folder_id == folder.id
+        ).scalar()
+        results.append({
+            "id": folder.id,
+            "brand_id": folder.brand_id,
+            "media_type": folder.media_type,
+            "name": folder.name,
+            "position": folder.position or 0,
+            "item_count": count,
+            "created_at": folder.created_at,
+            "updated_at": folder.updated_at,
+        })
+    return results
+
+
+@router.post("/folders", response_model=AdLibraryFolderResponse)
+def create_folder(
+    folder: AdLibraryFolderCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    existing = db.query(AdLibraryFolder).filter(
+        AdLibraryFolder.brand_id == folder.brand_id,
+        AdLibraryFolder.media_type == folder.media_type,
+        AdLibraryFolder.name == folder.name,
+    ).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="A folder with this name already exists")
+
+    db_folder = AdLibraryFolder(**folder.model_dump())
+    db.add(db_folder)
+    db.commit()
+    db.refresh(db_folder)
+    return {
+        "id": db_folder.id,
+        "brand_id": db_folder.brand_id,
+        "media_type": db_folder.media_type,
+        "name": db_folder.name,
+        "position": db_folder.position or 0,
+        "item_count": 0,
+        "created_at": db_folder.created_at,
+        "updated_at": db_folder.updated_at,
+    }
+
+
+@router.put("/folders/{folder_id}", response_model=AdLibraryFolderResponse)
+def update_folder(
+    folder_id: str,
+    folder: AdLibraryFolderUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    db_folder = db.query(AdLibraryFolder).filter(AdLibraryFolder.id == folder_id).first()
+    if not db_folder:
+        raise HTTPException(status_code=404, detail="Folder not found")
+    for key, value in folder.model_dump(exclude_unset=True).items():
+        setattr(db_folder, key, value)
+    db.commit()
+    db.refresh(db_folder)
+    count = db.query(func.count(AdLibraryItem.id)).filter(
+        AdLibraryItem.folder_id == folder_id
+    ).scalar()
+    return {
+        "id": db_folder.id,
+        "brand_id": db_folder.brand_id,
+        "media_type": db_folder.media_type,
+        "name": db_folder.name,
+        "position": db_folder.position or 0,
+        "item_count": count,
+        "created_at": db_folder.created_at,
+        "updated_at": db_folder.updated_at,
+    }
+
+
+@router.delete("/folders/{folder_id}")
+def delete_folder(
+    folder_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    db_folder = db.query(AdLibraryFolder).filter(AdLibraryFolder.id == folder_id).first()
+    if not db_folder:
+        raise HTTPException(status_code=404, detail="Folder not found")
+    # Items become uncategorized via ON DELETE SET NULL
+    db.delete(db_folder)
+    db.commit()
+    return {"message": "Folder deleted"}
+
+
+class MoveItemsRequest(BaseModel):
+    item_ids: List[str]
+
+
+@router.post("/folders/{folder_id}/move-items")
+def move_items_to_folder(
+    folder_id: str,
+    request: MoveItemsRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    folder = db.query(AdLibraryFolder).filter(AdLibraryFolder.id == folder_id).first()
+    if not folder:
+        raise HTTPException(status_code=404, detail="Folder not found")
+    updated = db.query(AdLibraryItem).filter(
+        AdLibraryItem.id.in_(request.item_ids)
+    ).update({"folder_id": folder_id}, synchronize_session="fetch")
+    db.commit()
+    return {"message": f"Moved {updated} items to folder"}
 
 
 # --- Static POST routes MUST come before /{item_id} routes ---

--- a/backend/app/api/v1/brands.py
+++ b/backend/app/api/v1/brands.py
@@ -18,7 +18,7 @@ def read_brands(
     brands = db.query(BrandModel).offset(skip).limit(limit).all()
     return brands
 
-@router.post("/", response_model=Brand)
+@router.post("", response_model=Brand)
 def create_brand(
     brand: BrandCreate,
     db: Session = Depends(get_db),

--- a/backend/app/api/v1/clickflare.py
+++ b/backend/app/api/v1/clickflare.py
@@ -1,0 +1,204 @@
+from fastapi import APIRouter, Depends, HTTPException
+from typing import Dict, Any, Optional
+from sqlalchemy.orm import Session
+from app.database import get_db
+from app.models import ClickflareConfig, ClickflareMapping, User
+from app.services.clickflare_service import ClickflareService
+from app.core.deps import get_current_active_user
+
+router = APIRouter()
+
+
+def get_clickflare_config(db: Session) -> Optional[ClickflareConfig]:
+    return db.query(ClickflareConfig).filter(ClickflareConfig.is_active == True).first()
+
+
+def get_service_from_db(db: Session) -> ClickflareService:
+    config = get_clickflare_config(db)
+    if not config:
+        raise HTTPException(status_code=400, detail="Clickflare is not configured")
+    return ClickflareService(api_key=config.api_key, tracking_domain=config.tracking_domain)
+
+
+# --- Status ---
+
+@router.get("/status")
+def get_status(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    config = get_clickflare_config(db)
+    return {
+        "enabled": bool(config and config.is_active and config.api_key),
+        "tracking_domain": config.tracking_domain if config else None,
+    }
+
+
+# --- Config ---
+
+@router.get("/config")
+def get_config(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    config = get_clickflare_config(db)
+    if not config:
+        return {"configured": False}
+    return {
+        "configured": True,
+        "api_key_masked": config.api_key[:8] + "..." if config.api_key else "",
+        "tracking_domain": config.tracking_domain,
+        "facebook_traffic_source_id": config.facebook_traffic_source_id,
+        "facebook_pixel_id": config.facebook_pixel_id,
+        "is_active": config.is_active,
+    }
+
+
+@router.post("/config")
+async def save_config(
+    data: Dict[str, Any],
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    config = get_clickflare_config(db)
+    if config:
+        if data.get("api_key"):
+            config.api_key = data["api_key"]
+        if data.get("tracking_domain"):
+            config.tracking_domain = data["tracking_domain"]
+        if "facebook_pixel_id" in data:
+            config.facebook_pixel_id = data.get("facebook_pixel_id")
+        if "is_active" in data:
+            config.is_active = data["is_active"]
+    else:
+        if not data.get("api_key") or not data.get("tracking_domain"):
+            raise HTTPException(status_code=400, detail="api_key and tracking_domain are required")
+        config = ClickflareConfig(
+            api_key=data["api_key"],
+            tracking_domain=data["tracking_domain"],
+            facebook_pixel_id=data.get("facebook_pixel_id"),
+        )
+        db.add(config)
+
+    db.commit()
+    db.refresh(config)
+    return {"message": "Clickflare configuration saved", "id": config.id}
+
+
+# --- Connection Test ---
+
+@router.post("/test-connection")
+async def test_connection(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    service = get_service_from_db(db)
+    try:
+        result = await service.test_connection()
+        return {"status": "success", "message": "Connected to Clickflare"}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Connection failed: {str(e)}")
+
+
+# --- Traffic Source Setup ---
+
+@router.post("/setup-traffic-source")
+async def setup_traffic_source(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    service = get_service_from_db(db)
+    try:
+        ts_id = await service.find_or_create_facebook_traffic_source()
+        config = get_clickflare_config(db)
+        if config:
+            config.facebook_traffic_source_id = ts_id
+            db.commit()
+        return {"traffic_source_id": ts_id}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Traffic source setup failed: {str(e)}")
+
+
+# --- Tracking URL ---
+
+@router.post("/generate-tracking-url")
+async def generate_tracking_url(
+    data: Dict[str, Any],
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    ad_name = data.get("ad_name", "Ad")
+    destination_url = data.get("destination_url")
+    facebook_ad_id = data.get("facebook_ad_id")
+
+    if not destination_url:
+        raise HTTPException(status_code=400, detail="destination_url is required")
+
+    config = get_clickflare_config(db)
+    if not config:
+        raise HTTPException(status_code=400, detail="Clickflare is not configured")
+
+    service = ClickflareService(api_key=config.api_key, tracking_domain=config.tracking_domain)
+    traffic_source_id = config.facebook_traffic_source_id
+
+    if not traffic_source_id:
+        traffic_source_id = await service.find_or_create_facebook_traffic_source()
+        config.facebook_traffic_source_id = traffic_source_id
+        db.commit()
+
+    try:
+        result = await service.generate_tracking_url(
+            ad_name=ad_name,
+            destination_url=destination_url,
+            traffic_source_id=traffic_source_id,
+        )
+
+        if facebook_ad_id:
+            mapping = ClickflareMapping(
+                facebook_ad_id=facebook_ad_id,
+                original_url=destination_url,
+                tracking_url=result["tracking_url"],
+                cf_offer_id=result["offer_id"],
+                cf_campaign_id=result["campaign_id"],
+            )
+            db.add(mapping)
+            db.commit()
+
+        return result
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to generate tracking URL: {str(e)}")
+
+
+# --- Reporting ---
+
+@router.get("/reports")
+async def get_reports(
+    date_from: str,
+    date_to: str,
+    group_by: str = "campaign",
+    campaign_id: Optional[str] = None,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    service = get_service_from_db(db)
+    try:
+        return await service.get_campaign_report(
+            date_from=date_from,
+            date_to=date_to,
+            group_by=group_by,
+            cf_campaign_id=campaign_id,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to fetch reports: {str(e)}")
+
+
+@router.get("/campaigns")
+async def list_campaigns(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    service = get_service_from_db(db)
+    try:
+        return await service.get_campaigns_list()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to fetch campaigns: {str(e)}")

--- a/backend/app/api/v1/facebook.py
+++ b/backend/app/api/v1/facebook.py
@@ -126,9 +126,23 @@ def create_creative(
     current_user: User = Depends(require_permission("campaigns:write"))
 ):
     try:
+        print(f"[facebook:create_creative] page_id={creative.get('page_id')}, image_hash={creative.get('image_hash')}, video_id={creative.get('video_id')}, ad_account_id={ad_account_id}")
+        print(f"[facebook:create_creative] Full payload: {creative}")
         result = service.create_creative(creative, ad_account_id)
+        print(f"[facebook:create_creative] Success: {dict(result)}")
         return dict(result)
     except Exception as e:
+        import traceback
+        print(f"[facebook:create_creative] FAILED: {type(e).__name__}: {e}")
+        print(f"[facebook:create_creative] Full traceback:")
+        traceback.print_exc()
+        # Try to extract Facebook API error details
+        if hasattr(e, 'api_error_message'):
+            print(f"[facebook:create_creative] FB API error: {e.api_error_message()}")
+        if hasattr(e, 'body'):
+            print(f"[facebook:create_creative] FB body: {e.body()}")
+        if hasattr(e, '_body'):
+            print(f"[facebook:create_creative] FB _body: {e._body}")
         raise HTTPException(status_code=500, detail=str(e))
 
 @router.post("/ads")

--- a/backend/app/api/v1/facebook.py
+++ b/backend/app/api/v1/facebook.py
@@ -80,6 +80,18 @@ def read_pages(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.get("/pages/{page_id}")
+def read_page_info(
+    page_id: str,
+    service: FacebookService = Depends(get_facebook_service),
+    current_user: User = Depends(get_current_active_user)
+):
+    try:
+        return service.get_page_info(page_id)
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=f"Could not find page: {str(e)}")
+
+
 @router.get("/adsets")
 def read_adsets(
     ad_account_id: Optional[str] = None,

--- a/backend/app/api/v1/generated_ads.py
+++ b/backend/app/api/v1/generated_ads.py
@@ -115,134 +115,112 @@ from pathlib import Path
 from app.core.config import settings
 
 try:
-    import fal_client
+    from google import genai
+    from google.genai import types as genai_types
 except ImportError:
-    fal_client = None
+    genai = None
 
 # Setup uploads directory
 UPLOAD_DIR = Path(__file__).parent.parent.parent.parent / "uploads"
 UPLOAD_DIR = UPLOAD_DIR.resolve()
 os.makedirs(UPLOAD_DIR, mode=0o755, exist_ok=True)
 
-async def download_and_save_image(image_url: str, prefix: str = "generated") -> str:
-    """
-    Download image from external URL and save it locally.
-    Returns the local URL path.
-    """
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(image_url, timeout=30.0)
-            response.raise_for_status()
+# Map frontend aspect ratios from width/height to string format
+def get_aspect_ratio(width: int, height: int) -> str:
+    """Convert width/height to aspect ratio string for Imagen API."""
+    ratio_map = {
+        (1080, 1080): "1:1",
+        (1080, 1350): "3:4",
+        (1080, 1920): "9:16",
+        (1920, 1080): "16:9",
+    }
+    return ratio_map.get((width, height), "1:1")
 
-            # Generate unique filename
-            unique_id = str(uuid.uuid4())
-            filename = f"{prefix}_{unique_id}.png"
-            file_path = UPLOAD_DIR / filename
-
-            # Save image
-            with open(file_path, "wb") as f:
-                f.write(response.content)
-
-            # Return local URL
-            return f"/uploads/{filename}"
-    except Exception as e:
-        print(f"Error downloading image: {e}")
-        # Return original URL as fallback
-        return image_url
+def save_image_bytes(image_bytes: bytes, prefix: str = "generated") -> str:
+    """Save image bytes to local uploads directory. Returns the local URL path."""
+    unique_id = str(uuid.uuid4())
+    filename = f"{prefix}_{unique_id}.png"
+    file_path = UPLOAD_DIR / filename
+    with open(file_path, "wb") as f:
+        f.write(image_bytes)
+    return f"/uploads/{filename}"
 
 @router.post("/generate-image")
 async def generate_image(
     request: ImageGenerationRequest,
     current_user: User = Depends(require_permission("ads:write"))
 ):
-    """Generate ad images using Fal.ai (with mock fallback)"""
-    
+    """Generate ad images using Google Imagen 4 (with mock fallback)"""
+
     images = []
-    use_fal = settings.FAL_AI_API_KEY and fal_client
-    
-    if use_fal:
-        os.environ["FAL_KEY"] = settings.FAL_AI_API_KEY
-        print(f"Generating images with Fal.ai using key: {settings.FAL_AI_API_KEY[:5]}...")
-    
+    use_imagen = settings.imagen_enabled and genai
+
+    imagen_client = None
+    if use_imagen:
+        imagen_client = genai.Client(api_key=settings.GEMINI_API_KEY)
+        print(f"Generating images with Imagen 4 using key: {settings.GEMINI_API_KEY[:8]}...")
+
     for i in range(request.count):
         for size in request.imageSizes:
             width = size.get('width', 1080)
             height = size.get('height', 1080)
             size_name = size.get('name', 'Square')
-            
+            aspect_ratio = size.get('aspectRatio') or get_aspect_ratio(width, height)
+
             # Build comprehensive prompt using old system logic
             prompt = build_comprehensive_prompt(request)
-            
+
             print(f"\n{'='*80}")
-            print(f"🎨 IMAGE GENERATION REQUEST")
+            print(f"IMAGE GENERATION REQUEST")
             print(f"{'='*80}")
-            print(f"📦 Brand: {request.brand.get('name') if request.brand else 'None'}")
-            print(f"📦 Product: {request.product.get('name') if request.product else 'None'}")
-            print(f"📦 Product Desc: {request.product.get('description') if request.product else 'None'}")
-            print(f"📦 Template Type: {request.template.get('type') if request.template else 'None'}")
-            print(f"📦 Copy Headline: {request.copy.get('headline') if request.copy else 'None'}")
-            print(f"\n📝 FULL GENERATED PROMPT:")
+            print(f"Brand: {request.brand.get('name') if request.brand else 'None'}")
+            print(f"Product: {request.product.get('name') if request.product else 'None'}")
+            print(f"Template Type: {request.template.get('type') if request.template else 'None'}")
+            print(f"Copy Headline: {request.copy.get('headline') if request.copy else 'None'}")
+            print(f"Size: {size_name} ({width}x{height}, aspect_ratio={aspect_ratio})")
+            print(f"\nFULL GENERATED PROMPT:")
             print(f"{prompt}")
             print(f"{'='*80}\n")
-            
-            if use_fal:
-                try:
-                    # Determine model and endpoint
-                    if request.useProductImage and request.productShots:
-                        # Use edit endpoint for image-to-image with product photo
-                        model_id = "fal-ai/nano-banana-pro/edit"
-                        print(f"Using product image: {request.productShots[0][:50]}...")
-                        
-                        arguments = {
-                            "prompt": prompt,
-                            "image_urls": request.productShots,
-                            "aspect_ratio": f"{width}:{height}",
-                            "output_format": "png"
-                        }
-                    else:
-                        # Standard text-to-image
-                        if request.model == "imagen4":
-                            model_id = "fal-ai/imagen4/preview"
-                            print(f"Using Imagen 4 model: {model_id}")
-                        else:
-                            model_id = "fal-ai/nano-banana-pro"
-                            print(f"Using Nano Banana Pro model: {model_id}")
-                        
-                        arguments = {
-                            "prompt": prompt,
-                            "image_size": {
-                                "width": width,
-                                "height": height
-                            }
-                        }
-                    
-                    # Submit to Fal.ai
-                    handler = await fal_client.submit_async(model_id, arguments=arguments)
-                    result = await handler.get()
-                    external_url = result['images'][0]['url']
 
-                    # Download and save image locally
-                    print(f"Downloading image from Fal.ai: {external_url[:50]}...")
-                    image_url = await download_and_save_image(external_url, prefix="generated")
-                    print(f"Saved locally as: {image_url}")
+            if use_imagen and imagen_client:
+                try:
+                    model = settings.IMAGEN_MODEL
+                    print(f"Calling Imagen 4: model={model}, aspect_ratio={aspect_ratio}")
+
+                    result = imagen_client.models.generate_images(
+                        model=model,
+                        prompt=prompt,
+                        config=genai_types.GenerateImagesConfig(
+                            number_of_images=1,
+                            aspect_ratio=aspect_ratio,
+                            person_generation="allow_adult",
+                        ),
+                    )
+
+                    if result.generated_images:
+                        image_bytes = result.generated_images[0].image.image_bytes
+                        image_url = save_image_bytes(image_bytes, prefix="generated")
+                        print(f"Saved locally as: {image_url}")
+                    else:
+                        print("Imagen returned no images")
+                        image_url = f"https://placehold.co/{width}x{height}/png?text=No+Image+Returned"
 
                 except Exception as e:
-                    print(f"Fal.ai generation failed: {e}")
-                    # Fallback to mock on error
-                    product_name = request.product.get('name', 'Product') if request.product else 'Product'
-                    image_url = f"https://placehold.co/{width}x{height}/png?text={product_name}+Error"
+                    print(f"Imagen generation failed: {e}")
+                    import traceback
+                    traceback.print_exc()
+                    image_url = f"https://placehold.co/{width}x{height}/png?text=Generation+Error"
             else:
-                # Mock generation
-                product_name = request.product.get('name', 'Product') if request.product else 'Product'
-                image_url = f"https://placehold.co/{width}x{height}/png?text={product_name}+{i+1}"
-            
+                # Mock generation (no GEMINI_API_KEY configured)
+                image_url = f"https://placehold.co/{width}x{height}/png?text=No+AI+Key+Configured"
+
             images.append({
                 "url": image_url,
                 "size": size_name,
                 "dimensions": f"{width}x{height}",
                 "prompt": prompt
             })
-            
+
     return {"images": images}
 
 @router.get("/")
@@ -361,12 +339,20 @@ def batch_save_ads(
         existing = db.query(GeneratedAd).filter(GeneratedAd.id == ad_data.id).first()
         if existing:
             continue
-            
+
+        # Validate template_id exists in DB (style archetypes are frontend-only)
+        template_id = ad_data.templateId
+        if template_id:
+            from app.models import WinningAd
+            template_exists = db.query(WinningAd).filter(WinningAd.id == template_id).first()
+            if not template_exists:
+                template_id = None
+
         new_ad = GeneratedAd(
             id=ad_data.id,
             brand_id=ad_data.brandId,
             product_id=ad_data.productId,
-            template_id=ad_data.templateId,
+            template_id=template_id,
             image_url=ad_data.imageUrl,
             headline=ad_data.headline,
             body=ad_data.body,
@@ -389,4 +375,7 @@ def batch_save_ads(
         return {"message": f"Saved {len(saved_ads)} ads", "count": len(saved_ads)}
     except Exception as e:
         db.rollback()
+        import traceback
+        traceback.print_exc()
+        print(f"Batch save error: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/api/v1/headlines.py
+++ b/backend/app/api/v1/headlines.py
@@ -1,0 +1,236 @@
+import json
+import os
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Form, Query
+from sqlalchemy.orm import Session
+from typing import List, Optional
+from app.database import get_db
+from app.models import Headline as HeadlineModel, Brand as BrandModel, Product as ProductModel, User
+from app.schemas.headline import Headline, HeadlineCreate, HeadlineBatchDelete
+from app.core.deps import get_current_active_user
+from app.core.config import settings
+
+router = APIRouter()
+
+HEADLINE_PROMPT = """You are a direct-response headline specialist who writes scroll-stopping Facebook ad headlines. You've studied the greats — Gary Halbert, Eugene Schwartz, David Ogilvy — and you know that the headline is the ad for the ad.
+
+Given the brand info, product details, and research document below, generate 15 high-converting headlines for Facebook ads.
+
+Brand: {brand_name}
+Brand Voice: {brand_voice}
+Product: {product_name}
+Product Description: {product_description}
+
+Research Document:
+{doc_content}
+
+RULES:
+- Each headline MUST be under 40 characters
+- Mix these styles across your 15 headlines:
+  * "curiosity" — open loops, "the secret...", "what nobody tells you about..."
+  * "urgency" — time pressure, scarcity, "before it's gone", "limited time"
+  * "benefit" — lead with the #1 benefit, answer "what's in it for me?"
+  * "social_proof" — numbers, testimonials, "join 10,000+", "as seen on..."
+  * "fomo" — fear of missing out, exclusivity, "don't miss this"
+- Use power words: secret, shocking, finally, free, instant, proven, limited, new
+- Each headline should be punchy and create an open loop the reader MUST click to close
+- Write like a top affiliate marketer — conversational, benefit-obsessed
+
+Return ONLY valid JSON with this exact structure:
+{{
+  "headlines": [
+    {{ "text": "Headline text here", "category": "curiosity" }},
+    {{ "text": "Another headline", "category": "urgency" }}
+  ]
+}}
+
+Return ONLY the JSON, no markdown formatting or code blocks."""
+
+
+def _parse_ai_response(raw_text: str) -> dict:
+    json_text = raw_text.strip()
+    if json_text.startswith("```"):
+        lines = json_text.split("\n")
+        lines = lines[1:]  # Remove opening fence
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        json_text = "\n".join(lines).strip()
+    return json.loads(json_text)
+
+
+def _extract_text_from_file(content: bytes, filename: str) -> str:
+    """Extract text from uploaded file based on extension."""
+    lower = filename.lower()
+    if lower.endswith('.txt') or lower.endswith('.md'):
+        return content.decode('utf-8', errors='replace')
+    elif lower.endswith('.pdf'):
+        try:
+            import io
+            from PyPDF2 import PdfReader
+            reader = PdfReader(io.BytesIO(content))
+            text = ""
+            for page in reader.pages:
+                text += page.extract_text() or ""
+            return text
+        except ImportError:
+            # Fallback: try to decode as text
+            return content.decode('utf-8', errors='replace')
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"Failed to read PDF: {str(e)}")
+    elif lower.endswith('.csv'):
+        return content.decode('utf-8', errors='replace')
+    else:
+        # Try to decode as text
+        return content.decode('utf-8', errors='replace')
+
+
+@router.get("", response_model=List[Headline])
+def list_headlines(
+    brand_id: Optional[str] = None,
+    product_id: Optional[str] = None,
+    category: Optional[str] = None,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    query = db.query(HeadlineModel)
+    if brand_id:
+        query = query.filter(HeadlineModel.brand_id == brand_id)
+    if product_id:
+        query = query.filter(HeadlineModel.product_id == product_id)
+    if category:
+        query = query.filter(HeadlineModel.category == category)
+    return query.order_by(HeadlineModel.created_at.desc()).all()
+
+
+@router.post("", response_model=Headline)
+def create_headline(
+    headline: HeadlineCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    db_headline = HeadlineModel(
+        brand_id=headline.brand_id,
+        product_id=headline.product_id,
+        text=headline.text,
+        category=headline.category,
+        source=headline.source,
+    )
+    db.add(db_headline)
+    db.commit()
+    db.refresh(db_headline)
+    return db_headline
+
+
+@router.post("/generate", response_model=List[Headline])
+async def generate_headlines(
+    brand_id: str = Form(...),
+    product_id: Optional[str] = Form(None),
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    """Upload a research document and generate headlines with Claude Haiku."""
+    # Fetch brand
+    brand = db.query(BrandModel).filter(BrandModel.id == brand_id).first()
+    if not brand:
+        raise HTTPException(status_code=404, detail="Brand not found")
+
+    # Fetch product (optional)
+    product = None
+    if product_id:
+        product = db.query(ProductModel).filter(ProductModel.id == product_id).first()
+
+    # Read file
+    content = await file.read()
+    if len(content) > 10 * 1024 * 1024:  # 10MB limit
+        raise HTTPException(status_code=400, detail="File too large (max 10MB)")
+
+    doc_text = _extract_text_from_file(content, file.filename or "document.txt")
+    if not doc_text.strip():
+        raise HTTPException(status_code=400, detail="Could not extract text from file")
+
+    # Truncate if too long (keep under ~8k chars for prompt)
+    if len(doc_text) > 8000:
+        doc_text = doc_text[:8000] + "\n\n[Document truncated at 8000 characters]"
+
+    # Build prompt
+    prompt = HEADLINE_PROMPT.format(
+        brand_name=brand.name,
+        brand_voice=brand.voice or "Not specified",
+        product_name=product.name if product else "General",
+        product_description=product.description if product else "Not specified",
+        doc_content=doc_text,
+    )
+
+    # Call Claude Haiku
+    try:
+        import anthropic
+    except ImportError:
+        raise HTTPException(status_code=500, detail="anthropic package not installed")
+
+    api_key = getattr(settings, "ANTHROPIC_API_KEY", None) or os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise HTTPException(status_code=500, detail="ANTHROPIC_API_KEY not configured")
+
+    try:
+        client = anthropic.Anthropic(api_key=api_key)
+        response = client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=2000,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        result = _parse_ai_response(response.content[0].text)
+    except json.JSONDecodeError as e:
+        print(f"[headlines] JSON parse error: {e}")
+        raise HTTPException(status_code=500, detail="Failed to parse AI response as JSON")
+    except Exception as e:
+        print(f"[headlines] AI error: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+    # Save headlines to DB
+    generated = result.get("headlines", [])
+    saved = []
+    for h in generated:
+        text = h.get("text", "").strip()
+        if not text:
+            continue
+        db_headline = HeadlineModel(
+            brand_id=brand_id,
+            product_id=product_id,
+            text=text,
+            category=h.get("category"),
+            source="ai",
+        )
+        db.add(db_headline)
+        db.flush()
+        saved.append(db_headline)
+
+    db.commit()
+    for h in saved:
+        db.refresh(h)
+
+    return saved
+
+
+@router.delete("/batch")
+def delete_headlines_batch(
+    body: HeadlineBatchDelete,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    deleted = db.query(HeadlineModel).filter(HeadlineModel.id.in_(body.ids)).delete(synchronize_session=False)
+    db.commit()
+    return {"deleted": deleted}
+
+
+@router.delete("/{headline_id}")
+def delete_headline(
+    headline_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    headline = db.query(HeadlineModel).filter(HeadlineModel.id == headline_id).first()
+    if not headline:
+        raise HTTPException(status_code=404, detail="Headline not found")
+    db.delete(headline)
+    db.commit()
+    return {"success": True}

--- a/backend/app/api/v1/higgsfield.py
+++ b/backend/app/api/v1/higgsfield.py
@@ -1,0 +1,72 @@
+"""
+Higgsfield AI API endpoints - Image-to-Video generation
+"""
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel
+from typing import Optional
+from app.api.v1.auth import get_current_active_user
+from app.services import higgsfield_service
+
+router = APIRouter()
+
+
+class GenerateVideoRequest(BaseModel):
+    image_url: str
+    motion_id: str
+    prompt: Optional[str] = ""
+    model: Optional[str] = "dop-lite"
+    strength: Optional[float] = 0.5
+
+
+@router.get("/status")
+async def get_status(user=Depends(get_current_active_user)):
+    """Check if Higgsfield is configured."""
+    return {"configured": higgsfield_service.is_configured()}
+
+
+@router.get("/motions")
+async def get_motions(user=Depends(get_current_active_user)):
+    """List available motion presets."""
+    if not higgsfield_service.is_configured():
+        raise HTTPException(status_code=503, detail="Higgsfield API not configured")
+    try:
+        motions = await higgsfield_service.list_motions()
+        return motions
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Higgsfield API error: {str(e)}")
+
+
+@router.post("/generate-video")
+async def generate_video(
+    req: GenerateVideoRequest,
+    user=Depends(get_current_active_user),
+):
+    """Submit an image-to-video generation job."""
+    if not higgsfield_service.is_configured():
+        raise HTTPException(status_code=503, detail="Higgsfield API not configured")
+    try:
+        result = await higgsfield_service.generate_video(
+            image_url=req.image_url,
+            motion_id=req.motion_id,
+            prompt=req.prompt,
+            model=req.model,
+            strength=req.strength,
+        )
+        return result
+    except Exception as e:
+        detail = str(e)
+        if "Not enough credits" in detail or "403" in detail:
+            raise HTTPException(status_code=402, detail="Not enough Higgsfield credits. Add credits at cloud.higgsfield.ai")
+        raise HTTPException(status_code=502, detail=f"Higgsfield API error: {detail}")
+
+
+@router.get("/jobs/{job_id}")
+async def get_job(job_id: str, user=Depends(get_current_active_user)):
+    """Check status of a video generation job."""
+    if not higgsfield_service.is_configured():
+        raise HTTPException(status_code=503, detail="Higgsfield API not configured")
+    try:
+        result = await higgsfield_service.get_job_status(job_id)
+        return result
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=f"Higgsfield API error: {str(e)}")

--- a/backend/app/api/v1/profiles.py
+++ b/backend/app/api/v1/profiles.py
@@ -44,7 +44,7 @@ def read_profiles(
         "created_at": p.created_at
     } for p in profiles]
 
-@router.post("/", response_model=CustomerProfile)
+@router.post("", response_model=CustomerProfile)
 def create_profile(
     profile: CustomerProfileCreate,
     db: Session = Depends(get_db),

--- a/backend/app/api/v1/research.py
+++ b/backend/app/api/v1/research.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 from app.database import get_db
 from app.schemas.research import (
     AdSearchRequest, ScrapedAdResponse, ScrapedAdCreate, ScrapedAdSearchResult, SavedSearchResponse,
-    BrandScrapeCreate, BrandScrapeResponse, BrandScrapeListResponse
+    BrandScrapeCreate, BrandScrapeUpdate, BrandScrapeResponse, BrandScrapeListResponse
 )
 from app.services.research_service import ResearchService
 from app.services.rate_limiter import rate_limiter
@@ -489,6 +489,77 @@ def get_brand_scrape(scrape_id: str, db: Session = Depends(get_db)):
     scrape = db.query(BrandScrape).filter(BrandScrape.id == scrape_id).first()
     if not scrape:
         raise HTTPException(status_code=404, detail="Brand scrape not found")
+
+    return scrape
+
+
+@router.patch("/brand-scrapes/{scrape_id}", response_model=BrandScrapeListResponse)
+def update_brand_scrape(
+    scrape_id: str,
+    request: BrandScrapeUpdate,
+    db: Session = Depends(get_db)
+):
+    """Update a brand scrape (e.g. rename)."""
+    from app.models import BrandScrape
+
+    scrape = db.query(BrandScrape).filter(BrandScrape.id == scrape_id).first()
+    if not scrape:
+        raise HTTPException(status_code=404, detail="Brand scrape not found")
+
+    if request.brand_name is not None:
+        scrape.brand_name = request.brand_name
+
+    db.commit()
+    db.refresh(scrape)
+    return scrape
+
+
+@router.post("/brand-scrapes/{scrape_id}/refresh", response_model=BrandScrapeListResponse)
+async def refresh_brand_scrape(
+    scrape_id: str,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db)
+):
+    """Re-scrape a brand's ads (deletes old ads, re-runs scraper)."""
+    from app.models import BrandScrape, BrandScrapedAd
+    from app.services.brand_scraper import BrandScraperService
+
+    scrape = db.query(BrandScrape).filter(BrandScrape.id == scrape_id).first()
+    if not scrape:
+        raise HTTPException(status_code=404, detail="Brand scrape not found")
+
+    if scrape.status == "scraping":
+        raise HTTPException(status_code=409, detail="Scrape already in progress")
+
+    # Delete old ads
+    db.query(BrandScrapedAd).filter(BrandScrapedAd.brand_scrape_id == scrape_id).delete()
+    scrape.status = "pending"
+    scrape.total_ads = 0
+    scrape.media_downloaded = 0
+    scrape.error_message = None
+    db.commit()
+    db.refresh(scrape)
+
+    # Re-run scrape in background
+    async def run_scrape():
+        from app.database import SessionLocal
+        scrape_db = SessionLocal()
+        try:
+            scraper = BrandScraperService(scrape_db)
+            scrape_record = scrape_db.query(BrandScrape).filter(BrandScrape.id == scrape_id).first()
+            if scrape_record:
+                await scraper.scrape_brand(scrape_record)
+        except Exception as e:
+            print(f"Background refresh scrape error: {e}")
+            scrape_record = scrape_db.query(BrandScrape).filter(BrandScrape.id == scrape_id).first()
+            if scrape_record:
+                scrape_record.status = "failed"
+                scrape_record.error_message = str(e)[:500]
+                scrape_db.commit()
+        finally:
+            scrape_db.close()
+
+    background_tasks.add_task(run_scrape)
 
     return scrape
 

--- a/backend/app/api/v1/video_analysis.py
+++ b/backend/app/api/v1/video_analysis.py
@@ -437,18 +437,20 @@ async def analyze_video(
             tmp_path = tmp.name
             tmp.write(content)
 
+        filename = (file.filename if file else None) or (os.path.basename(url.split("?")[0]) if url else "video.mp4")
+
         if provider == "transcribe_haiku":
             # Step 1: Gemini transcribes the audio
             print("[video_analysis:transcribe_haiku] Step 1 — Gemini transcribing audio...")
-            transcript_data = await _transcribe_with_gemini(tmp_path, file.filename or "video.mp4", len(content))
+            transcript_data = await _transcribe_with_gemini(tmp_path, filename, len(content))
             print(f"[video_analysis:transcribe_haiku] Transcript: {transcript_data.get('transcript', '')[:200]}...")
             # Step 2: Haiku generates copy from frames + transcript
             print("[video_analysis:transcribe_haiku] Step 2 — Haiku generating copy with frames + transcript...")
-            result = await _analyze_with_claude(tmp_path, file.filename or "video.mp4", transcript_data=transcript_data)
+            result = await _analyze_with_claude(tmp_path, filename, transcript_data=transcript_data)
         elif provider == "claude":
-            result = await _analyze_with_claude(tmp_path, file.filename or "video.mp4")
+            result = await _analyze_with_claude(tmp_path, filename)
         else:
-            result = await _analyze_with_gemini(tmp_path, file.filename or "video.mp4", len(content))
+            result = await _analyze_with_gemini(tmp_path, filename, len(content))
 
         return {
             "bodies": result["bodies"][:3],

--- a/backend/app/api/v1/video_analysis.py
+++ b/backend/app/api/v1/video_analysis.py
@@ -73,6 +73,41 @@ Rules:
 - If no audio/speech is detected, set transcript to "" and still fill in key_claims from any on-screen text
 - Return ONLY the JSON, no markdown formatting or code blocks"""
 
+IMAGE_ANALYSIS_PROMPT = """You are an elite direct-response copywriter who specializes in Facebook ads that CONVERT. You've studied the greats — Gary Halbert, Eugene Schwartz, David Ogilvy — and you write scroll-stopping copy that drives clicks and sales.
+
+Analyze this image carefully — pay attention to the product, the setting, any text overlays, branding, and the overall mood/vibe.
+
+Based on the image, generate high-converting Facebook ad copy using direct response and affiliate marketing principles. Return ONLY valid JSON with this exact structure:
+
+{
+  "bodies": [
+    "Primary text variation 1 — Problem-Agitate-Solve angle with a strong CTA",
+    "Primary text variation 2 — Curiosity hook with benefit-stacking",
+    "Primary text variation 3 — Social proof / story-driven with urgency"
+  ],
+  "headlines": [
+    "Headline 1 (under 40 chars, power words)",
+    "Headline 2 (benefit-driven, curiosity)",
+    "Headline 3 (urgency or fear of missing out)"
+  ],
+  "image_summary": "Brief 1-2 sentence summary of what the image shows"
+}
+
+DIRECT RESPONSE COPYWRITING RULES — follow these strictly:
+- Open with a pattern interrupt or curiosity hook that stops the scroll (e.g., "Wait — did you know...?" or a bold claim)
+- Use the Problem-Agitate-Solve framework: name the pain, twist the knife, present the product as the solution
+- Write in a conversational, first-person tone — like texting a friend, not writing an essay
+- Stack benefits, not features. Every feature must answer "so what?" for the reader
+- Use power words: "secret", "shocking", "finally", "free", "instant", "proven", "limited"
+- Create urgency: limited time, limited stock, exclusive access, "before it's gone"
+- End EVERY body copy with a clear, compelling CTA (e.g., "Tap the link before they sell out")
+- Headlines should be punchy, benefit-first, and create an open loop the reader MUST click to close
+- Each variation should take a genuinely different angle — don't just rephrase the same idea
+- If there's text in the image, incorporate key phrases, claims, or offers from it
+- Write like a top affiliate marketer: conversational, urgent, benefit-obsessed, action-oriented
+- Return ONLY the JSON, no markdown formatting or code blocks"""
+
+
 HAIKU_SYSTEM_PROMPT = """You are an elite direct-response copywriter for Facebook ads, specializing in affiliate marketing that needs to be profitable on the frontend FAST. You write for cold traffic — people who have never heard of this product — and your only job is to stop their scroll, hook them, and get the click.
 
 Your copy philosophy:
@@ -418,3 +453,93 @@ async def analyze_video(
     finally:
         if tmp_path and os.path.exists(tmp_path):
             os.unlink(tmp_path)
+
+
+@router.post("/analyze-image")
+async def analyze_image(
+    file: UploadFile = File(...),
+    provider: str = Query("haiku", pattern="^(haiku|gemini)$"),
+    current_user: User = Depends(get_current_active_user),
+):
+    """Analyze an image with AI to generate ad copy suggestions.
+
+    provider: "haiku" (default) — uses Claude Haiku with vision
+              "gemini" — uses Gemini 2.0 Flash with vision
+    """
+    content_type = file.content_type or ""
+    if not content_type.startswith("image/"):
+        raise HTTPException(status_code=400, detail="File must be an image")
+
+    try:
+        image_data = await file.read()
+        image_b64 = base64.b64encode(image_data).decode("utf-8")
+
+        # Map content types
+        media_type = content_type
+        if media_type == "image/jpg":
+            media_type = "image/jpeg"
+
+        if provider == "gemini":
+            if not genai:
+                raise HTTPException(status_code=500, detail="google-genai not installed")
+            api_key = getattr(settings, "GEMINI_API_KEY", None) or os.environ.get("GEMINI_API_KEY")
+            if not api_key:
+                raise HTTPException(status_code=500, detail="GEMINI_API_KEY not configured")
+
+            client = genai.Client(api_key=api_key)
+            image_part = genai.types.Part.from_bytes(data=image_data, mime_type=media_type)
+            response = client.models.generate_content(
+                model="gemini-2.0-flash",
+                contents=[image_part, IMAGE_ANALYSIS_PROMPT],
+            )
+            result = _parse_ai_response(response.text)
+        else:
+            # Claude Haiku
+            if not anthropic:
+                raise HTTPException(status_code=500, detail="anthropic package not installed")
+            api_key = getattr(settings, "ANTHROPIC_API_KEY", None) or os.environ.get("ANTHROPIC_API_KEY")
+            if not api_key:
+                raise HTTPException(status_code=500, detail="ANTHROPIC_API_KEY not configured")
+
+            client = anthropic.Anthropic(api_key=api_key)
+            response = client.messages.create(
+                model="claude-haiku-4-5-20251001",
+                max_tokens=2000,
+                system=HAIKU_SYSTEM_PROMPT,
+                messages=[{
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": media_type,
+                                "data": image_b64,
+                            },
+                        },
+                        {
+                            "type": "text",
+                            "text": IMAGE_ANALYSIS_PROMPT,
+                        },
+                    ],
+                }],
+            )
+            result = _parse_ai_response(response.content[0].text)
+
+        return {
+            "bodies": result.get("bodies", [])[:3],
+            "headlines": result.get("headlines", [])[:3],
+            "image_summary": result.get("image_summary", ""),
+            "provider": provider,
+        }
+
+    except json.JSONDecodeError as e:
+        print(f"[image_analysis] JSON parse error: {e}")
+        raise HTTPException(status_code=500, detail="Failed to parse AI response as JSON")
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"[image_analysis] Error: {e}")
+        import traceback
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/api/v1/video_analysis.py
+++ b/backend/app/api/v1/video_analysis.py
@@ -426,12 +426,15 @@ async def analyze_video(
             content = await file.read()
         else:
             # Download from URL server-side
+            print(f"[video_analysis] Downloading video from URL: {url[:100]}...")
             async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as client:
                 resp = await client.get(url)
                 resp.raise_for_status()
             content = resp.content
+            resp_ct = resp.headers.get("content-type", "")
             ext = os.path.splitext(url.split("?")[0])[1] or ".mp4"
             suffix = ext
+            print(f"[video_analysis] Downloaded {len(content)} bytes, content-type: {resp_ct}, suffix: {suffix}")
 
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
             tmp_path = tmp.name
@@ -452,9 +455,12 @@ async def analyze_video(
         else:
             result = await _analyze_with_gemini(tmp_path, filename, len(content))
 
+        bodies = result.get("bodies", [])[:3]
+        headlines = result.get("headlines", [])[:3]
+        print(f"[video_analysis] Final result — {len(bodies)} bodies, {len(headlines)} headlines")
         return {
-            "bodies": result["bodies"][:3],
-            "headlines": result["headlines"][:3],
+            "bodies": bodies,
+            "headlines": headlines,
             "video_summary": result.get("video_summary", ""),
             "provider": provider,
         }

--- a/backend/app/api/v1/video_analysis.py
+++ b/backend/app/api/v1/video_analysis.py
@@ -1,0 +1,151 @@
+import os
+import json
+import time
+import tempfile
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+from app.models import User
+from app.core.deps import get_current_active_user
+from app.core.config import settings
+
+router = APIRouter()
+
+try:
+    from google import genai
+except ImportError:
+    genai = None
+
+ANALYSIS_PROMPT = """You are an expert Facebook ad copywriter. Watch this video carefully — pay attention to both the visuals AND the audio/voiceover.
+
+Based on the video content, generate Facebook ad copy. Return ONLY valid JSON with this exact structure:
+
+{
+  "bodies": [
+    "Primary text variation 1 (2-3 sentences, compelling, includes call-to-action)",
+    "Primary text variation 2 (different angle/hook)",
+    "Primary text variation 3 (different emotional appeal)"
+  ],
+  "headlines": [
+    "Headline 1 (under 40 chars, punchy)",
+    "Headline 2 (different angle)",
+    "Headline 3 (urgency or curiosity)"
+  ],
+  "video_summary": "Brief 1-2 sentence summary of what the video shows and says"
+}
+
+Requirements:
+- Primary text should be 2-3 sentences each, suitable for Facebook ads
+- Headlines should be under 40 characters, attention-grabbing
+- Each variation should take a different angle (e.g., benefit-focused, problem-solution, social proof)
+- Match the tone and messaging of the video
+- If there's spoken audio, incorporate key phrases or claims from it
+- Return ONLY the JSON, no markdown formatting or code blocks"""
+
+
+@router.post("/analyze")
+async def analyze_video(
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_active_user),
+):
+    """Analyze a video with Gemini 2.0 Flash to generate ad copy suggestions."""
+
+    if not settings.GEMINI_API_KEY:
+        raise HTTPException(status_code=500, detail="GEMINI_API_KEY is not configured")
+
+    if genai is None:
+        raise HTTPException(status_code=500, detail="google-genai package is not installed")
+
+    # Validate file type
+    content_type = file.content_type or ""
+    if not content_type.startswith("video/"):
+        raise HTTPException(status_code=400, detail="File must be a video")
+
+    tmp_path = None
+    gemini_file = None
+    client = genai.Client(api_key=settings.GEMINI_API_KEY)
+
+    try:
+        # Save uploaded file to temp location
+        suffix = os.path.splitext(file.filename or "video.mp4")[1] or ".mp4"
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            tmp_path = tmp.name
+            content = await file.read()
+            tmp.write(content)
+
+        print(f"[video_analysis] Uploading {file.filename} ({len(content)} bytes) to Gemini File API...")
+
+        # Upload to Gemini File API
+        gemini_file = client.files.upload(file=tmp_path)
+        print(f"[video_analysis] File uploaded: {gemini_file.name}, state={gemini_file.state}")
+
+        # Poll until processing is complete
+        max_wait = 120  # seconds
+        poll_interval = 3
+        elapsed = 0
+        while gemini_file.state.name == "PROCESSING" and elapsed < max_wait:
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+            gemini_file = client.files.get(name=gemini_file.name)
+            print(f"[video_analysis] Polling... state={gemini_file.state} ({elapsed}s)")
+
+        if gemini_file.state.name == "FAILED":
+            raise HTTPException(status_code=500, detail="Gemini failed to process the video")
+
+        if gemini_file.state.name != "ACTIVE":
+            raise HTTPException(
+                status_code=500,
+                detail=f"Video processing timed out after {max_wait}s (state: {gemini_file.state.name})",
+            )
+
+        print(f"[video_analysis] File ready, sending to gemini-2.0-flash...")
+
+        # Send to Gemini for analysis
+        response = client.models.generate_content(
+            model="gemini-2.0-flash",
+            contents=[gemini_file, ANALYSIS_PROMPT],
+        )
+
+        raw_text = response.text.strip()
+        print(f"[video_analysis] Raw response: {raw_text[:500]}")
+
+        # Parse JSON from response (handle markdown code blocks)
+        json_text = raw_text
+        if json_text.startswith("```"):
+            # Strip markdown code fences
+            lines = json_text.split("\n")
+            # Remove first line (```json or ```) and last line (```)
+            lines = [l for l in lines if not l.strip().startswith("```")]
+            json_text = "\n".join(lines)
+
+        result = json.loads(json_text)
+
+        # Validate structure
+        if "bodies" not in result or "headlines" not in result:
+            raise ValueError("Response missing required fields")
+
+        return {
+            "bodies": result["bodies"][:3],
+            "headlines": result["headlines"][:3],
+            "video_summary": result.get("video_summary", ""),
+        }
+
+    except json.JSONDecodeError as e:
+        print(f"[video_analysis] JSON parse error: {e}")
+        raise HTTPException(status_code=500, detail="Failed to parse AI response as JSON")
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"[video_analysis] Error: {e}")
+        import traceback
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=str(e))
+    finally:
+        # Clean up temp file
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        # Clean up Gemini file
+        if gemini_file:
+            try:
+                client.files.delete(name=gemini_file.name)
+                print(f"[video_analysis] Cleaned up Gemini file: {gemini_file.name}")
+            except Exception as e:
+                print(f"[video_analysis] Failed to clean up Gemini file: {e}")

--- a/backend/app/api/v1/video_analysis.py
+++ b/backend/app/api/v1/video_analysis.py
@@ -5,7 +5,9 @@ import glob
 import base64
 import tempfile
 import subprocess
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Query
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Query, Form
+from typing import Optional
 from app.models import User
 from app.core.deps import get_current_active_user
 from app.core.config import settings
@@ -398,7 +400,8 @@ async def _analyze_with_claude(tmp_path: str, filename: str, transcript_data: di
 
 @router.post("/analyze")
 async def analyze_video(
-    file: UploadFile = File(...),
+    file: Optional[UploadFile] = File(None),
+    url: Optional[str] = Form(None),
     provider: str = Query("gemini", pattern="^(gemini|claude|transcribe_haiku)$"),
     current_user: User = Depends(get_current_active_user),
 ):
@@ -408,16 +411,30 @@ async def analyze_video(
               "claude" — extracts key frames and sends to Claude Haiku
               "transcribe_haiku" — Gemini transcribes audio, then Haiku writes copy from frames + transcript
     """
-    content_type = file.content_type or ""
-    if not content_type.startswith("video/"):
-        raise HTTPException(status_code=400, detail="File must be a video")
+    if file:
+        content_type = file.content_type or ""
+        if not content_type.startswith("video/"):
+            raise HTTPException(status_code=400, detail="File must be a video")
+
+    if not file and not url:
+        raise HTTPException(status_code=400, detail="Either file or url is required")
 
     tmp_path = None
     try:
-        suffix = os.path.splitext(file.filename or "video.mp4")[1] or ".mp4"
+        if file:
+            suffix = os.path.splitext(file.filename or "video.mp4")[1] or ".mp4"
+            content = await file.read()
+        else:
+            # Download from URL server-side
+            async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as client:
+                resp = await client.get(url)
+                resp.raise_for_status()
+            content = resp.content
+            ext = os.path.splitext(url.split("?")[0])[1] or ".mp4"
+            suffix = ext
+
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
             tmp_path = tmp.name
-            content = await file.read()
             tmp.write(content)
 
         if provider == "transcribe_haiku":
@@ -457,7 +474,8 @@ async def analyze_video(
 
 @router.post("/analyze-image")
 async def analyze_image(
-    file: UploadFile = File(...),
+    file: Optional[UploadFile] = File(None),
+    url: Optional[str] = Form(None),
     provider: str = Query("haiku", pattern="^(haiku|gemini)$"),
     current_user: User = Depends(get_current_active_user),
 ):
@@ -466,16 +484,27 @@ async def analyze_image(
     provider: "haiku" (default) — uses Claude Haiku with vision
               "gemini" — uses Gemini 2.0 Flash with vision
     """
-    content_type = file.content_type or ""
-    if not content_type.startswith("image/"):
-        raise HTTPException(status_code=400, detail="File must be an image")
+    if not file and not url:
+        raise HTTPException(status_code=400, detail="Either file or url is required")
 
     try:
-        image_data = await file.read()
+        if file:
+            content_type = file.content_type or ""
+            if not content_type.startswith("image/"):
+                raise HTTPException(status_code=400, detail="File must be an image")
+            image_data = await file.read()
+            media_type = content_type
+        else:
+            # Download from URL server-side (avoids CORS)
+            async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+                resp = await client.get(url)
+                resp.raise_for_status()
+            image_data = resp.content
+            media_type = resp.headers.get("content-type", "image/jpeg").split(";")[0]
+
         image_b64 = base64.b64encode(image_data).decode("utf-8")
 
         # Map content types
-        media_type = content_type
         if media_type == "image/jpg":
             media_type = "image/jpeg"
 

--- a/backend/app/api/v1/video_analysis.py
+++ b/backend/app/api/v1/video_analysis.py
@@ -1,8 +1,11 @@
 import os
 import json
 import time
+import glob
+import base64
 import tempfile
-from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+import subprocess
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File, Query
 from app.models import User
 from app.core.deps import get_current_active_user
 from app.core.config import settings
@@ -14,118 +17,392 @@ try:
 except ImportError:
     genai = None
 
-ANALYSIS_PROMPT = """You are an expert Facebook ad copywriter. Watch this video carefully — pay attention to both the visuals AND the audio/voiceover.
+try:
+    import anthropic
+except ImportError:
+    anthropic = None
 
-Based on the video content, generate Facebook ad copy. Return ONLY valid JSON with this exact structure:
+ANALYSIS_PROMPT = """You are an elite direct-response copywriter who specializes in Facebook ads that CONVERT. You've studied the greats — Gary Halbert, Eugene Schwartz, David Ogilvy — and you write scroll-stopping copy that drives clicks and sales.
+
+Watch/analyze this video carefully — pay attention to both the visuals AND the audio/voiceover.
+
+Based on the video content, generate high-converting Facebook ad copy using direct response and affiliate marketing principles. Return ONLY valid JSON with this exact structure:
 
 {
   "bodies": [
-    "Primary text variation 1 (2-3 sentences, compelling, includes call-to-action)",
-    "Primary text variation 2 (different angle/hook)",
-    "Primary text variation 3 (different emotional appeal)"
+    "Primary text variation 1 — Problem-Agitate-Solve angle with a strong CTA",
+    "Primary text variation 2 — Curiosity hook with benefit-stacking",
+    "Primary text variation 3 — Social proof / story-driven with urgency"
   ],
   "headlines": [
-    "Headline 1 (under 40 chars, punchy)",
-    "Headline 2 (different angle)",
-    "Headline 3 (urgency or curiosity)"
+    "Headline 1 (under 40 chars, power words)",
+    "Headline 2 (benefit-driven, curiosity)",
+    "Headline 3 (urgency or fear of missing out)"
   ],
   "video_summary": "Brief 1-2 sentence summary of what the video shows and says"
 }
 
-Requirements:
-- Primary text should be 2-3 sentences each, suitable for Facebook ads
-- Headlines should be under 40 characters, attention-grabbing
-- Each variation should take a different angle (e.g., benefit-focused, problem-solution, social proof)
-- Match the tone and messaging of the video
-- If there's spoken audio, incorporate key phrases or claims from it
+DIRECT RESPONSE COPYWRITING RULES — follow these strictly:
+- Open with a pattern interrupt or curiosity hook that stops the scroll (e.g., "Wait — did you know...?" or a bold claim)
+- Use the Problem-Agitate-Solve framework: name the pain, twist the knife, present the product as the solution
+- Write in a conversational, first-person tone — like texting a friend, not writing an essay
+- Stack benefits, not features. Every feature must answer "so what?" for the reader
+- Use power words: "secret", "shocking", "finally", "free", "instant", "proven", "limited"
+- Create urgency: limited time, limited stock, exclusive access, "before it's gone"
+- End EVERY body copy with a clear, compelling CTA (e.g., "Tap the link before they sell out")
+- Headlines should be punchy, benefit-first, and create an open loop the reader MUST click to close
+- Each variation should take a genuinely different angle — don't just rephrase the same idea
+- If there's spoken audio, incorporate key phrases, claims, or testimonials from it
+- Write like a top affiliate marketer: conversational, urgent, benefit-obsessed, action-oriented
 - Return ONLY the JSON, no markdown formatting or code blocks"""
 
+TRANSCRIPTION_PROMPT = """Watch this video carefully and transcribe ALL spoken audio — every word of the voiceover, narration, dialogue, or on-screen text that is read aloud.
 
-@router.post("/analyze")
-async def analyze_video(
-    file: UploadFile = File(...),
-    current_user: User = Depends(get_current_active_user),
-):
-    """Analyze a video with Gemini 2.0 Flash to generate ad copy suggestions."""
+Return ONLY valid JSON with this exact structure:
 
+{
+  "transcript": "The full word-for-word transcript of everything spoken in the video",
+  "key_claims": ["List of specific claims, benefits, or testimonials mentioned"],
+  "product_name": "The product or brand name if mentioned, otherwise null",
+  "tone": "Brief description of the speaker's tone and style (e.g. excited, authoritative, casual)"
+}
+
+Rules:
+- Transcribe verbatim — capture the exact words spoken, including filler words if they add authenticity
+- If there are multiple speakers, note speaker changes with [Speaker 1], [Speaker 2] etc.
+- If no audio/speech is detected, set transcript to "" and still fill in key_claims from any on-screen text
+- Return ONLY the JSON, no markdown formatting or code blocks"""
+
+HAIKU_SYSTEM_PROMPT = """You are an elite direct-response copywriter for Facebook ads, specializing in affiliate marketing that needs to be profitable on the frontend FAST. You write for cold traffic — people who have never heard of this product — and your only job is to stop their scroll, hook them, and get the click.
+
+Your copy philosophy:
+- You write like the best affiliate marketers: Frank Kern, Ryan Deiss, Ezra Firestone
+- Every ad must pass the "would I stop scrolling for this?" test
+- You optimize for CTR first, then conversion — because without the click, nothing else matters
+- You treat Facebook ad copy like a mini sales letter: hook → story/proof → CTA
+
+Your direct-response rules:
+1. HOOK (first line): Pattern interrupt. Bold claim, question, or controversy. This line alone decides if they read or scroll.
+2. BODY: Use one framework per variation — PAS (Problem-Agitate-Solve), AIDA (Attention-Interest-Desire-Action), or Before-After-Bridge
+3. PROOF: Weave in specific claims, numbers, or testimonials from the video. Specificity = believability.
+4. CTA: Every body MUST end with an urgent, specific call to action. "Learn more" is banned. Use "Tap the link to...", "Get yours before...", "See why X people..."
+5. TONE: Conversational. First-person. Like texting your best friend about something that actually changed your life.
+6. HEADLINES: Under 40 chars. Benefit-first. Create an open loop. Use power words.
+7. Each variation must take a COMPLETELY different angle — different hook, different framework, different emotional trigger.
+
+You are writing ads that need to generate a positive ROI from day one. Every word must earn its place."""
+
+
+def _parse_ai_response(raw_text: str) -> dict:
+    """Parse JSON from AI response, handling markdown code fences."""
+    json_text = raw_text.strip()
+    if json_text.startswith("```"):
+        lines = json_text.split("\n")
+        lines = [l for l in lines if not l.strip().startswith("```")]
+        json_text = "\n".join(lines)
+
+    result = json.loads(json_text)
+    if "bodies" not in result or "headlines" not in result:
+        raise ValueError("Response missing required fields")
+    return result
+
+
+def _extract_frames(video_path: str, num_frames: int = 10) -> list[str]:
+    """Extract frames from a video using ffmpeg, return list of temp file paths."""
+    tmp_dir = tempfile.mkdtemp(prefix="claude_frames_")
+
+    # Get video duration
+    probe_cmd = [
+        "ffprobe", "-v", "error",
+        "-show_entries", "format=duration",
+        "-of", "default=noprint_wrappers=1:nokey=1",
+        video_path,
+    ]
+    try:
+        duration = float(subprocess.check_output(probe_cmd, stderr=subprocess.DEVNULL).decode().strip())
+    except (subprocess.CalledProcessError, ValueError):
+        duration = 30.0  # fallback
+
+    # Calculate interval between frames
+    interval = max(duration / (num_frames + 1), 0.5)
+
+    # Extract frames at regular intervals
+    output_pattern = os.path.join(tmp_dir, "frame_%03d.jpg")
+    ffmpeg_cmd = [
+        "ffmpeg", "-i", video_path,
+        "-vf", f"fps=1/{interval:.2f}",
+        "-frames:v", str(num_frames),
+        "-q:v", "2",
+        output_pattern,
+        "-y", "-loglevel", "error",
+    ]
+    subprocess.run(ffmpeg_cmd, check=True, timeout=60)
+
+    frame_paths = sorted(glob.glob(os.path.join(tmp_dir, "frame_*.jpg")))
+    print(f"[video_analysis] Extracted {len(frame_paths)} frames from video ({duration:.1f}s)")
+    return frame_paths
+
+
+async def _transcribe_with_gemini(tmp_path: str, filename: str, content_length: int) -> dict:
+    """Use Gemini to transcribe the video audio and extract key claims."""
     if not settings.GEMINI_API_KEY:
         raise HTTPException(status_code=500, detail="GEMINI_API_KEY is not configured")
-
     if genai is None:
         raise HTTPException(status_code=500, detail="google-genai package is not installed")
 
-    # Validate file type
-    content_type = file.content_type or ""
-    if not content_type.startswith("video/"):
-        raise HTTPException(status_code=400, detail="File must be a video")
-
-    tmp_path = None
-    gemini_file = None
     client = genai.Client(api_key=settings.GEMINI_API_KEY)
+    gemini_file = None
 
     try:
-        # Save uploaded file to temp location
-        suffix = os.path.splitext(file.filename or "video.mp4")[1] or ".mp4"
-        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
-            tmp_path = tmp.name
-            content = await file.read()
-            tmp.write(content)
-
-        print(f"[video_analysis] Uploading {file.filename} ({len(content)} bytes) to Gemini File API...")
-
-        # Upload to Gemini File API
+        print(f"[video_analysis:transcribe] Uploading {filename} ({content_length} bytes) for transcription...")
         gemini_file = client.files.upload(file=tmp_path)
-        print(f"[video_analysis] File uploaded: {gemini_file.name}, state={gemini_file.state}")
 
-        # Poll until processing is complete
-        max_wait = 120  # seconds
-        poll_interval = 3
-        elapsed = 0
+        max_wait, poll_interval, elapsed = 120, 3, 0
         while gemini_file.state.name == "PROCESSING" and elapsed < max_wait:
             time.sleep(poll_interval)
             elapsed += poll_interval
             gemini_file = client.files.get(name=gemini_file.name)
-            print(f"[video_analysis] Polling... state={gemini_file.state} ({elapsed}s)")
+
+        if gemini_file.state.name == "FAILED":
+            raise HTTPException(status_code=500, detail="Gemini failed to process the video for transcription")
+        if gemini_file.state.name != "ACTIVE":
+            raise HTTPException(status_code=500, detail=f"Video processing timed out after {max_wait}s")
+
+        print(f"[video_analysis:transcribe] File ready, transcribing with gemini-2.0-flash...")
+        response = client.models.generate_content(
+            model="gemini-2.0-flash",
+            contents=[gemini_file, TRANSCRIPTION_PROMPT],
+        )
+
+        if hasattr(response, "usage_metadata") and response.usage_metadata:
+            um = response.usage_metadata
+            print(f"[video_analysis:transcribe] Tokens — prompt: {um.prompt_token_count}, response: {um.candidates_token_count}")
+
+        raw_text = response.text.strip()
+        print(f"[video_analysis:transcribe] Transcript response: {raw_text[:300]}")
+        result = _parse_ai_response_flexible(raw_text)
+        return result
+
+    finally:
+        if gemini_file:
+            try:
+                client.files.delete(name=gemini_file.name)
+            except Exception as e:
+                print(f"[video_analysis:transcribe] Failed to clean up Gemini file: {e}")
+
+
+def _parse_ai_response_flexible(raw_text: str) -> dict:
+    """Parse JSON from AI response, handling markdown code fences. No required fields."""
+    json_text = raw_text.strip()
+    if json_text.startswith("```"):
+        lines = json_text.split("\n")
+        lines = [l for l in lines if not l.strip().startswith("```")]
+        json_text = "\n".join(lines)
+    return json.loads(json_text)
+
+
+async def _analyze_with_gemini(tmp_path: str, filename: str, content_length: int) -> dict:
+    """Analyze video with Gemini 2.0 Flash (supports video+audio natively)."""
+    if not settings.GEMINI_API_KEY:
+        raise HTTPException(status_code=500, detail="GEMINI_API_KEY is not configured")
+    if genai is None:
+        raise HTTPException(status_code=500, detail="google-genai package is not installed")
+
+    client = genai.Client(api_key=settings.GEMINI_API_KEY)
+    gemini_file = None
+
+    try:
+        print(f"[video_analysis:gemini] Uploading {filename} ({content_length} bytes) to Gemini File API...")
+        gemini_file = client.files.upload(file=tmp_path)
+        print(f"[video_analysis:gemini] File uploaded: {gemini_file.name}, state={gemini_file.state}")
+
+        # Poll until processing is complete
+        max_wait, poll_interval, elapsed = 120, 3, 0
+        while gemini_file.state.name == "PROCESSING" and elapsed < max_wait:
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+            gemini_file = client.files.get(name=gemini_file.name)
+            print(f"[video_analysis:gemini] Polling... state={gemini_file.state} ({elapsed}s)")
 
         if gemini_file.state.name == "FAILED":
             raise HTTPException(status_code=500, detail="Gemini failed to process the video")
-
         if gemini_file.state.name != "ACTIVE":
             raise HTTPException(
                 status_code=500,
                 detail=f"Video processing timed out after {max_wait}s (state: {gemini_file.state.name})",
             )
 
-        print(f"[video_analysis] File ready, sending to gemini-2.0-flash...")
-
-        # Send to Gemini for analysis
+        print(f"[video_analysis:gemini] File ready, sending to gemini-2.0-flash...")
         response = client.models.generate_content(
             model="gemini-2.0-flash",
             contents=[gemini_file, ANALYSIS_PROMPT],
         )
 
+        if hasattr(response, "usage_metadata") and response.usage_metadata:
+            um = response.usage_metadata
+            print(f"[video_analysis:gemini] Tokens — prompt: {um.prompt_token_count}, response: {um.candidates_token_count}, total: {um.total_token_count}")
+
         raw_text = response.text.strip()
-        print(f"[video_analysis] Raw response: {raw_text[:500]}")
+        print(f"[video_analysis:gemini] Raw response: {raw_text[:500]}")
+        return _parse_ai_response(raw_text)
 
-        # Parse JSON from response (handle markdown code blocks)
-        json_text = raw_text
-        if json_text.startswith("```"):
-            # Strip markdown code fences
-            lines = json_text.split("\n")
-            # Remove first line (```json or ```) and last line (```)
-            lines = [l for l in lines if not l.strip().startswith("```")]
-            json_text = "\n".join(lines)
+    finally:
+        if gemini_file:
+            try:
+                client.files.delete(name=gemini_file.name)
+                print(f"[video_analysis:gemini] Cleaned up Gemini file: {gemini_file.name}")
+            except Exception as e:
+                print(f"[video_analysis:gemini] Failed to clean up Gemini file: {e}")
 
-        result = json.loads(json_text)
 
-        # Validate structure
-        if "bodies" not in result or "headlines" not in result:
-            raise ValueError("Response missing required fields")
+async def _analyze_with_claude(tmp_path: str, filename: str, transcript_data: dict = None) -> dict:
+    """Analyze video with Claude Haiku by extracting key frames and sending as images.
+
+    If transcript_data is provided (from Gemini transcription), it's included as context
+    so Haiku can write copy informed by both visuals AND spoken audio.
+    """
+    if not settings.ANTHROPIC_API_KEY:
+        raise HTTPException(status_code=500, detail="ANTHROPIC_API_KEY is not configured")
+    if anthropic is None:
+        raise HTTPException(status_code=500, detail="anthropic package is not installed")
+
+    frame_paths = []
+    try:
+        frame_paths = _extract_frames(tmp_path, num_frames=10)
+        if not frame_paths:
+            raise HTTPException(status_code=500, detail="Failed to extract frames from video")
+
+        # Build image content blocks
+        image_content = []
+        for i, fp in enumerate(frame_paths):
+            with open(fp, "rb") as f:
+                img_data = base64.standard_b64encode(f.read()).decode("utf-8")
+            image_content.append({
+                "type": "text",
+                "text": f"Frame {i + 1} of {len(frame_paths)}:",
+            })
+            image_content.append({
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/jpeg",
+                    "data": img_data,
+                },
+            })
+
+        # Build the user prompt — include transcript if available
+        if transcript_data:
+            transcript = transcript_data.get("transcript", "")
+            key_claims = transcript_data.get("key_claims", [])
+            product_name = transcript_data.get("product_name", "")
+            tone = transcript_data.get("tone", "")
+
+            transcript_context = "\n\n--- VIDEO AUDIO TRANSCRIPT ---\n"
+            if transcript:
+                transcript_context += f"SPOKEN WORDS: {transcript}\n"
+            if key_claims:
+                transcript_context += f"KEY CLAIMS & BENEFITS: {', '.join(key_claims)}\n"
+            if product_name:
+                transcript_context += f"PRODUCT/BRAND: {product_name}\n"
+            if tone:
+                transcript_context += f"SPEAKER TONE: {tone}\n"
+            transcript_context += "--- END TRANSCRIPT ---\n\n"
+            transcript_context += "Use the transcript above as your PRIMARY source for claims, benefits, and proof points. The frames show you the visual style and product. Write copy that leverages BOTH."
+
+            user_prompt = ANALYSIS_PROMPT.replace(
+                "Watch/analyze this video carefully",
+                "Analyze these key frames extracted from a video along with the audio transcript below"
+            ) + transcript_context
+        else:
+            user_prompt = ANALYSIS_PROMPT.replace(
+                "Watch/analyze this video carefully",
+                "Analyze these key frames extracted from a video"
+            )
+
+        image_content.append({
+            "type": "text",
+            "text": user_prompt,
+        })
+
+        mode_label = "transcribe+haiku" if transcript_data else "claude"
+        print(f"[video_analysis:{mode_label}] Sending {len(frame_paths)} frames{' + transcript' if transcript_data else ''} to claude-haiku-4-5-20251001...")
+
+        client = anthropic.Anthropic(api_key=settings.ANTHROPIC_API_KEY)
+        create_kwargs = {
+            "model": "claude-haiku-4-5-20251001",
+            "max_tokens": 1500,
+            "messages": [{"role": "user", "content": image_content}],
+        }
+        if transcript_data:
+            create_kwargs["system"] = HAIKU_SYSTEM_PROMPT
+        response = client.messages.create(**create_kwargs)
+
+        # Log token usage
+        if hasattr(response, "usage") and response.usage:
+            u = response.usage
+            print(f"[video_analysis:{mode_label}] Tokens — input: {u.input_tokens}, output: {u.output_tokens}")
+
+        raw_text = response.content[0].text.strip()
+        print(f"[video_analysis:{mode_label}] Raw response: {raw_text[:500]}")
+        return _parse_ai_response(raw_text)
+
+    finally:
+        # Clean up extracted frames
+        for fp in frame_paths:
+            try:
+                os.unlink(fp)
+            except OSError:
+                pass
+        # Clean up temp directory
+        if frame_paths:
+            try:
+                os.rmdir(os.path.dirname(frame_paths[0]))
+            except OSError:
+                pass
+
+
+@router.post("/analyze")
+async def analyze_video(
+    file: UploadFile = File(...),
+    provider: str = Query("gemini", pattern="^(gemini|claude|transcribe_haiku)$"),
+    current_user: User = Depends(get_current_active_user),
+):
+    """Analyze a video with AI to generate ad copy suggestions.
+
+    provider: "gemini" (default) — uses Gemini 2.0 Flash with native video+audio
+              "claude" — extracts key frames and sends to Claude Haiku
+              "transcribe_haiku" — Gemini transcribes audio, then Haiku writes copy from frames + transcript
+    """
+    content_type = file.content_type or ""
+    if not content_type.startswith("video/"):
+        raise HTTPException(status_code=400, detail="File must be a video")
+
+    tmp_path = None
+    try:
+        suffix = os.path.splitext(file.filename or "video.mp4")[1] or ".mp4"
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            tmp_path = tmp.name
+            content = await file.read()
+            tmp.write(content)
+
+        if provider == "transcribe_haiku":
+            # Step 1: Gemini transcribes the audio
+            print("[video_analysis:transcribe_haiku] Step 1 — Gemini transcribing audio...")
+            transcript_data = await _transcribe_with_gemini(tmp_path, file.filename or "video.mp4", len(content))
+            print(f"[video_analysis:transcribe_haiku] Transcript: {transcript_data.get('transcript', '')[:200]}...")
+            # Step 2: Haiku generates copy from frames + transcript
+            print("[video_analysis:transcribe_haiku] Step 2 — Haiku generating copy with frames + transcript...")
+            result = await _analyze_with_claude(tmp_path, file.filename or "video.mp4", transcript_data=transcript_data)
+        elif provider == "claude":
+            result = await _analyze_with_claude(tmp_path, file.filename or "video.mp4")
+        else:
+            result = await _analyze_with_gemini(tmp_path, file.filename or "video.mp4", len(content))
 
         return {
             "bodies": result["bodies"][:3],
             "headlines": result["headlines"][:3],
             "video_summary": result.get("video_summary", ""),
+            "provider": provider,
         }
 
     except json.JSONDecodeError as e:
@@ -139,13 +416,5 @@ async def analyze_video(
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
     finally:
-        # Clean up temp file
         if tmp_path and os.path.exists(tmp_path):
             os.unlink(tmp_path)
-        # Clean up Gemini file
-        if gemini_file:
-            try:
-                client.files.delete(name=gemini_file.name)
-                print(f"[video_analysis] Cleaned up Gemini file: {gemini_file.name}")
-            except Exception as e:
-                print(f"[video_analysis] Failed to clean up Gemini file: {e}")

--- a/backend/app/api/v1/video_analysis.py
+++ b/backend/app/api/v1/video_analysis.py
@@ -130,6 +130,80 @@ Your direct-response rules:
 You are writing ads that need to generate a positive ROI from day one. Every word must earn its place."""
 
 
+SAFE_VIDEO_PROMPT = """You are a professional Facebook ad copywriter focused on writing clean, policy-compliant ad copy that gets approved quickly and avoids any risk of rejection.
+
+Watch/analyze this video carefully — pay attention to both the visuals AND the audio/voiceover.
+
+Based on the video content, generate Facebook ad copy that is safe, professional, and compliant with Facebook Advertising Policies. Return ONLY valid JSON with this exact structure:
+
+{
+  "bodies": [
+    "Primary text variation 1 — straightforward benefit-focused",
+    "Primary text variation 2 — informational and professional",
+    "Primary text variation 3 — friendly and approachable"
+  ],
+  "headlines": [
+    "Headline 1 (under 40 chars, clear benefit)",
+    "Headline 2 (informational)",
+    "Headline 3 (simple and direct)"
+  ],
+  "video_summary": "Brief 1-2 sentence summary of what the video shows and says"
+}
+
+SAFE COPY RULES — follow these strictly:
+- Write clean, professional copy — NO hype, NO exaggerated claims, NO sensational language
+- DO NOT use words like: "shocking", "secret", "miracle", "guaranteed", "free", "limited time", "act now", "urgent"
+- DO NOT make health claims, income claims, or before/after promises
+- DO NOT use excessive capitalization, exclamation marks, or emoji spam
+- DO NOT create false urgency or scarcity
+- DO NOT use clickbait or misleading hooks
+- Focus on clearly describing what the product/service does and its genuine benefits
+- Use a friendly, professional, conversational tone
+- Headlines should be clear and descriptive, not sensational
+- CTAs should be simple: "Learn More", "Shop Now", "See Details", "Find Out More"
+- Each variation should highlight a different genuine benefit or angle
+- If there's spoken audio, reference the actual content without exaggeration
+- Write copy that would pass Facebook's automated review with zero issues
+- Return ONLY the JSON, no markdown formatting or code blocks"""
+
+
+SAFE_IMAGE_PROMPT = """You are a professional Facebook ad copywriter focused on writing clean, policy-compliant ad copy that gets approved quickly and avoids any risk of rejection.
+
+Analyze this image carefully — pay attention to the product, the setting, any text overlays, branding, and the overall mood.
+
+Based on the image, generate Facebook ad copy that is safe, professional, and compliant with Facebook Advertising Policies. Return ONLY valid JSON with this exact structure:
+
+{
+  "bodies": [
+    "Primary text variation 1 — straightforward benefit-focused",
+    "Primary text variation 2 — informational and professional",
+    "Primary text variation 3 — friendly and approachable"
+  ],
+  "headlines": [
+    "Headline 1 (under 40 chars, clear benefit)",
+    "Headline 2 (informational)",
+    "Headline 3 (simple and direct)"
+  ],
+  "image_summary": "Brief 1-2 sentence summary of what the image shows"
+}
+
+SAFE COPY RULES — follow these strictly:
+- Write clean, professional copy — NO hype, NO exaggerated claims, NO sensational language
+- DO NOT use words like: "shocking", "secret", "miracle", "guaranteed", "free", "limited time", "act now", "urgent"
+- DO NOT make health claims, income claims, or before/after promises
+- DO NOT use excessive capitalization, exclamation marks, or emoji spam
+- DO NOT create false urgency or scarcity
+- DO NOT use clickbait or misleading hooks
+- Focus on clearly describing what the product/service does and its genuine benefits
+- Use a friendly, professional, conversational tone
+- Headlines should be clear and descriptive, not sensational
+- CTAs should be simple: "Learn More", "Shop Now", "See Details", "Find Out More"
+- Each variation should highlight a different genuine benefit or angle
+- If there's text in the image, reference the actual content without exaggeration
+- Write copy that would pass Facebook's automated review with zero issues
+- Return ONLY the JSON, no markdown formatting or code blocks"""
+
+
 def _parse_ai_response(raw_text: str) -> dict:
     """Parse JSON from AI response, handling markdown code fences."""
     json_text = raw_text.strip()
@@ -238,7 +312,7 @@ def _parse_ai_response_flexible(raw_text: str) -> dict:
     return json.loads(json_text)
 
 
-async def _analyze_with_gemini(tmp_path: str, filename: str, content_length: int) -> dict:
+async def _analyze_with_gemini(tmp_path: str, filename: str, content_length: int, prompt_override: str = None) -> dict:
     """Analyze video with Gemini 2.0 Flash (supports video+audio natively)."""
     if not settings.GEMINI_API_KEY:
         raise HTTPException(status_code=500, detail="GEMINI_API_KEY is not configured")
@@ -272,7 +346,7 @@ async def _analyze_with_gemini(tmp_path: str, filename: str, content_length: int
         print(f"[video_analysis:gemini] File ready, sending to gemini-2.0-flash...")
         response = client.models.generate_content(
             model="gemini-2.0-flash",
-            contents=[gemini_file, ANALYSIS_PROMPT],
+            contents=[gemini_file, prompt_override or ANALYSIS_PROMPT],
         )
 
         if hasattr(response, "usage_metadata") and response.usage_metadata:
@@ -402,7 +476,7 @@ async def _analyze_with_claude(tmp_path: str, filename: str, transcript_data: di
 async def analyze_video(
     file: Optional[UploadFile] = File(None),
     url: Optional[str] = Form(None),
-    provider: str = Query("gemini", pattern="^(gemini|claude|transcribe_haiku)$"),
+    provider: str = Query("gemini", pattern="^(gemini|claude|transcribe_haiku|safe)$"),
     current_user: User = Depends(get_current_active_user),
 ):
     """Analyze a video with AI to generate ad copy suggestions.
@@ -410,6 +484,7 @@ async def analyze_video(
     provider: "gemini" (default) — uses Gemini 2.0 Flash with native video+audio
               "claude" — extracts key frames and sends to Claude Haiku
               "transcribe_haiku" — Gemini transcribes audio, then Haiku writes copy from frames + transcript
+              "safe" — Gemini Flash with policy-compliant, low-risk copy
     """
     if file:
         content_type = file.content_type or ""
@@ -442,7 +517,10 @@ async def analyze_video(
 
         filename = (file.filename if file else None) or (os.path.basename(url.split("?")[0]) if url else "video.mp4")
 
-        if provider == "transcribe_haiku":
+        if provider == "safe":
+            # Safe/compliant copy using Gemini Flash with toned-down prompt
+            result = await _analyze_with_gemini(tmp_path, filename, len(content), prompt_override=SAFE_VIDEO_PROMPT)
+        elif provider == "transcribe_haiku":
             # Step 1: Gemini transcribes the audio
             print("[video_analysis:transcribe_haiku] Step 1 — Gemini transcribing audio...")
             transcript_data = await _transcribe_with_gemini(tmp_path, filename, len(content))
@@ -484,13 +562,14 @@ async def analyze_video(
 async def analyze_image(
     file: Optional[UploadFile] = File(None),
     url: Optional[str] = Form(None),
-    provider: str = Query("haiku", pattern="^(haiku|gemini)$"),
+    provider: str = Query("haiku", pattern="^(haiku|gemini|safe)$"),
     current_user: User = Depends(get_current_active_user),
 ):
     """Analyze an image with AI to generate ad copy suggestions.
 
     provider: "haiku" (default) — uses Claude Haiku with vision
               "gemini" — uses Gemini 2.0 Flash with vision
+              "safe" — Gemini Flash with policy-compliant, low-risk copy
     """
     if not file and not url:
         raise HTTPException(status_code=400, detail="Either file or url is required")
@@ -516,18 +595,19 @@ async def analyze_image(
         if media_type == "image/jpg":
             media_type = "image/jpeg"
 
-        if provider == "gemini":
+        if provider in ("gemini", "safe"):
             if not genai:
                 raise HTTPException(status_code=500, detail="google-genai not installed")
             api_key = getattr(settings, "GEMINI_API_KEY", None) or os.environ.get("GEMINI_API_KEY")
             if not api_key:
                 raise HTTPException(status_code=500, detail="GEMINI_API_KEY not configured")
 
+            prompt = SAFE_IMAGE_PROMPT if provider == "safe" else IMAGE_ANALYSIS_PROMPT
             client = genai.Client(api_key=api_key)
             image_part = genai.types.Part.from_bytes(data=image_data, mime_type=media_type)
             response = client.models.generate_content(
                 model="gemini-2.0-flash",
-                contents=[image_part, IMAGE_ANALYSIS_PROMPT],
+                contents=[image_part, prompt],
             )
             result = _parse_ai_response(response.text)
         else:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,11 @@
 import os
+from pathlib import Path
 from dotenv import load_dotenv
 
-load_dotenv()
+# Load .env.local first (overrides), then .env as fallback
+project_root = Path(__file__).parent.parent.parent.parent
+load_dotenv(project_root / ".env.local")
+load_dotenv(project_root / ".env")
 
 class Settings:
     PROJECT_NAME: str = "Facebook Ad Automation App"
@@ -28,9 +32,12 @@ class Settings:
     
     # External APIs
     GEMINI_API_KEY: str = os.getenv("GEMINI_API_KEY", "")
-    FAL_AI_API_KEY: str = os.getenv("FAL_AI_API_KEY", "")
+    ANTHROPIC_API_KEY: str = os.getenv("ANTHROPIC_API_KEY", "")
     KIE_AI_API_KEY: str = os.getenv("KIE_AI_API_KEY", "")
     FACEBOOK_ACCESS_TOKEN: str = os.getenv("FACEBOOK_ACCESS_TOKEN", "")
+
+    # Google Imagen 4 (image generation) - uses same GEMINI_API_KEY
+    IMAGEN_MODEL: str = os.getenv("IMAGEN_MODEL", "imagen-4.0-generate-001")
 
     # Auth settings - SECRET_KEY is required
     SECRET_KEY: str = os.getenv("SECRET_KEY", "")
@@ -52,8 +59,18 @@ class Settings:
     R2_PUBLIC_URL: str = os.getenv("R2_PUBLIC_URL", "")
 
     @property
+    def imagen_enabled(self) -> bool:
+        return bool(self.GEMINI_API_KEY)
+
+    @property
     def r2_enabled(self) -> bool:
-        return bool(self.R2_ACCOUNT_ID and self.R2_ACCESS_KEY_ID and self.R2_SECRET_ACCESS_KEY)
+        placeholders = {"", "your-r2-account-id", "your-r2-access-key-id", "your-r2-secret-access-key"}
+        return bool(
+            self.R2_ACCOUNT_ID and self.R2_ACCESS_KEY_ID and self.R2_SECRET_ACCESS_KEY
+            and self.R2_ACCOUNT_ID not in placeholders
+            and self.R2_ACCESS_KEY_ID not in placeholders
+            and self.R2_SECRET_ACCESS_KEY not in placeholders
+        )
 
     @property
     def r2_endpoint_url(self) -> str:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -117,7 +117,7 @@ async def startup_event():
 
 
 # Include Routers
-from app.api.v1 import brands, products, research, generated_ads, templates, facebook, uploads, dashboard, copy_generation, profiles, ad_remix, prompts, ad_styles, auth, users, video_analysis, ads_library, higgsfield, headlines
+from app.api.v1 import brands, products, research, generated_ads, templates, facebook, uploads, dashboard, copy_generation, profiles, ad_remix, prompts, ad_styles, auth, users, video_analysis, ads_library, higgsfield, headlines, clickflare
 
 app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
 app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
@@ -138,6 +138,7 @@ app.include_router(video_analysis.router, prefix="/api/v1/video-analysis", tags=
 app.include_router(ads_library.router, prefix="/api/v1/ads-library", tags=["ads-library"])
 app.include_router(higgsfield.router, prefix="/api/v1/higgsfield", tags=["higgsfield"])
 app.include_router(headlines.router, prefix="/api/v1/headlines", tags=["headlines"])
+app.include_router(clickflare.router, prefix="/api/v1/clickflare", tags=["clickflare"])
 
 # Mount static files for uploads
 import os

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -78,10 +78,11 @@ async def health_check():
 # Database Connection Validation
 @app.on_event("startup")
 async def startup_event():
-    """Validate PostgreSQL connection on startup"""
-    from app.database import engine
+    """Validate PostgreSQL connection and ensure tables exist on startup"""
+    from app.database import engine, Base
     from sqlalchemy import text
-    
+    import app.models  # noqa: F401 — ensure all models are imported
+
     try:
         with engine.connect() as conn:
             result = conn.execute(text("SELECT version()"))
@@ -94,6 +95,10 @@ async def startup_event():
         print(f"❌ Failed to connect to database: {e}")
         print(f"   DATABASE_URL: {sanitized_url}")
         raise RuntimeError(f"Database connection failed: {e}")
+
+    # Create any new tables (safe — skips existing tables)
+    Base.metadata.create_all(bind=engine)
+    print("✅ Database tables synced")
 
 
 # Include Routers

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -96,7 +96,7 @@ async def startup_event():
 
 
 # Include Routers
-from app.api.v1 import brands, products, research, generated_ads, templates, facebook, uploads, dashboard, copy_generation, profiles, ad_remix, prompts, ad_styles, auth, users
+from app.api.v1 import brands, products, research, generated_ads, templates, facebook, uploads, dashboard, copy_generation, profiles, ad_remix, prompts, ad_styles, auth, users, video_analysis
 
 app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
 app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
@@ -113,6 +113,7 @@ app.include_router(profiles.router, prefix="/api/v1/profiles", tags=["profiles"]
 app.include_router(ad_remix.router, prefix="/api/v1/ad-remix", tags=["ad-remix"])
 app.include_router(prompts.router, prefix="/api/v1/prompts", tags=["prompts"])
 app.include_router(ad_styles.router, prefix="/api/v1/ad-styles", tags=["ad-styles"])
+app.include_router(video_analysis.router, prefix="/api/v1/video-analysis", tags=["video-analysis"])
 
 # Mount static files for uploads
 import os

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -100,6 +100,21 @@ async def startup_event():
     Base.metadata.create_all(bind=engine)
     print("✅ Database tables synced")
 
+    # Add missing columns to existing tables (create_all won't ALTER)
+    with engine.connect() as conn:
+        # Add folder_id to ad_library_items if missing
+        result = conn.execute(text("""
+            SELECT column_name FROM information_schema.columns
+            WHERE table_name = 'ad_library_items' AND column_name = 'folder_id'
+        """))
+        if not result.fetchone():
+            conn.execute(text("""
+                ALTER TABLE ad_library_items
+                ADD COLUMN folder_id VARCHAR REFERENCES ad_library_folders(id) ON DELETE SET NULL
+            """))
+            conn.commit()
+            print("✅ Added folder_id column to ad_library_items")
+
 
 # Include Routers
 from app.api.v1 import brands, products, research, generated_ads, templates, facebook, uploads, dashboard, copy_generation, profiles, ad_remix, prompts, ad_styles, auth, users, video_analysis, ads_library, higgsfield, headlines

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -97,7 +97,7 @@ async def startup_event():
 
 
 # Include Routers
-from app.api.v1 import brands, products, research, generated_ads, templates, facebook, uploads, dashboard, copy_generation, profiles, ad_remix, prompts, ad_styles, auth, users, video_analysis
+from app.api.v1 import brands, products, research, generated_ads, templates, facebook, uploads, dashboard, copy_generation, profiles, ad_remix, prompts, ad_styles, auth, users, video_analysis, ads_library, higgsfield
 
 app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
 app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
@@ -115,6 +115,8 @@ app.include_router(ad_remix.router, prefix="/api/v1/ad-remix", tags=["ad-remix"]
 app.include_router(prompts.router, prefix="/api/v1/prompts", tags=["prompts"])
 app.include_router(ad_styles.router, prefix="/api/v1/ad-styles", tags=["ad-styles"])
 app.include_router(video_analysis.router, prefix="/api/v1/video-analysis", tags=["video-analysis"])
+app.include_router(ads_library.router, prefix="/api/v1/ads-library", tags=["ads-library"])
+app.include_router(higgsfield.router, prefix="/api/v1/higgsfield", tags=["higgsfield"])
 
 # Mount static files for uploads
 import os

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -50,6 +50,7 @@ app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=[trusted_proxies] if tr
 # CORS origins from env var or defaults
 default_origins = [
     "http://localhost:5173",
+    "http://localhost:5175",
     "http://localhost:3000",
 ]
 extra_origins = os.getenv("ALLOWED_ORIGINS", "").split(",")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -97,7 +97,7 @@ async def startup_event():
 
 
 # Include Routers
-from app.api.v1 import brands, products, research, generated_ads, templates, facebook, uploads, dashboard, copy_generation, profiles, ad_remix, prompts, ad_styles, auth, users, video_analysis, ads_library, higgsfield
+from app.api.v1 import brands, products, research, generated_ads, templates, facebook, uploads, dashboard, copy_generation, profiles, ad_remix, prompts, ad_styles, auth, users, video_analysis, ads_library, higgsfield, headlines
 
 app.include_router(auth.router, prefix="/api/v1/auth", tags=["auth"])
 app.include_router(users.router, prefix="/api/v1/users", tags=["users"])
@@ -117,6 +117,7 @@ app.include_router(ad_styles.router, prefix="/api/v1/ad-styles", tags=["ad-style
 app.include_router(video_analysis.router, prefix="/api/v1/video-analysis", tags=["video-analysis"])
 app.include_router(ads_library.router, prefix="/api/v1/ads-library", tags=["ads-library"])
 app.include_router(higgsfield.router, prefix="/api/v1/higgsfield", tags=["higgsfield"])
+app.include_router(headlines.router, prefix="/api/v1/headlines", tags=["headlines"])
 
 # Mount static files for uploads
 import os

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -540,3 +540,30 @@ class Headline(Base):
 
     brand = relationship("Brand")
     product = relationship("Product")
+
+
+class ClickflareConfig(Base):
+    __tablename__ = "clickflare_config"
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    api_key = Column(String, nullable=False)
+    tracking_domain = Column(String, nullable=False)
+    facebook_traffic_source_id = Column(String, nullable=True)
+    facebook_pixel_id = Column(String, nullable=True)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+
+class ClickflareMapping(Base):
+    __tablename__ = "clickflare_mappings"
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    facebook_ad_id = Column(String, ForeignKey("facebook_ads.id", ondelete="CASCADE"), nullable=False)
+    original_url = Column(String, nullable=False)
+    tracking_url = Column(String, nullable=False)
+    cf_offer_id = Column(String, nullable=True)
+    cf_campaign_id = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    facebook_ad = relationship("FacebookAd")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Integer, ForeignKey, DateTime, Text, JSON, Table, Boolean
+from sqlalchemy import Column, String, Integer, ForeignKey, DateTime, Text, JSON, Table, Boolean, UniqueConstraint
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from app.database import Base
@@ -501,7 +501,29 @@ class AdLibraryItem(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
+    folder_id = Column(String, ForeignKey("ad_library_folders.id", ondelete="SET NULL"), nullable=True)
+
     brand = relationship("Brand")
+    folder = relationship("AdLibraryFolder", back_populates="items")
+
+
+class AdLibraryFolder(Base):
+    __tablename__ = "ad_library_folders"
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    brand_id = Column(String, ForeignKey("brands.id", ondelete="CASCADE"), nullable=False)
+    media_type = Column(String, nullable=False, default="image")  # 'image' or 'video'
+    name = Column(String, nullable=False)
+    position = Column(Integer, nullable=True, default=0)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    brand = relationship("Brand")
+    items = relationship("AdLibraryItem", back_populates="folder")
+
+    __table_args__ = (
+        UniqueConstraint('brand_id', 'media_type', 'name', name='uq_folder_brand_media_name'),
+    )
 
 
 class Headline(Base):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -489,6 +489,7 @@ class AdLibraryItem(Base):
     media_type = Column(String, nullable=False, default="image")  # 'image' or 'video'
     media_url = Column(String, nullable=False)
     thumbnail_url = Column(String, nullable=True)
+    variants = Column(JSON, nullable=True)  # {"1:1": "url_square", "9:16": "url_story"}
     file_size = Column(Integer, nullable=True)
     headline = Column(String, nullable=True)
     body = Column(Text, nullable=True)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -502,3 +502,19 @@ class AdLibraryItem(Base):
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
     brand = relationship("Brand")
+
+
+class Headline(Base):
+    __tablename__ = "headlines"
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    brand_id = Column(String, ForeignKey("brands.id", ondelete="CASCADE"), nullable=False)
+    product_id = Column(String, ForeignKey("products.id", ondelete="SET NULL"), nullable=True)
+    text = Column(Text, nullable=False)
+    category = Column(String, nullable=True)  # curiosity, urgency, benefit, social_proof, fomo
+    source = Column(String, default="ai")     # ai or manual
+    research_doc_url = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    brand = relationship("Brand")
+    product = relationship("Product")

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -478,3 +478,26 @@ class BrandScrapedAd(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     brand_scrape = relationship("BrandScrape", back_populates="ads")
+
+
+class AdLibraryItem(Base):
+    __tablename__ = "ad_library_items"
+
+    id = Column(String, primary_key=True, default=generate_uuid)
+    brand_id = Column(String, ForeignKey("brands.id", ondelete="SET NULL"), nullable=True)
+    name = Column(String, nullable=True)
+    media_type = Column(String, nullable=False, default="image")  # 'image' or 'video'
+    media_url = Column(String, nullable=False)
+    thumbnail_url = Column(String, nullable=True)
+    file_size = Column(Integer, nullable=True)
+    headline = Column(String, nullable=True)
+    body = Column(Text, nullable=True)
+    cta = Column(String, nullable=True)
+    tags = Column(JSON, nullable=True)  # ["testimonial", "Q1"]
+    funnel_stage = Column(String, nullable=True)  # tofu, mofu, bofu
+    ad_format = Column(String, nullable=True)  # single_image, carousel, story, reel, ugc, testimonial
+    status = Column(String, nullable=False, default="draft")  # draft, ready, active, archived
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    brand = relationship("Brand")

--- a/backend/app/schemas/ads_library.py
+++ b/backend/app/schemas/ads_library.py
@@ -1,0 +1,55 @@
+from pydantic import BaseModel
+from typing import Optional, List
+from datetime import datetime
+
+
+class AdLibraryItemCreate(BaseModel):
+    brand_id: Optional[str] = None
+    name: Optional[str] = None
+    media_type: str = "image"
+    media_url: str
+    thumbnail_url: Optional[str] = None
+    file_size: Optional[int] = None
+    headline: Optional[str] = None
+    body: Optional[str] = None
+    cta: Optional[str] = None
+    tags: Optional[List[str]] = None
+    funnel_stage: Optional[str] = None
+    ad_format: Optional[str] = None
+    status: str = "draft"
+
+
+class AdLibraryItemUpdate(BaseModel):
+    brand_id: Optional[str] = None
+    name: Optional[str] = None
+    media_type: Optional[str] = None
+    headline: Optional[str] = None
+    body: Optional[str] = None
+    cta: Optional[str] = None
+    tags: Optional[List[str]] = None
+    funnel_stage: Optional[str] = None
+    ad_format: Optional[str] = None
+    status: Optional[str] = None
+
+
+class AdLibraryItemResponse(BaseModel):
+    id: str
+    brand_id: Optional[str] = None
+    brand_name: Optional[str] = None
+    name: Optional[str] = None
+    media_type: str
+    media_url: str
+    thumbnail_url: Optional[str] = None
+    file_size: Optional[int] = None
+    headline: Optional[str] = None
+    body: Optional[str] = None
+    cta: Optional[str] = None
+    tags: Optional[List[str]] = None
+    funnel_stage: Optional[str] = None
+    ad_format: Optional[str] = None
+    status: str
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/backend/app/schemas/ads_library.py
+++ b/backend/app/schemas/ads_library.py
@@ -3,8 +3,38 @@ from typing import Optional, List, Dict
 from datetime import datetime
 
 
+# --- Folder Schemas ---
+
+class AdLibraryFolderCreate(BaseModel):
+    brand_id: str
+    media_type: str = "image"
+    name: str
+
+
+class AdLibraryFolderUpdate(BaseModel):
+    name: Optional[str] = None
+    position: Optional[int] = None
+
+
+class AdLibraryFolderResponse(BaseModel):
+    id: str
+    brand_id: str
+    media_type: str
+    name: str
+    position: Optional[int] = 0
+    item_count: Optional[int] = 0
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+# --- Item Schemas ---
+
 class AdLibraryItemCreate(BaseModel):
     brand_id: Optional[str] = None
+    folder_id: Optional[str] = None
     name: Optional[str] = None
     media_type: str = "image"
     media_url: str
@@ -22,6 +52,7 @@ class AdLibraryItemCreate(BaseModel):
 
 class AdLibraryItemUpdate(BaseModel):
     brand_id: Optional[str] = None
+    folder_id: Optional[str] = None
     name: Optional[str] = None
     media_type: Optional[str] = None
     media_url: Optional[str] = None
@@ -40,6 +71,8 @@ class AdLibraryItemResponse(BaseModel):
     id: str
     brand_id: Optional[str] = None
     brand_name: Optional[str] = None
+    folder_id: Optional[str] = None
+    folder_name: Optional[str] = None
     name: Optional[str] = None
     media_type: str
     media_url: str

--- a/backend/app/schemas/ads_library.py
+++ b/backend/app/schemas/ads_library.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Optional, List
+from typing import Optional, List, Dict
 from datetime import datetime
 
 
@@ -9,6 +9,7 @@ class AdLibraryItemCreate(BaseModel):
     media_type: str = "image"
     media_url: str
     thumbnail_url: Optional[str] = None
+    variants: Optional[Dict[str, str]] = None  # {"1:1": "url", "9:16": "url"}
     file_size: Optional[int] = None
     headline: Optional[str] = None
     body: Optional[str] = None
@@ -23,6 +24,9 @@ class AdLibraryItemUpdate(BaseModel):
     brand_id: Optional[str] = None
     name: Optional[str] = None
     media_type: Optional[str] = None
+    media_url: Optional[str] = None
+    thumbnail_url: Optional[str] = None
+    variants: Optional[Dict[str, str]] = None
     headline: Optional[str] = None
     body: Optional[str] = None
     cta: Optional[str] = None
@@ -40,6 +44,7 @@ class AdLibraryItemResponse(BaseModel):
     media_type: str
     media_url: str
     thumbnail_url: Optional[str] = None
+    variants: Optional[Dict[str, str]] = None
     file_size: Optional[int] = None
     headline: Optional[str] = None
     body: Optional[str] = None

--- a/backend/app/schemas/headline.py
+++ b/backend/app/schemas/headline.py
@@ -1,0 +1,29 @@
+from pydantic import BaseModel
+from typing import Optional, List
+from datetime import datetime
+
+
+class HeadlineCreate(BaseModel):
+    text: str
+    brand_id: str
+    product_id: Optional[str] = None
+    category: Optional[str] = None
+    source: str = "manual"
+
+
+class HeadlineBatchDelete(BaseModel):
+    ids: List[str]
+
+
+class Headline(BaseModel):
+    id: str
+    brand_id: str
+    product_id: Optional[str] = None
+    text: str
+    category: Optional[str] = None
+    source: str = "ai"
+    research_doc_url: Optional[str] = None
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/backend/app/schemas/research.py
+++ b/backend/app/schemas/research.py
@@ -71,6 +71,10 @@ class BrandScrapeCreate(BaseModel):
     page_url: str  # Facebook Ads Library URL with view_all_page_id
 
 
+class BrandScrapeUpdate(BaseModel):
+    brand_name: Optional[str] = None
+
+
 class BrandScrapedAdResponse(BaseModel):
     id: str
     external_id: str

--- a/backend/app/schemas/research.py
+++ b/backend/app/schemas/research.py
@@ -7,6 +7,7 @@ class AdSearchRequest(BaseModel):
     platform: str = "facebook"
     limit: int = 10
     country: str = "US"
+    language: str = ""  # Language filter: en, es, de, fr, pt, it, etc. Empty = all
     offset: int = 0  # Pagination: controls scroll depth
     exclude_ids: List[str] = []  # IDs to skip (already fetched)
     negative_keywords: List[str] = []  # Keywords to exclude from results

--- a/backend/app/services/brand_scraper.py
+++ b/backend/app/services/brand_scraper.py
@@ -172,6 +172,7 @@ class BrandScraperService:
 
         ads = []
         captured_images = {}  # url -> bytes
+        captured_videos = []  # list of {url, data, content_type}
         fb_email = os.getenv("FB_SCRAPER_EMAIL")
         fb_password = os.getenv("FB_SCRAPER_PASSWORD")
 
@@ -184,8 +185,8 @@ class BrandScraperService:
                 )
                 page = await context.new_page()
 
-                # Capture images as they load
-                async def capture_image_response(response):
+                # Capture images and videos as they load
+                async def capture_media_response(response):
                     url = response.url
                     content_type = response.headers.get('content-type', '')
                     if 'image' in content_type and ('scontent' in url or 'fbcdn' in url):
@@ -195,8 +196,20 @@ class BrandScraperService:
                                 captured_images[url] = body
                         except:
                             pass
+                    elif 'video' in content_type:
+                        try:
+                            body = await response.body()
+                            if len(body) > 10000:  # Only substantial videos
+                                captured_videos.append({
+                                    'url': url,
+                                    'data': body,
+                                    'content_type': content_type
+                                })
+                                print(f"Captured video: {len(body)} bytes")
+                        except:
+                            pass
 
-                page.on('response', capture_image_response)
+                page.on('response', capture_media_response)
 
                 # Login to Facebook if credentials provided (optional - public URLs work without login)
                 if fb_email and fb_password:
@@ -317,6 +330,10 @@ class BrandScraperService:
                                 }
                             });
 
+                            // Check if this ad has a video
+                            const hasVideo = div.querySelector('video') !== null ||
+                                           text.match(/\\d+:\\d+/) !== null;
+
                             results.push({
                                 id: libraryId,
                                 page_name: pageName,
@@ -324,7 +341,8 @@ class BrandScraperService:
                                 ad_creative_link_titles: headline ? [headline] : null,
                                 ad_creative_bodies: adCopy ? [adCopy] : null,
                                 ad_creative_link_captions: ctaText ? [ctaText] : null,
-                                _image_urls: imageUrls
+                                _image_urls: imageUrls,
+                                _has_video: hasVideo
                             });
                         });
 
@@ -332,7 +350,7 @@ class BrandScraperService:
                     }
                 """)
 
-                print(f"Playwright extracted {len(ads)} ads, captured {len(captured_images)} images from network")
+                print(f"Playwright extracted {len(ads)} ads, captured {len(captured_images)} images and {len(captured_videos)} videos from network")
 
                 # Log image URL stats
                 total_img_urls = sum(len(ad.get('_image_urls', [])) for ad in ads)
@@ -353,6 +371,22 @@ class BrandScraperService:
                             matched_count += 1
 
                 print(f"Matched {matched_count} images to ads")
+
+                # Assign captured videos to ads that have video indicators
+                video_idx = 0
+                for ad in ads:
+                    if ad.get('_has_video') and video_idx < len(captured_videos):
+                        vid = captured_videos[video_idx]
+                        ad['_media_data'].append({
+                            'url': vid['url'],
+                            'type': 'video',
+                            'content_type': vid['content_type'],
+                            'data': vid['data']
+                        })
+                        video_idx += 1
+
+                if captured_videos:
+                    print(f"Assigned {video_idx} videos to ads")
 
                 # If few matches, distribute captured images to ads without media
                 if matched_count < len(ads) // 2 and captured_images:
@@ -672,6 +706,10 @@ class BrandScraperService:
         # Detect carousel
         if len(r2_urls) > 1 and media_type == "image":
             media_type = "carousel"
+
+        # Use DOM hint to classify video ads (videos don't auto-stream in Ads Library)
+        if ad_data.get("_has_video") and media_type == "image":
+            media_type = "video"
 
         # Extract page info
         page_name = ad_data.get("page_name")

--- a/backend/app/services/brand_scraper.py
+++ b/backend/app/services/brand_scraper.py
@@ -330,6 +330,30 @@ class BrandScraperService:
                                 }
                             });
 
+                            // Extract start date - try multiple patterns
+                            let startDate = null;
+                            // Pattern 1: "Started running on Feb 4, 2026"
+                            let dateMatch = text.match(/Started running on\\s+(.+?)(?:\\n|$)/);
+                            if (!dateMatch) {
+                                // Pattern 2: "Active since ..."
+                                dateMatch = text.match(/Active since\\s+(.+?)(?:\\n|$)/);
+                            }
+                            if (!dateMatch) {
+                                // Pattern 3: Look for month day, year pattern near end of text
+                                dateMatch = text.match(/((?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\\s+\\d{1,2},?\\s+\\d{4})(?:\\n|$)/);
+                            }
+                            if (!dateMatch) {
+                                // Pattern 4: ISO-ish date YYYY-MM-DD
+                                dateMatch = text.match(/(\\d{4}-\\d{2}-\\d{2})/);
+                            }
+                            if (dateMatch) startDate = dateMatch[1].trim();
+
+                            // Debug: log first ad's text around date area
+                            if (results.length === 0) {
+                                const last200 = text.slice(-200);
+                                console.log('DEBUG date extraction - last 200 chars of first ad text:', last200);
+                            }
+
                             // Check if this ad has a video
                             const hasVideo = div.querySelector('video') !== null ||
                                            text.match(/\\d+:\\d+/) !== null;
@@ -341,6 +365,7 @@ class BrandScraperService:
                                 ad_creative_link_titles: headline ? [headline] : null,
                                 ad_creative_bodies: adCopy ? [adCopy] : null,
                                 ad_creative_link_captions: ctaText ? [ctaText] : null,
+                                ad_delivery_start_time: startDate,
                                 _image_urls: imageUrls,
                                 _has_video: hasVideo
                             });
@@ -351,6 +376,12 @@ class BrandScraperService:
                 """)
 
                 print(f"Playwright extracted {len(ads)} ads, captured {len(captured_images)} images and {len(captured_videos)} videos from network")
+
+                # Debug: show date extraction results
+                dates_found = sum(1 for ad in ads if ad.get('ad_delivery_start_time'))
+                print(f"Dates extracted: {dates_found}/{len(ads)} ads have start dates")
+                if ads and not ads[0].get('ad_delivery_start_time'):
+                    print(f"DEBUG: First ad keys: {list(ads[0].keys()) if ads else 'none'}")
 
                 # Log image URL stats
                 total_img_urls = sum(len(ad.get('_image_urls', [])) for ad in ads)

--- a/backend/app/services/brand_scraper.py
+++ b/backend/app/services/brand_scraper.py
@@ -198,26 +198,29 @@ class BrandScraperService:
 
                 page.on('response', capture_image_response)
 
-                # Login to Facebook if credentials provided
+                # Login to Facebook if credentials provided (optional - public URLs work without login)
                 if fb_email and fb_password:
-                    print("Logging into Facebook...")
-                    await page.goto("https://www.facebook.com/login", timeout=30000)
-                    await page.wait_for_timeout(2000)
+                    try:
+                        print("Logging into Facebook...")
+                        await page.goto("https://www.facebook.com/login", timeout=30000)
+                        await page.wait_for_timeout(2000)
 
-                    await page.fill('input[name="email"]', fb_email)
-                    await page.fill('input[name="pass"]', fb_password)
-                    await page.click('button[name="login"]')
+                        await page.fill('input[name="email"]', fb_email)
+                        await page.fill('input[name="pass"]', fb_password)
+                        await page.click('button[name="login"]')
 
-                    # Wait for login to complete
-                    await page.wait_for_timeout(5000)
+                        # Wait for login to complete
+                        await page.wait_for_timeout(5000)
 
-                    # Check if logged in
-                    current_url = page.url.lower()
-                    if "login" in current_url or "checkpoint" in current_url:
-                        error_detail = "Login page still showing" if "login" in current_url else "Security checkpoint triggered"
-                        raise Exception(f"Facebook login failed: {error_detail}. URL: {page.url}")
-                    else:
-                        print("Facebook login successful")
+                        # Check if logged in
+                        current_url = page.url.lower()
+                        if "login" in current_url or "checkpoint" in current_url:
+                            error_detail = "Login page still showing" if "login" in current_url else "Security checkpoint triggered"
+                            print(f"Facebook login failed: {error_detail}. Continuing without login (public URL).")
+                        else:
+                            print("Facebook login successful")
+                    except Exception as login_err:
+                        print(f"Facebook login error: {login_err}. Continuing without login (public URL).")
 
                 # Build URL
                 if is_search:

--- a/backend/app/services/clickflare_service.py
+++ b/backend/app/services/clickflare_service.py
@@ -1,0 +1,170 @@
+"""
+Clickflare Tracking Service
+REST API integration with Clickflare (developers.clickflare.io)
+"""
+import httpx
+from typing import Optional
+from urllib.parse import urlencode
+
+BASE_URL = "https://api.clickflare.io/v1"
+TIMEOUT = 30.0
+
+
+class ClickflareService:
+    def __init__(self, api_key: str, tracking_domain: str):
+        self.api_key = api_key
+        self.tracking_domain = tracking_domain
+        self.headers = {
+            "Access-Key": api_key,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    async def test_connection(self) -> dict:
+        """Test API connectivity."""
+        async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+            resp = await client.get(
+                f"{BASE_URL}/campaigns",
+                headers=self.headers,
+                params={"limit": 1},
+            )
+            resp.raise_for_status()
+            return {"status": "connected", "data": resp.json()}
+
+    async def get_traffic_sources(self) -> list:
+        """List all traffic sources."""
+        async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+            resp = await client.get(f"{BASE_URL}/traffic-sources", headers=self.headers)
+            resp.raise_for_status()
+            return resp.json()
+
+    async def find_or_create_facebook_traffic_source(self) -> str:
+        """Find existing Facebook traffic source or create one. Returns ID."""
+        sources = await self.get_traffic_sources()
+        data = sources.get("data", sources) if isinstance(sources, dict) else sources
+        if isinstance(data, list):
+            for source in data:
+                name = source.get("name", "").lower()
+                if "facebook" in name or "meta" in name:
+                    return source["id"]
+
+        async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+            resp = await client.post(
+                f"{BASE_URL}/traffic-sources",
+                headers=self.headers,
+                json={
+                    "name": "Facebook Ads",
+                    "postbackUrl": "",
+                    "trackingFields": {
+                        "trackingField1": {"name": "campaign_id", "parameter": "campaign_id"},
+                        "trackingField2": {"name": "adset_id", "parameter": "adset_id"},
+                        "trackingField3": {"name": "ad_id", "parameter": "ad_id"},
+                        "trackingField4": {"name": "placement", "parameter": "placement"},
+                        "trackingField5": {"name": "site_source_name", "parameter": "site_source_name"},
+                    },
+                },
+            )
+            resp.raise_for_status()
+            result = resp.json()
+            return result.get("id", result.get("data", {}).get("id"))
+
+    async def create_offer(self, name: str, url: str) -> str:
+        """Create a Clickflare offer. Returns offer ID."""
+        async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+            resp = await client.post(
+                f"{BASE_URL}/offers",
+                headers=self.headers,
+                json={"name": name, "url": url},
+            )
+            resp.raise_for_status()
+            result = resp.json()
+            return result.get("id", result.get("data", {}).get("id"))
+
+    async def create_campaign(self, name: str, offer_id: str, traffic_source_id: str) -> str:
+        """Create a Clickflare campaign. Returns campaign ID."""
+        async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+            resp = await client.post(
+                f"{BASE_URL}/campaigns",
+                headers=self.headers,
+                json={
+                    "name": name,
+                    "trafficSourceId": traffic_source_id,
+                    "costModel": "auto",
+                    "flow": {
+                        "type": "url",
+                        "url": "",
+                        "offers": [{"id": offer_id, "weight": 100}],
+                    },
+                },
+            )
+            resp.raise_for_status()
+            result = resp.json()
+            return result.get("id", result.get("data", {}).get("id"))
+
+    def build_tracking_url(self, cf_campaign_id: str) -> str:
+        """Build redirect tracking URL with Facebook dynamic macros."""
+        fb_params = {
+            "trackingField1": "{{campaign.id}}",
+            "trackingField2": "{{adset.id}}",
+            "trackingField3": "{{ad.id}}",
+            "trackingField4": "{{placement}}",
+            "trackingField5": "{{site_source_name}}",
+        }
+        query = urlencode(fb_params, safe="{}")
+        return f"https://{self.tracking_domain}/cf/r/{cf_campaign_id}?{query}"
+
+    async def generate_tracking_url(
+        self,
+        ad_name: str,
+        destination_url: str,
+        traffic_source_id: str,
+    ) -> dict:
+        """Full workflow: create offer + campaign + return tracking URL."""
+        offer_id = await self.create_offer(
+            name=f"Offer - {ad_name}",
+            url=destination_url,
+        )
+        campaign_id = await self.create_campaign(
+            name=f"CF - {ad_name}",
+            offer_id=offer_id,
+            traffic_source_id=traffic_source_id,
+        )
+        tracking_url = self.build_tracking_url(campaign_id)
+        return {
+            "offer_id": offer_id,
+            "campaign_id": campaign_id,
+            "tracking_url": tracking_url,
+            "original_url": destination_url,
+        }
+
+    async def get_campaign_report(
+        self,
+        date_from: str,
+        date_to: str,
+        group_by: str = "campaign",
+        cf_campaign_id: Optional[str] = None,
+    ) -> dict:
+        """Fetch performance report."""
+        params = {
+            "dateFrom": date_from,
+            "dateTo": date_to,
+            "groupBy": group_by,
+        }
+        if cf_campaign_id:
+            params["campaignId"] = cf_campaign_id
+
+        async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+            resp = await client.get(
+                f"{BASE_URL}/reports",
+                headers=self.headers,
+                params=params,
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    async def get_campaigns_list(self) -> list:
+        """Fetch all Clickflare campaigns."""
+        async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+            resp = await client.get(f"{BASE_URL}/campaigns", headers=self.headers)
+            resp.raise_for_status()
+            return resp.json()

--- a/backend/app/services/clickflare_service.py
+++ b/backend/app/services/clickflare_service.py
@@ -6,7 +6,7 @@ import httpx
 from typing import Optional
 from urllib.parse import urlencode
 
-BASE_URL = "https://api.clickflare.io/v1"
+BASE_URL = "https://public-api.clickflare.io/api"
 TIMEOUT = 30.0
 
 
@@ -15,28 +15,43 @@ class ClickflareService:
         self.api_key = api_key
         self.tracking_domain = tracking_domain
         self.headers = {
-            "Access-Key": api_key,
+            "Api-Key": api_key,
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
+
+    def _handle_response(self, resp: httpx.Response) -> dict:
+        """Handle response with clear error messages."""
+        if resp.status_code == 403:
+            body = resp.json() if resp.headers.get("content-type", "").startswith("application/json") else {}
+            msg = body.get("message", "")
+            if "PublicApi" in str(body):
+                raise httpx.HTTPStatusError(
+                    "Public API access is not enabled on your Clickflare account. "
+                    "Go to Clickflare Settings > Security > API Access and ensure Public API is enabled.",
+                    request=resp.request,
+                    response=resp,
+                )
+            raise httpx.HTTPStatusError(msg or "Forbidden", request=resp.request, response=resp)
+        resp.raise_for_status()
+        return resp.json()
 
     async def test_connection(self) -> dict:
         """Test API connectivity."""
         async with httpx.AsyncClient(timeout=TIMEOUT) as client:
             resp = await client.get(
-                f"{BASE_URL}/campaigns",
+                f"{BASE_URL}/campaigns/list",
                 headers=self.headers,
                 params={"limit": 1},
             )
-            resp.raise_for_status()
-            return {"status": "connected", "data": resp.json()}
+            data = self._handle_response(resp)
+            return {"status": "connected", "data": data}
 
     async def get_traffic_sources(self) -> list:
         """List all traffic sources."""
         async with httpx.AsyncClient(timeout=TIMEOUT) as client:
             resp = await client.get(f"{BASE_URL}/traffic-sources", headers=self.headers)
-            resp.raise_for_status()
-            return resp.json()
+            return self._handle_response(resp)
 
     async def find_or_create_facebook_traffic_source(self) -> str:
         """Find existing Facebook traffic source or create one. Returns ID."""
@@ -64,8 +79,7 @@ class ClickflareService:
                     },
                 },
             )
-            resp.raise_for_status()
-            result = resp.json()
+            result = self._handle_response(resp)
             return result.get("id", result.get("data", {}).get("id"))
 
     async def create_offer(self, name: str, url: str) -> str:
@@ -76,8 +90,7 @@ class ClickflareService:
                 headers=self.headers,
                 json={"name": name, "url": url},
             )
-            resp.raise_for_status()
-            result = resp.json()
+            result = self._handle_response(resp)
             return result.get("id", result.get("data", {}).get("id"))
 
     async def create_campaign(self, name: str, offer_id: str, traffic_source_id: str) -> str:
@@ -97,8 +110,7 @@ class ClickflareService:
                     },
                 },
             )
-            resp.raise_for_status()
-            result = resp.json()
+            result = self._handle_response(resp)
             return result.get("id", result.get("data", {}).get("id"))
 
     def build_tracking_url(self, cf_campaign_id: str) -> str:
@@ -144,27 +156,28 @@ class ClickflareService:
         group_by: str = "campaign",
         cf_campaign_id: Optional[str] = None,
     ) -> dict:
-        """Fetch performance report."""
-        params = {
+        """Fetch performance report via POST."""
+        body = {
             "dateFrom": date_from,
             "dateTo": date_to,
             "groupBy": group_by,
         }
         if cf_campaign_id:
-            params["campaignId"] = cf_campaign_id
+            body["campaignId"] = cf_campaign_id
 
         async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-            resp = await client.get(
-                f"{BASE_URL}/reports",
+            resp = await client.post(
+                f"{BASE_URL}/report",
                 headers=self.headers,
-                params=params,
+                json=body,
             )
-            resp.raise_for_status()
-            return resp.json()
+            return self._handle_response(resp)
 
     async def get_campaigns_list(self) -> list:
         """Fetch all Clickflare campaigns."""
         async with httpx.AsyncClient(timeout=TIMEOUT) as client:
-            resp = await client.get(f"{BASE_URL}/campaigns", headers=self.headers)
-            resp.raise_for_status()
-            return resp.json()
+            resp = await client.get(
+                f"{BASE_URL}/campaigns/list",
+                headers=self.headers,
+            )
+            return self._handle_response(resp)

--- a/backend/app/services/facebook_service.py
+++ b/backend/app/services/facebook_service.py
@@ -54,21 +54,34 @@ class FacebookService:
 
 
     def get_ad_accounts(self):
-        """Fetch all ad accounts for the current user."""
+        """Fetch all ad accounts for the current user or system user."""
         if not self.api:
-            # Try to initialize if not already done
             self.initialize()
-        
-        # Use the SDK's User object to fetch ad accounts
+
+        # First try /me/adaccounts (works for user tokens)
         print("Fetching ad accounts for user 'me'...")
         try:
             me = User(fbid='me', api=self.api)
             my_accounts = me.get_ad_accounts(fields=['id', 'name', 'account_id', 'account_status', 'currency', 'balance', 'amount_spent'])
-            print(f"Found {len(my_accounts)} accounts.")
-            return [dict(acc) for acc in my_accounts]
+            if len(my_accounts) > 0:
+                print(f"Found {len(my_accounts)} accounts.")
+                return [dict(acc) for acc in my_accounts]
+            print("/me/adaccounts returned 0 accounts, falling back to direct account lookup...")
         except Exception as e:
-            print(f"Error fetching ad accounts: {e}")
-            raise e
+            print(f"/me/adaccounts failed ({e}), falling back to direct account lookup...")
+
+        # Fallback for system user tokens: query the configured ad account directly
+        if self.account:
+            try:
+                fields = ['id', 'name', 'account_id', 'account_status', 'currency', 'balance', 'amount_spent']
+                account_data = self.account.api_get(fields=fields)
+                print(f"Found configured account: {account_data.get('name')}")
+                return [dict(account_data)]
+            except Exception as e2:
+                print(f"Direct account lookup also failed: {e2}")
+                raise e2
+
+        raise Exception("No ad accounts found and no default account configured.")
 
     def _get_account(self, ad_account_id=None):
         """Helper to get AdAccount object."""

--- a/backend/app/services/facebook_service.py
+++ b/backend/app/services/facebook_service.py
@@ -180,6 +180,14 @@ class FacebookService:
         pages = me.get_accounts(fields=fields)
         return [dict(page) for page in pages]
 
+    def get_page_info(self, page_id: str):
+        """Fetch a single Facebook Page's name by ID."""
+        from facebook_business.adobjects.page import Page
+
+        page = Page(fbid=page_id, api=self.api)
+        page.api_get(fields=[Page.Field.id, Page.Field.name])
+        return {"id": page[Page.Field.id], "name": page[Page.Field.name]}
+
     def get_adsets(self, ad_account_id=None, campaign_id=None):
         """Fetch all ad sets."""
         fields = [

--- a/backend/app/services/higgsfield_service.py
+++ b/backend/app/services/higgsfield_service.py
@@ -1,0 +1,90 @@
+"""
+Higgsfield AI Service - Image-to-Video generation
+Uses the Higgsfield platform API (DoP model) to animate static images.
+"""
+import os
+import httpx
+from typing import Optional
+
+
+BASE_URL = "https://platform.higgsfield.ai"
+TIMEOUT = 30.0
+
+
+def _get_headers():
+    api_key = os.getenv("HIGGSFIELD_API_KEY")
+    secret = os.getenv("HIGGSFIELD_API_SECRET")
+    if not api_key or not secret:
+        raise ValueError("HIGGSFIELD_API_KEY and HIGGSFIELD_API_SECRET must be set")
+    return {
+        "hf-api-key": api_key,
+        "hf-secret": secret,
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+
+async def list_motions():
+    """Get available video motion presets (zoom, dolly, pan, etc.)"""
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        resp = await client.get(f"{BASE_URL}/v1/motions", headers=_get_headers())
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def generate_video(
+    image_url: str,
+    motion_id: str,
+    prompt: str = "",
+    model: str = "dop-lite",
+    strength: float = 0.5,
+) -> dict:
+    """
+    Submit image-to-video generation job.
+
+    Args:
+        image_url: Public URL of the source image
+        motion_id: Motion preset ID (from list_motions)
+        prompt: Description of the scene (auto-generated if empty)
+        model: dop-lite (cheapest), dop-turbo, or dop-preview
+        strength: Motion intensity 0.0-1.0
+
+    Returns:
+        Job response with id for polling
+    """
+    if not prompt:
+        prompt = "Cinematic video with smooth natural motion"
+
+    request_body = {
+        "params": {
+            "model": model,
+            "prompt": prompt,
+            "input_images": [{"type": "image_url", "image_url": image_url}],
+            "motions": [{"id": motion_id, "strength": strength}],
+        }
+    }
+
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        resp = await client.post(
+            f"{BASE_URL}/v1/image2video/dop",
+            headers=_get_headers(),
+            json=request_body,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def get_job_status(job_id: str) -> dict:
+    """Check status of a generation job. Returns status + results when done."""
+    async with httpx.AsyncClient(timeout=TIMEOUT) as client:
+        resp = await client.get(
+            f"{BASE_URL}/v1/job-sets/{job_id}",
+            headers=_get_headers(),
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+def is_configured() -> bool:
+    """Check if Higgsfield credentials are set."""
+    return bool(os.getenv("HIGGSFIELD_API_KEY") and os.getenv("HIGGSFIELD_API_SECRET"))

--- a/backend/app/services/research_service.py
+++ b/backend/app/services/research_service.py
@@ -33,6 +33,7 @@ class ResearchService:
             request.query,
             request.limit,
             request.country,
+            request.language,
             request.offset,
             request.exclude_ids,
             request.negative_keywords
@@ -184,6 +185,7 @@ class ResearchService:
             request.query,
             request.limit,
             request.country,
+            request.language,
             request.offset,
             request.exclude_ids,
             request.negative_keywords

--- a/backend/app/services/scraper.py
+++ b/backend/app/services/scraper.py
@@ -26,7 +26,7 @@ class FacebookAdsLibraryAPI:
         self.access_token = os.getenv("FACEBOOK_ADS_LIBRARY_TOKEN") or os.getenv("VITE_FACEBOOK_ACCESS_TOKEN")
         self.db = db
 
-    async def search_ads(self, query: str, limit: int = 10, country: str = "US", offset: int = 0, exclude_ids: List[str] = None, negative_keywords: List[str] = None):
+    async def search_ads(self, query: str, limit: int = 10, country: str = "US", language: str = "", offset: int = 0, exclude_ids: List[str] = None, negative_keywords: List[str] = None):
         """
         Search Facebook Ads Library using API or fallback to scraper.
 
@@ -34,6 +34,7 @@ class FacebookAdsLibraryAPI:
             query: Search term (brand name, keyword, etc.)
             limit: Maximum number of ads to return
             country: Country code for ad_reached_countries
+            language: Language filter (e.g. 'en', 'es', 'de', 'fr'). Empty = all.
             offset: Number of "pages" to skip (controls scroll depth)
             exclude_ids: List of ad IDs to exclude (already fetched)
             negative_keywords: List of keywords to filter out from results
@@ -45,12 +46,13 @@ class FacebookAdsLibraryAPI:
             - filtered_by_keyword_blacklist: Count filtered by keywords
             - api_calls_made: Number of API calls
         """
-        print(f"Searching Facebook Ads Library for '{query}' in {country} (offset={offset}, negative_keywords={negative_keywords})")
+        lang_label = f", language={language}" if language else ""
+        print(f"Searching Facebook Ads Library for '{query}' in {country}{lang_label} (offset={offset}, negative_keywords={negative_keywords})")
 
         # Try API first if token available
         if self.access_token:
             try:
-                ads = await self._api_search(query, limit, country, offset, exclude_ids or [], negative_keywords or [])
+                ads = await self._api_search(query, limit, country, language, offset, exclude_ids or [], negative_keywords or [])
 
                 # Fall back to Chromium if:
                 # 1. API returns 0 ads (completely blocked keyword)
@@ -65,14 +67,14 @@ class FacebookAdsLibraryAPI:
                     should_fallback = True
 
                 if should_fallback:
-                    return await self._fallback_search(query, limit, country, offset, exclude_ids or [], negative_keywords or [])
+                    return await self._fallback_search(query, limit, country, language, offset, exclude_ids or [], negative_keywords or [])
 
                 return ads
             except Exception as e:
                 print(f"API search failed: {e}, falling back to scraper")
 
         # Fallback to scraper
-        return await self._fallback_search(query, limit, country, offset, exclude_ids or [], negative_keywords or [])
+        return await self._fallback_search(query, limit, country, language, offset, exclude_ids or [], negative_keywords or [])
 
     def _log_api_usage(self, query: str, api_calls: int, ads_returned: int, ads_saved: int):
         """Log API usage to database"""
@@ -93,7 +95,7 @@ class FacebookAdsLibraryAPI:
         self.db.add(log)
         self.db.commit()
 
-    async def _api_search(self, query: str, limit: int, country: str, offset: int, exclude_ids: List[str], negative_keywords: List[str]) -> List[ScrapedAdCreate]:
+    async def _api_search(self, query: str, limit: int, country: str, language: str, offset: int, exclude_ids: List[str], negative_keywords: List[str]) -> List[ScrapedAdCreate]:
         """Search using official Facebook Ads Library API."""
         ads = []
         negative_keywords_lower = [kw.lower() for kw in negative_keywords]
@@ -137,6 +139,9 @@ class FacebookAdsLibraryAPI:
                     "limit": batch_size,
                     "fields": "id,ad_creative_bodies,ad_creative_link_titles,ad_creative_link_captions,ad_snapshot_url,page_name,impressions,spend,currency,publisher_platforms,ad_delivery_start_time,ad_delivery_stop_time"
                 }
+
+                if language:
+                    params["languages"] = language
 
                 if after_cursor:
                     params["after"] = after_cursor
@@ -274,7 +279,7 @@ class FacebookAdsLibraryAPI:
             media_type=media_type
         )
 
-    async def _fallback_search(self, query: str, limit: int, country: str = "US", offset: int = 0, exclude_ids: List[str] = None, negative_keywords: List[str] = None) -> List[ScrapedAdCreate]:
+    async def _fallback_search(self, query: str, limit: int, country: str = "US", language: str = "", offset: int = 0, exclude_ids: List[str] = None, negative_keywords: List[str] = None) -> List[ScrapedAdCreate]:
         """
         Scrape Facebook Ads Library using Playwright.
         Extracts ad text data from DOM without media.
@@ -311,6 +316,8 @@ class FacebookAdsLibraryAPI:
                     "sort_data[mode]": "relevancy_monthly_grouped",
                     "media_type": "all"
                 }
+                if language:
+                    params["content_languages[0]"] = language
                 url = f"https://www.facebook.com/ads/library/?{urllib.parse.urlencode(params)}"
 
                 print(f"Scraping: {url}")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,10 +5,11 @@ sqlalchemy==2.0.36
 python-dotenv==1.0.0
 httpx==0.25.1
 google-generativeai==0.8.5
+google-genai>=1.0.0
 python-multipart==0.0.6
 facebook-business>=18.0.0
+anthropic>=0.40.0
 psycopg2-binary==2.9.11
-fal-client
 passlib[bcrypt]==1.7.4
 bcrypt==4.2.0
 python-jose[cryptography]==3.3.0

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "facebook_ad_builder",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "facebook_ad_builder",
-      "version": "0.0.0",
+      "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@supabase/supabase-js": "^2.83.0",
@@ -130,7 +131,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -487,7 +487,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -511,7 +510,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1695,6 +1693,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1715,6 +1714,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1728,6 +1728,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -1737,7 +1738,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/dom/node_modules/pretty-format": {
       "version": "27.5.1",
@@ -1745,6 +1747,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -1759,7 +1762,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -1814,7 +1818,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1896,7 +1901,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1907,7 +1911,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2092,7 +2095,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2453,7 +2455,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3044,6 +3045,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3287,7 +3289,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4437,7 +4438,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4468,7 +4468,6 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -4670,6 +4669,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5409,7 +5409,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5765,7 +5764,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5775,7 +5773,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6705,7 +6702,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6967,7 +6963,6 @@
       "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -7574,7 +7569,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7588,7 +7582,6 @@
       "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "1.6.1",
         "@vitest/runner": "1.6.1",
@@ -8391,7 +8384,6 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,7 @@ import AdRemix from './pages/AdRemix';
 import Settings from './pages/Settings';
 import Login from './pages/Login';
 import UserManagement from './pages/UserManagement';
+import AdsLibrary from './pages/AdsLibrary';
 
 function App() {
   return (
@@ -65,6 +66,7 @@ function App() {
                   <Route path="facebook-campaigns" element={<FacebookCampaigns />} />
                   <Route path="winning-ads" element={<WinningAds />} />
                   <Route path="generated-ads" element={<GeneratedAds />} />
+                  <Route path="ads-library" element={<AdsLibrary />} />
                   <Route path="brands" element={<Brands />} />
                   <Route path="products" element={<Products />} />
                   <Route path="profiles" element={<CustomerProfiles />} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -36,6 +36,7 @@ import Login from './pages/Login';
 import UserManagement from './pages/UserManagement';
 import AdsLibrary from './pages/AdsLibrary';
 import Headlines from './pages/Headlines';
+import PromptsAndDocs from './pages/PromptsAndDocs';
 
 function App() {
   return (
@@ -69,6 +70,7 @@ function App() {
                   <Route path="generated-ads" element={<GeneratedAds />} />
                   <Route path="ads-library" element={<AdsLibrary />} />
                   <Route path="headlines" element={<Headlines />} />
+                  <Route path="prompts" element={<PromptsAndDocs />} />
                   <Route path="brands" element={<Brands />} />
                   <Route path="products" element={<Products />} />
                   <Route path="profiles" element={<CustomerProfiles />} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -35,6 +35,7 @@ import Settings from './pages/Settings';
 import Login from './pages/Login';
 import UserManagement from './pages/UserManagement';
 import AdsLibrary from './pages/AdsLibrary';
+import Headlines from './pages/Headlines';
 
 function App() {
   return (
@@ -67,6 +68,7 @@ function App() {
                   <Route path="winning-ads" element={<WinningAds />} />
                   <Route path="generated-ads" element={<GeneratedAds />} />
                   <Route path="ads-library" element={<AdsLibrary />} />
+                  <Route path="headlines" element={<Headlines />} />
                   <Route path="brands" element={<Brands />} />
                   <Route path="products" element={<Products />} />
                   <Route path="profiles" element={<CustomerProfiles />} />

--- a/frontend/src/api/adsLibrary.js
+++ b/frontend/src/api/adsLibrary.js
@@ -1,0 +1,36 @@
+import axios from 'axios';
+
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000/api/v1';
+const API_URL = `${API_BASE}/ads-library`;
+
+export const getLibraryItems = async (filters = {}) => {
+    const response = await axios.get(API_URL, { params: filters });
+    return response.data;
+};
+
+export const getLibraryStats = async () => {
+    const response = await axios.get(`${API_URL}/stats`);
+    return response.data;
+};
+
+export const createLibraryItem = async (item) => {
+    const response = await axios.post(API_URL, item);
+    return response.data;
+};
+
+export const updateLibraryItem = async (itemId, item) => {
+    const response = await axios.put(`${API_URL}/${itemId}`, item);
+    return response.data;
+};
+
+export const deleteLibraryItem = async (itemId) => {
+    const response = await axios.delete(`${API_URL}/${itemId}`);
+    return response.data;
+};
+
+export const uploadFile = async (file) => {
+    const formData = new FormData();
+    formData.append('file', file);
+    const response = await axios.post(`${API_BASE}/uploads/`, formData);
+    return response.data;
+};

--- a/frontend/src/api/adsLibrary.js
+++ b/frontend/src/api/adsLibrary.js
@@ -3,34 +3,39 @@ import axios from 'axios';
 const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000/api/v1';
 const API_URL = `${API_BASE}/ads-library`;
 
+const authHeaders = () => {
+    const token = localStorage.getItem('accessToken');
+    return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
 export const getLibraryItems = async (filters = {}) => {
-    const response = await axios.get(API_URL, { params: filters });
+    const response = await axios.get(API_URL, { params: filters, headers: authHeaders() });
     return response.data;
 };
 
 export const getLibraryStats = async () => {
-    const response = await axios.get(`${API_URL}/stats`);
+    const response = await axios.get(`${API_URL}/stats`, { headers: authHeaders() });
     return response.data;
 };
 
 export const createLibraryItem = async (item) => {
-    const response = await axios.post(API_URL, item);
+    const response = await axios.post(API_URL, item, { headers: authHeaders() });
     return response.data;
 };
 
 export const updateLibraryItem = async (itemId, item) => {
-    const response = await axios.put(`${API_URL}/${itemId}`, item);
+    const response = await axios.put(`${API_URL}/${itemId}`, item, { headers: authHeaders() });
     return response.data;
 };
 
 export const deleteLibraryItem = async (itemId) => {
-    const response = await axios.delete(`${API_URL}/${itemId}`);
+    const response = await axios.delete(`${API_URL}/${itemId}`, { headers: authHeaders() });
     return response.data;
 };
 
 export const uploadFile = async (file) => {
     const formData = new FormData();
     formData.append('file', file);
-    const response = await axios.post(`${API_BASE}/uploads/`, formData);
+    const response = await axios.post(`${API_BASE}/uploads/`, formData, { headers: authHeaders() });
     return response.data;
 };

--- a/frontend/src/api/adsLibrary.js
+++ b/frontend/src/api/adsLibrary.js
@@ -13,8 +13,35 @@ export const getLibraryItems = async (filters = {}) => {
     return response.data;
 };
 
-export const getLibraryStats = async () => {
-    const response = await axios.get(`${API_URL}/stats`, { headers: authHeaders() });
+export const getLibraryStats = async (filters = {}) => {
+    const response = await axios.get(`${API_URL}/stats`, { params: filters, headers: authHeaders() });
+    return response.data;
+};
+
+// --- Folder API ---
+
+export const getFolders = async (filters = {}) => {
+    const response = await axios.get(`${API_URL}/folders`, { params: filters, headers: authHeaders() });
+    return response.data;
+};
+
+export const createFolder = async (folder) => {
+    const response = await axios.post(`${API_URL}/folders`, folder, { headers: authHeaders() });
+    return response.data;
+};
+
+export const updateFolder = async (folderId, data) => {
+    const response = await axios.put(`${API_URL}/folders/${folderId}`, data, { headers: authHeaders() });
+    return response.data;
+};
+
+export const deleteFolder = async (folderId) => {
+    const response = await axios.delete(`${API_URL}/folders/${folderId}`, { headers: authHeaders() });
+    return response.data;
+};
+
+export const moveItemsToFolder = async (folderId, itemIds) => {
+    const response = await axios.post(`${API_URL}/folders/${folderId}/move-items`, { item_ids: itemIds }, { headers: authHeaders() });
     return response.data;
 };
 

--- a/frontend/src/api/adsLibrary.js
+++ b/frontend/src/api/adsLibrary.js
@@ -60,10 +60,15 @@ export const deleteLibraryItem = async (itemId) => {
     return response.data;
 };
 
-export const uploadFile = async (file) => {
+export const uploadFile = async (file, onProgress) => {
     const formData = new FormData();
     formData.append('file', file);
-    const response = await axios.post(`${API_BASE}/uploads/`, formData, { headers: authHeaders() });
+    const response = await axios.post(`${API_BASE}/uploads/`, formData, {
+        headers: authHeaders(),
+        onUploadProgress: onProgress
+            ? (e) => onProgress(Math.round((e.loaded * 100) / (e.total || e.loaded)))
+            : undefined,
+    });
     return response.data;
 };
 

--- a/frontend/src/api/adsLibrary.js
+++ b/frontend/src/api/adsLibrary.js
@@ -39,3 +39,82 @@ export const uploadFile = async (file) => {
     const response = await axios.post(`${API_BASE}/uploads/`, formData, { headers: authHeaders() });
     return response.data;
 };
+
+export const getAiName = async (imageUrl) => {
+    const response = await axios.post(`${API_URL}/ai-name`, { image_url: imageUrl }, { headers: authHeaders() });
+    return response.data;
+};
+
+/**
+ * Extract a thumbnail frame from a video file using HTML5 canvas.
+ * Returns a Blob of the thumbnail image.
+ */
+export const extractVideoThumbnail = (videoFile) => {
+    return new Promise((resolve, reject) => {
+        const video = document.createElement('video');
+        video.preload = 'metadata';
+        video.muted = true;
+        video.playsInline = true;
+
+        const url = URL.createObjectURL(videoFile);
+        video.src = url;
+
+        video.onloadeddata = () => {
+            // Seek to 1 second or 10% of duration, whichever is less
+            video.currentTime = Math.min(1, video.duration * 0.1);
+        };
+
+        video.onseeked = () => {
+            const canvas = document.createElement('canvas');
+            canvas.width = video.videoWidth;
+            canvas.height = video.videoHeight;
+            const ctx = canvas.getContext('2d');
+            ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+            canvas.toBlob((blob) => {
+                URL.revokeObjectURL(url);
+                video.remove();
+                if (blob) {
+                    resolve(blob);
+                } else {
+                    reject(new Error('Failed to create thumbnail blob'));
+                }
+            }, 'image/jpeg', 0.85);
+        };
+
+        video.onerror = () => {
+            URL.revokeObjectURL(url);
+            video.remove();
+            reject(new Error('Failed to load video'));
+        };
+    });
+};
+
+/**
+ * Detect aspect ratio from an image file.
+ * Returns "1:1", "9:16", "16:9", "4:5", or the raw ratio string.
+ */
+export const detectAspectRatio = (imageFile) => {
+    return new Promise((resolve) => {
+        const img = new window.Image();
+        const url = URL.createObjectURL(imageFile);
+        img.onload = () => {
+            const w = img.naturalWidth;
+            const h = img.naturalHeight;
+            URL.revokeObjectURL(url);
+
+            const ratio = w / h;
+            // Match common FB ad ratios with some tolerance
+            if (Math.abs(ratio - 1) < 0.08) resolve('1:1');
+            else if (Math.abs(ratio - 9 / 16) < 0.08) resolve('9:16');
+            else if (Math.abs(ratio - 16 / 9) < 0.08) resolve('16:9');
+            else if (Math.abs(ratio - 4 / 5) < 0.08) resolve('4:5');
+            else if (Math.abs(ratio - 4 / 3) < 0.08) resolve('4:3');
+            else resolve(`${w}:${h}`);
+        };
+        img.onerror = () => {
+            URL.revokeObjectURL(url);
+            resolve('unknown');
+        };
+        img.src = url;
+    });
+};

--- a/frontend/src/api/adsLibrary.js
+++ b/frontend/src/api/adsLibrary.js
@@ -40,6 +40,11 @@ export const uploadFile = async (file) => {
     return response.data;
 };
 
+export const getVideoThumbnail = async (videoUrl) => {
+    const response = await axios.post(`${API_URL}/video-thumbnail`, { video_url: videoUrl }, { headers: authHeaders() });
+    return response.data;
+};
+
 export const getAiName = async (imageUrl) => {
     const response = await axios.post(`${API_URL}/ai-name`, { image_url: imageUrl }, { headers: authHeaders() });
     return response.data;

--- a/frontend/src/api/adsLibrary.js
+++ b/frontend/src/api/adsLibrary.js
@@ -52,40 +52,85 @@ export const getAiName = async (imageUrl) => {
 export const extractVideoThumbnail = (videoFile) => {
     return new Promise((resolve, reject) => {
         const video = document.createElement('video');
-        video.preload = 'metadata';
+        video.preload = 'auto';
         video.muted = true;
         video.playsInline = true;
+        video.crossOrigin = 'anonymous';
 
         const url = URL.createObjectURL(videoFile);
-        video.src = url;
+        let resolved = false;
 
-        video.onloadeddata = () => {
-            // Seek to 1 second or 10% of duration, whichever is less
-            video.currentTime = Math.min(1, video.duration * 0.1);
-        };
+        // Timeout after 15 seconds
+        const timeout = setTimeout(() => {
+            if (!resolved) {
+                resolved = true;
+                cleanup();
+                reject(new Error('Thumbnail extraction timed out'));
+            }
+        }, 15000);
 
-        video.onseeked = () => {
-            const canvas = document.createElement('canvas');
-            canvas.width = video.videoWidth;
-            canvas.height = video.videoHeight;
-            const ctx = canvas.getContext('2d');
-            ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
-            canvas.toBlob((blob) => {
-                URL.revokeObjectURL(url);
-                video.remove();
-                if (blob) {
-                    resolve(blob);
-                } else {
-                    reject(new Error('Failed to create thumbnail blob'));
-                }
-            }, 'image/jpeg', 0.85);
-        };
-
-        video.onerror = () => {
+        const cleanup = () => {
+            clearTimeout(timeout);
             URL.revokeObjectURL(url);
-            video.remove();
-            reject(new Error('Failed to load video'));
+            video.pause();
+            video.removeAttribute('src');
+            video.load();
         };
+
+        const captureFrame = () => {
+            if (resolved) return;
+            try {
+                const w = video.videoWidth || 640;
+                const h = video.videoHeight || 360;
+                const canvas = document.createElement('canvas');
+                canvas.width = w;
+                canvas.height = h;
+                const ctx = canvas.getContext('2d');
+                ctx.drawImage(video, 0, 0, w, h);
+                canvas.toBlob((blob) => {
+                    if (resolved) return;
+                    resolved = true;
+                    cleanup();
+                    if (blob && blob.size > 1000) {
+                        resolve(blob);
+                    } else {
+                        reject(new Error('Captured frame is blank'));
+                    }
+                }, 'image/jpeg', 0.85);
+            } catch (e) {
+                if (!resolved) {
+                    resolved = true;
+                    cleanup();
+                    reject(e);
+                }
+            }
+        };
+
+        video.onloadedmetadata = () => {
+            // Seek to 1 second or 10% of duration
+            const seekTo = Math.min(1, (video.duration || 5) * 0.1);
+            video.currentTime = seekTo;
+        };
+
+        video.onseeked = captureFrame;
+
+        // Fallback: if seeked never fires, try capturing on canplay
+        video.oncanplay = () => {
+            if (!resolved && video.currentTime === 0) {
+                // Seek didn't work, try capturing at 0
+                setTimeout(captureFrame, 500);
+            }
+        };
+
+        video.onerror = (e) => {
+            if (!resolved) {
+                resolved = true;
+                cleanup();
+                reject(new Error(`Video load error: ${e?.message || 'unknown'}`));
+            }
+        };
+
+        video.src = url;
     });
 };
 

--- a/frontend/src/api/clickflare.js
+++ b/frontend/src/api/clickflare.js
@@ -1,0 +1,63 @@
+import axios from 'axios';
+
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000/api/v1';
+const API_URL = `${API_BASE}/clickflare`;
+
+const authHeaders = () => {
+    const token = localStorage.getItem('accessToken');
+    return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
+// --- Status ---
+
+export const getClickflareStatus = async () => {
+    const response = await axios.get(`${API_URL}/status`, { headers: authHeaders() });
+    return response.data;
+};
+
+// --- Config ---
+
+export const getClickflareConfig = async () => {
+    const response = await axios.get(`${API_URL}/config`, { headers: authHeaders() });
+    return response.data;
+};
+
+export const saveClickflareConfig = async (data) => {
+    const response = await axios.post(`${API_URL}/config`, data, { headers: authHeaders() });
+    return response.data;
+};
+
+export const testClickflareConnection = async () => {
+    const response = await axios.post(`${API_URL}/test-connection`, {}, { headers: authHeaders() });
+    return response.data;
+};
+
+export const setupTrafficSource = async () => {
+    const response = await axios.post(`${API_URL}/setup-traffic-source`, {}, { headers: authHeaders() });
+    return response.data;
+};
+
+// --- Tracking URL ---
+
+export const generateTrackingUrl = async (adName, destinationUrl, facebookAdId = null) => {
+    const response = await axios.post(`${API_URL}/generate-tracking-url`, {
+        ad_name: adName,
+        destination_url: destinationUrl,
+        facebook_ad_id: facebookAdId,
+    }, { headers: authHeaders() });
+    return response.data;
+};
+
+// --- Reporting ---
+
+export const getClickflareReports = async (dateFrom, dateTo, groupBy = 'campaign', campaignId = null) => {
+    const params = { date_from: dateFrom, date_to: dateTo, group_by: groupBy };
+    if (campaignId) params.campaign_id = campaignId;
+    const response = await axios.get(`${API_URL}/reports`, { params, headers: authHeaders() });
+    return response.data;
+};
+
+export const getClickflareCampaigns = async () => {
+    const response = await axios.get(`${API_URL}/campaigns`, { headers: authHeaders() });
+    return response.data;
+};

--- a/frontend/src/api/higgsfield.js
+++ b/frontend/src/api/higgsfield.js
@@ -3,13 +3,18 @@ import axios from 'axios';
 const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000/api/v1';
 const API_URL = `${API_BASE}/higgsfield`;
 
+const authHeaders = () => {
+    const token = localStorage.getItem('accessToken');
+    return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
 export const getHiggsfieldStatus = async () => {
-    const response = await axios.get(`${API_URL}/status`);
+    const response = await axios.get(`${API_URL}/status`, { headers: authHeaders() });
     return response.data;
 };
 
 export const getMotions = async () => {
-    const response = await axios.get(`${API_URL}/motions`);
+    const response = await axios.get(`${API_URL}/motions`, { headers: authHeaders() });
     return response.data;
 };
 
@@ -20,11 +25,11 @@ export const generateVideo = async ({ image_url, motion_id, prompt, model, stren
         prompt,
         model: model || 'dop-lite',
         strength: strength || 0.5,
-    });
+    }, { headers: authHeaders() });
     return response.data;
 };
 
 export const getJobStatus = async (jobId) => {
-    const response = await axios.get(`${API_URL}/jobs/${jobId}`);
+    const response = await axios.get(`${API_URL}/jobs/${jobId}`, { headers: authHeaders() });
     return response.data;
 };

--- a/frontend/src/api/higgsfield.js
+++ b/frontend/src/api/higgsfield.js
@@ -1,0 +1,30 @@
+import axios from 'axios';
+
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000/api/v1';
+const API_URL = `${API_BASE}/higgsfield`;
+
+export const getHiggsfieldStatus = async () => {
+    const response = await axios.get(`${API_URL}/status`);
+    return response.data;
+};
+
+export const getMotions = async () => {
+    const response = await axios.get(`${API_URL}/motions`);
+    return response.data;
+};
+
+export const generateVideo = async ({ image_url, motion_id, prompt, model, strength }) => {
+    const response = await axios.post(`${API_URL}/generate-video`, {
+        image_url,
+        motion_id,
+        prompt,
+        model: model || 'dop-lite',
+        strength: strength || 0.5,
+    });
+    return response.data;
+};
+
+export const getJobStatus = async (jobId) => {
+    const response = await axios.get(`${API_URL}/jobs/${jobId}`);
+    return response.data;
+};

--- a/frontend/src/api/research.js
+++ b/frontend/src/api/research.js
@@ -215,6 +215,26 @@ export const getBrandScrape = async (scrapeId) => {
     }
 };
 
+export const updateBrandScrape = async (scrapeId, data) => {
+    try {
+        const response = await axios.patch(`${API_URL}/brand-scrapes/${scrapeId}`, data);
+        return response.data;
+    } catch (error) {
+        console.error('Error updating brand scrape:', error);
+        throw error;
+    }
+};
+
+export const refreshBrandScrape = async (scrapeId) => {
+    try {
+        const response = await axios.post(`${API_URL}/brand-scrapes/${scrapeId}/refresh`);
+        return response.data;
+    } catch (error) {
+        console.error('Error refreshing brand scrape:', error);
+        throw error;
+    }
+};
+
 export const deleteBrandScrape = async (scrapeId) => {
     try {
         const response = await axios.delete(`${API_URL}/brand-scrapes/${scrapeId}`);

--- a/frontend/src/components/AdAccountStep.jsx
+++ b/frontend/src/components/AdAccountStep.jsx
@@ -195,6 +195,32 @@ const AdAccountStep = ({ onNext }) => {
                             </div>
                         </div>
 
+                        {/* Balance */}
+                        {selectedAdAccount.balance && (
+                            <div className="flex items-start gap-3">
+                                <CreditCard className="text-gray-400 mt-0.5" size={18} />
+                                <div>
+                                    <div className="text-xs text-gray-500 font-medium">Balance</div>
+                                    <div className="text-sm font-semibold text-gray-900">
+                                        {formatCurrency(selectedAdAccount.balance, selectedAdAccount.currency) || '$0.00'}
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+
+                        {/* Total Spent */}
+                        {selectedAdAccount.amountSpent && (
+                            <div className="flex items-start gap-3">
+                                <TrendingUp className="text-gray-400 mt-0.5" size={18} />
+                                <div>
+                                    <div className="text-xs text-gray-500 font-medium">Total Spent</div>
+                                    <div className="text-sm font-semibold text-gray-900">
+                                        {formatCurrency(selectedAdAccount.amountSpent, selectedAdAccount.currency) || '$0.00'}
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+
                         {/* Business Name - only if exists */}
                         {selectedAdAccount.businessName && (
                             <div className="col-span-2 flex items-start gap-3">

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -602,26 +602,45 @@ const AdCreativeStep = ({ onNext, onBack }) => {
             const newBodies = (data.bodies || []).filter(b => b && b.trim());
             const newHeadlines = (data.headlines || []).filter(h => h && h.trim());
 
-            setCreativeData(prev => {
-                // Keep existing non-empty entries, append new ones, cap at 6
-                const existingBodies = prev.bodies.filter(b => b && b.trim());
-                const existingHeadlines = prev.headlines.filter(h => h && h.trim());
-                const mergedBodies = [...existingBodies, ...newBodies].slice(0, 6);
-                const mergedHeadlines = [...existingHeadlines, ...newHeadlines].slice(0, 6);
-                // Ensure at least 1 slot
-                if (mergedBodies.length === 0) mergedBodies.push('');
-                if (mergedHeadlines.length === 0) mergedHeadlines.push('');
-                return { ...prev, bodies: mergedBodies, headlines: mergedHeadlines };
-            });
+            if (isPerCreative) {
+                // In per-creative mode, put copy on the specific creative
+                const idx = creativeData.creatives.findIndex(c => c.id === creative.id);
+                if (idx !== -1) {
+                    setCreativeData(prev => {
+                        const updated = [...prev.creatives];
+                        const existing = updated[idx];
+                        const existingBodies = (existing.bodies || []).filter(b => b && b.trim());
+                        const existingHeadlines = (existing.headlines || []).filter(h => h && h.trim());
+                        updated[idx] = {
+                            ...existing,
+                            bodies: [...existingBodies, ...newBodies].slice(0, 6),
+                            headlines: [...existingHeadlines, ...newHeadlines].slice(0, 6),
+                        };
+                        if (updated[idx].bodies.length === 0) updated[idx].bodies = [''];
+                        if (updated[idx].headlines.length === 0) updated[idx].headlines = [''];
+                        return { ...prev, creatives: updated };
+                    });
+                    setCurrentCreativeIndex(idx);
+                }
+            } else {
+                setCreativeData(prev => {
+                    const existingBodies = prev.bodies.filter(b => b && b.trim());
+                    const existingHeadlines = prev.headlines.filter(h => h && h.trim());
+                    const mergedBodies = [...existingBodies, ...newBodies].slice(0, 6);
+                    const mergedHeadlines = [...existingHeadlines, ...newHeadlines].slice(0, 6);
+                    if (mergedBodies.length === 0) mergedBodies.push('');
+                    if (mergedHeadlines.length === 0) mergedHeadlines.push('');
+                    return { ...prev, bodies: mergedBodies, headlines: mergedHeadlines };
+                });
 
-            // Persist merged results to localStorage
-            if (selectedAdAccount) {
-                const existingBodies = creativeData.bodies.filter(b => b && b.trim());
-                const existingHeadlines = creativeData.headlines.filter(h => h && h.trim());
-                const allBodies = [...existingBodies, ...newBodies].slice(0, 6);
-                const allHeadlines = [...existingHeadlines, ...newHeadlines].slice(0, 6);
-                localStorage.setItem(`defaultBodies_${selectedAdAccount.id}`, JSON.stringify(allBodies));
-                localStorage.setItem(`defaultHeadlines_${selectedAdAccount.id}`, JSON.stringify(allHeadlines));
+                if (selectedAdAccount) {
+                    const existingBodies = creativeData.bodies.filter(b => b && b.trim());
+                    const existingHeadlines = creativeData.headlines.filter(h => h && h.trim());
+                    const allBodies = [...existingBodies, ...newBodies].slice(0, 6);
+                    const allHeadlines = [...existingHeadlines, ...newHeadlines].slice(0, 6);
+                    localStorage.setItem(`defaultBodies_${selectedAdAccount.id}`, JSON.stringify(allBodies));
+                    localStorage.setItem(`defaultHeadlines_${selectedAdAccount.id}`, JSON.stringify(allHeadlines));
+                }
             }
 
             const providerName = provider === 'transcribe_haiku' ? 'Transcribe + Haiku' : provider === 'claude' ? 'Claude Haiku' : 'Gemini';

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -959,7 +959,8 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                     {creativeData.creatives && creativeData.creatives.length > 0 && (
                         <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-4">
                             {creativeData.creatives.map((creative) => (
-                                <div key={creative.id} className="relative group border rounded-lg overflow-hidden aspect-square bg-gray-100">
+                                <div key={creative.id} className="relative group border rounded-lg aspect-square bg-gray-100 overflow-visible">
+                                  <div className="absolute inset-0 overflow-hidden rounded-lg">
                                     {creative.mediaType === 'video' ? (
                                         creative.thumbnailUrl ? (
                                             <img
@@ -985,6 +986,7 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                                             className="w-full h-full object-cover"
                                         />
                                     )}
+                                  </div>
                                     {/* Media type badge */}
                                     <div className="absolute top-2 left-2">
                                         {creative.mediaType === 'video' ? (
@@ -1009,7 +1011,7 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                                                 <Sparkles size={16} />
                                             </button>
                                             {providerMenuId === creative.id && (
-                                                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 bg-white rounded-lg shadow-xl border border-gray-200 py-1 w-52 z-50">
+                                                <div className="absolute top-full left-1/2 -translate-x-1/2 mt-2 bg-white rounded-lg shadow-xl border border-gray-200 py-1 w-52 z-50">
                                                     {creative.mediaType === 'video' ? (
                                                         <>
                                                             <button

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -1,6 +1,6 @@
 import { useToast } from '../context/ToastContext';
 import React, { useState, useEffect } from 'react';
-import { ChevronRight, Upload, X, Loader, Trash2, Film, Image, Sparkles, Play, FolderOpen, Check } from 'lucide-react';
+import { ChevronRight, ChevronLeft, Upload, X, Loader, Trash2, Film, Image, Sparkles, Play, FolderOpen, Check } from 'lucide-react';
 import { useCampaign } from '../context/CampaignContext';
 import { useAuth } from '../context/AuthContext';
 import { getPages } from '../lib/facebookApi';
@@ -38,6 +38,9 @@ const AdCreativeStep = ({ onNext, onBack }) => {
     const [manualPageEntry, setManualPageEntry] = useState(false);
     const [isDragging, setIsDragging] = useState(false);
     const [playingVideo, setPlayingVideo] = useState(null);
+
+    // Per-creative mode
+    const [currentCreativeIndex, setCurrentCreativeIndex] = useState(0);
 
     // Ads Library import
     const { brands } = useBrands();
@@ -394,6 +397,75 @@ const AdCreativeStep = ({ onNext, onBack }) => {
         }
     };
 
+    // Per-creative mode helpers
+    const isPerCreative = creativeData.creativeMode === 'per_creative';
+    const currentCreative = creativeData.creatives?.[currentCreativeIndex];
+
+    const updateCreativeField = (creativeIndex, field, value) => {
+        setCreativeData(prev => {
+            const newCreatives = [...prev.creatives];
+            newCreatives[creativeIndex] = { ...newCreatives[creativeIndex], [field]: value };
+            return { ...prev, creatives: newCreatives };
+        });
+    };
+
+    const handlePerCreativeBodyChange = (bodyIndex, value) => {
+        const bodies = [...(currentCreative?.bodies || [''])];
+        bodies[bodyIndex] = value;
+        updateCreativeField(currentCreativeIndex, 'bodies', bodies);
+    };
+
+    const handlePerCreativeHeadlineChange = (headlineIndex, value) => {
+        const headlines = [...(currentCreative?.headlines || [''])];
+        headlines[headlineIndex] = value;
+        updateCreativeField(currentCreativeIndex, 'headlines', headlines);
+    };
+
+    const addPerCreativeBody = () => {
+        const bodies = currentCreative?.bodies || [''];
+        if (bodies.length < 6) {
+            updateCreativeField(currentCreativeIndex, 'bodies', [...bodies, '']);
+        }
+    };
+
+    const addPerCreativeHeadline = () => {
+        const headlines = currentCreative?.headlines || [''];
+        if (headlines.length < 6) {
+            updateCreativeField(currentCreativeIndex, 'headlines', [...headlines, '']);
+        }
+    };
+
+    const removePerCreativeBody = (index) => {
+        const bodies = currentCreative?.bodies || [''];
+        if (bodies.length > 1) {
+            updateCreativeField(currentCreativeIndex, 'bodies', bodies.filter((_, i) => i !== index));
+        }
+    };
+
+    const removePerCreativeHeadline = (index) => {
+        const headlines = currentCreative?.headlines || [''];
+        if (headlines.length > 1) {
+            updateCreativeField(currentCreativeIndex, 'headlines', headlines.filter((_, i) => i !== index));
+        }
+    };
+
+    // Initialize per-creative fields when switching to per-creative mode
+    React.useEffect(() => {
+        if (isPerCreative && creativeData.creatives.length > 0) {
+            let needsInit = false;
+            const updated = creativeData.creatives.map(c => {
+                if (!c.headlines) {
+                    needsInit = true;
+                    return { ...c, headlines: [''], bodies: [''], description: '', cta: 'LEARN_MORE' };
+                }
+                return c;
+            });
+            if (needsInit) {
+                setCreativeData(prev => ({ ...prev, creatives: updated }));
+            }
+        }
+    }, [isPerCreative, creativeData.creatives.length]);
+
     const handleMediaUpload = (e) => {
         const files = Array.from(e.target.files);
         if (files.length === 0) return;
@@ -494,16 +566,33 @@ const AdCreativeStep = ({ onNext, onBack }) => {
             return;
         }
 
-        // Validate primary text
-        if (!creativeData.bodies[0] || !creativeData.bodies[0].trim()) {
-            showWarning('Please provide primary text');
-            return;
-        }
-
-        // Validate headline
-        if (!creativeData.headlines[0] || !creativeData.headlines[0].trim()) {
-            showWarning('Please provide a headline');
-            return;
+        if (isPerCreative) {
+            // Per-creative mode: each creative must have at least 1 non-empty headline and body
+            for (let i = 0; i < creativeData.creatives.length; i++) {
+                const c = creativeData.creatives[i];
+                const hasBody = (c.bodies || []).some(b => b && b.trim());
+                const hasHeadline = (c.headlines || []).some(h => h && h.trim());
+                if (!hasBody) {
+                    setCurrentCreativeIndex(i);
+                    showWarning(`Creative ${i + 1} ("${c.name}") needs at least one primary text`);
+                    return;
+                }
+                if (!hasHeadline) {
+                    setCurrentCreativeIndex(i);
+                    showWarning(`Creative ${i + 1} ("${c.name}") needs at least one headline`);
+                    return;
+                }
+            }
+        } else {
+            // Standard mode: validate global copy fields
+            if (!creativeData.bodies[0] || !creativeData.bodies[0].trim()) {
+                showWarning('Please provide primary text');
+                return;
+            }
+            if (!creativeData.headlines[0] || !creativeData.headlines[0].trim()) {
+                showWarning('Please provide a headline');
+                return;
+            }
         }
 
         if (!creativeData.websiteUrl) {
@@ -538,9 +627,36 @@ const AdCreativeStep = ({ onNext, onBack }) => {
 
     return (
         <div>
-            <h2 className="text-2xl font-bold mb-6">Ad Creative - Standard Ads</h2>
+            <h2 className="text-2xl font-bold mb-4">Ad Creative</h2>
+
+            {/* Mode Toggle */}
+            <div className="flex items-center gap-1 bg-gray-100 p-1 rounded-lg mb-6 w-fit">
+                <button
+                    onClick={() => setCreativeData(prev => ({ ...prev, creativeMode: 'standard' }))}
+                    className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                        !isPerCreative
+                            ? 'bg-white text-gray-900 shadow-sm'
+                            : 'text-gray-500 hover:text-gray-700'
+                    }`}
+                >
+                    Standard (Bulk)
+                </button>
+                <button
+                    onClick={() => setCreativeData(prev => ({ ...prev, creativeMode: 'per_creative' }))}
+                    className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${
+                        isPerCreative
+                            ? 'bg-white text-gray-900 shadow-sm'
+                            : 'text-gray-500 hover:text-gray-700'
+                    }`}
+                >
+                    Per Creative
+                </button>
+            </div>
+
             <p className="text-gray-600 mb-6">
-                Create standard ads with a single primary text and headline. We will create one ad for each image you upload.
+                {isPerCreative
+                    ? 'Each image/video gets its own dedicated copy. Step through creatives one at a time.'
+                    : 'Create standard ads with shared copy across all media. We will create permutations of each image × headline × body.'}
             </p>
 
             <div className="space-y-6">
@@ -857,158 +973,363 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                     </div>
                 </div>
 
-                {/* Body Text */}
-                <div>
-                    <div className="flex items-center justify-between mb-2">
-                        <label className="block text-sm font-medium text-gray-700">
-                            Primary Text *
-                        </label>
-                        {creativeData.bodies.length < 6 && (
-                            <button
-                                type="button"
-                                onClick={addBodyField}
-                                className="text-sm text-amber-600 hover:text-amber-700 font-medium flex items-center gap-1"
-                            >
-                                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                                </svg>
-                                Add Body Copy
-                            </button>
-                        )}
-                    </div>
-                    <div className="space-y-3">
-                        {creativeData.bodies.map((body, index) => (
-                            <div key={index} className="relative">
-                                <textarea
-                                    value={body}
-                                    onChange={(e) => handleBodyChange(index, e.target.value)}
-                                    placeholder={`Body copy ${index + 1}...`}
-                                    rows="3"
-                                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
-                                />
-                                {index >= 1 && (
-                                    <button
-                                        type="button"
-                                        onClick={() => removeBodyField(index)}
-                                        className="absolute top-2 right-2 text-red-500 hover:text-red-700"
-                                        title="Remove this body copy"
-                                    >
-                                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                                        </svg>
-                                    </button>
-                                )}
+                {/* Copy Fields - Standard or Per Creative */}
+                {isPerCreative ? (
+                    /* ===== PER CREATIVE MODE ===== */
+                    creativeData.creatives.length > 0 ? (
+                        <div className="border border-gray-200 rounded-xl overflow-hidden">
+                            {/* Creative Navigation Header */}
+                            <div className="bg-gray-50 px-6 py-4 flex items-center justify-between border-b border-gray-200">
+                                <button
+                                    onClick={() => setCurrentCreativeIndex(Math.max(0, currentCreativeIndex - 1))}
+                                    disabled={currentCreativeIndex === 0}
+                                    className="flex items-center gap-1 px-3 py-1.5 text-sm font-medium rounded-lg disabled:opacity-30 disabled:cursor-not-allowed text-gray-700 hover:bg-gray-200 transition-colors"
+                                >
+                                    <ChevronLeft size={16} /> Previous
+                                </button>
+                                <span className="text-sm font-semibold text-gray-800">
+                                    Creative {currentCreativeIndex + 1} of {creativeData.creatives.length}
+                                </span>
+                                <button
+                                    onClick={() => setCurrentCreativeIndex(Math.min(creativeData.creatives.length - 1, currentCreativeIndex + 1))}
+                                    disabled={currentCreativeIndex === creativeData.creatives.length - 1}
+                                    className="flex items-center gap-1 px-3 py-1.5 text-sm font-medium rounded-lg disabled:opacity-30 disabled:cursor-not-allowed text-gray-700 hover:bg-gray-200 transition-colors"
+                                >
+                                    Next <ChevronRight size={16} />
+                                </button>
                             </div>
-                        ))}
-                    </div>
-                </div>
 
-                {/* Headline */}
-                <div>
-                    <div className="flex items-center justify-between mb-2">
-                        <label className="block text-sm font-medium text-gray-700">
-                            Headline *
-                        </label>
-                        {creativeData.headlines.length < 6 && (
-                            <button
-                                type="button"
-                                onClick={addHeadlineField}
-                                className="text-sm text-amber-600 hover:text-amber-700 font-medium flex items-center gap-1"
-                            >
-                                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-                                </svg>
-                                Add Headline
-                            </button>
-                        )}
-                    </div>
-                    <div className="space-y-3">
-                        {creativeData.headlines.map((headline, index) => (
-                            <div key={index} className="relative">
-                                <input
-                                    type="text"
-                                    value={headline}
-                                    onChange={(e) => handleHeadlineChange(index, e.target.value)}
-                                    placeholder={`Headline ${index + 1}...`}
-                                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
-                                />
-                                {index >= 1 && (
-                                    <button
-                                        type="button"
-                                        onClick={() => removeHeadlineField(index)}
-                                        className="absolute top-2 right-2 text-red-500 hover:text-red-700"
-                                        title="Remove this headline"
-                                    >
-                                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                                        </svg>
-                                    </button>
-                                )}
-                            </div>
-                        ))}
-                    </div>
-                </div>
-
-                {/* Description */}
-                <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                        Description
-                    </label>
-                    <input
-                        type="text"
-                        value={creativeData.description}
-                        onChange={(e) => handleInputChange('description', e.target.value)}
-                        placeholder="Shop now and save!"
-                        className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
-                    />
-                </div>
-
-                {/* Ad Permutation Counter */}
-                {creativeData.creatives && creativeData.creatives.length > 0 && (
-                    <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
-                        <div className="flex items-center gap-2 text-amber-800">
-                            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                            </svg>
-                            <span className="font-medium">
-                                {(() => {
-                                    const validHeadlines = creativeData.headlines.filter(h => h && h.trim() !== '').length;
-                                    const validBodies = creativeData.bodies.filter(b => b && b.trim() !== '').length;
-                                    const totalAds = creativeData.creatives.length * validHeadlines * validBodies;
-                                    const imageCount = creativeData.creatives.filter(c => c.mediaType !== 'video').length;
-                                    const videoCount = creativeData.creatives.filter(c => c.mediaType === 'video').length;
-                                    const mediaDesc = [];
-                                    if (imageCount > 0) mediaDesc.push(`${imageCount} image${imageCount !== 1 ? 's' : ''}`);
-                                    if (videoCount > 0) mediaDesc.push(`${videoCount} video${videoCount !== 1 ? 's' : ''}`);
+                            {/* Creative dots / tabs */}
+                            <div className="bg-gray-50 px-6 pb-3 flex items-center gap-2 flex-wrap">
+                                {creativeData.creatives.map((c, idx) => {
+                                    const hasBody = (c.bodies || []).some(b => b && b.trim());
+                                    const hasHeadline = (c.headlines || []).some(h => h && h.trim());
+                                    const isComplete = hasBody && hasHeadline;
                                     return (
-                                        <>
-                                            {totalAds} ad{totalAds !== 1 ? 's' : ''} will be created
-                                            <span className="text-sm font-normal ml-2">
-                                                ({mediaDesc.join(' + ')} × {validHeadlines} headline{validHeadlines !== 1 ? 's' : ''} × {validBodies} bod{validBodies !== 1 ? 'ies' : 'y'})
-                                            </span>
-                                        </>
+                                        <button
+                                            key={c.id}
+                                            onClick={() => setCurrentCreativeIndex(idx)}
+                                            className={`w-8 h-8 rounded-full text-xs font-bold transition-all ${
+                                                idx === currentCreativeIndex
+                                                    ? 'bg-amber-600 text-white scale-110 shadow'
+                                                    : isComplete
+                                                        ? 'bg-green-100 text-green-700 border border-green-300'
+                                                        : 'bg-gray-200 text-gray-500 hover:bg-gray-300'
+                                            }`}
+                                            title={c.name}
+                                        >
+                                            {idx + 1}
+                                        </button>
                                     );
-                                })()}
-                            </span>
-                        </div>
-                    </div>
-                )}
+                                })}
+                            </div>
 
-                {/* Call to Action */}
-                <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">
-                        Call to Action *
-                    </label>
-                    <select
-                        value={creativeData.cta}
-                        onChange={(e) => handleInputChange('cta', e.target.value)}
-                        className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
-                    >
-                        {CTA_OPTIONS.map(cta => (
-                            <option key={cta} value={cta}>{cta.replace(/_/g, ' ')}</option>
-                        ))}
-                    </select>
-                </div>
+                            {/* Current Creative Preview + Fields */}
+                            {currentCreative && (
+                                <div className="p-6 space-y-5">
+                                    {/* Thumbnail + Name */}
+                                    <div className="flex items-center gap-4">
+                                        <div className="w-20 h-20 rounded-lg overflow-hidden bg-gray-100 flex-shrink-0">
+                                            {currentCreative.mediaType === 'video' ? (
+                                                currentCreative.thumbnailUrl ? (
+                                                    <img src={currentCreative.thumbnailUrl} alt={currentCreative.name} className="w-full h-full object-cover" />
+                                                ) : (
+                                                    <video src={currentCreative.previewUrl} className="w-full h-full object-cover" muted />
+                                                )
+                                            ) : (
+                                                <img src={currentCreative.previewUrl} alt={currentCreative.name} className="w-full h-full object-cover" />
+                                            )}
+                                        </div>
+                                        <div>
+                                            <p className="font-semibold text-gray-900">{currentCreative.name}</p>
+                                            <span className={`text-xs px-2 py-0.5 rounded ${currentCreative.mediaType === 'video' ? 'bg-purple-100 text-purple-700' : 'bg-blue-100 text-blue-700'}`}>
+                                                {currentCreative.mediaType === 'video' ? 'Video' : 'Image'}
+                                            </span>
+                                        </div>
+                                    </div>
+
+                                    {/* Per-creative Primary Text */}
+                                    <div>
+                                        <div className="flex items-center justify-between mb-2">
+                                            <label className="block text-sm font-medium text-gray-700">Primary Text *</label>
+                                            {(currentCreative.bodies || ['']).length < 6 && (
+                                                <button type="button" onClick={addPerCreativeBody}
+                                                    className="text-sm text-amber-600 hover:text-amber-700 font-medium flex items-center gap-1">
+                                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                                                    </svg>
+                                                    Add Body Copy
+                                                </button>
+                                            )}
+                                        </div>
+                                        <div className="space-y-3">
+                                            {(currentCreative.bodies || ['']).map((body, index) => (
+                                                <div key={index} className="relative">
+                                                    <textarea
+                                                        value={body}
+                                                        onChange={(e) => handlePerCreativeBodyChange(index, e.target.value)}
+                                                        placeholder={`Body copy ${index + 1}...`}
+                                                        rows="3"
+                                                        className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                                                    />
+                                                    {index >= 1 && (
+                                                        <button type="button" onClick={() => removePerCreativeBody(index)}
+                                                            className="absolute top-2 right-2 text-red-500 hover:text-red-700" title="Remove">
+                                                            <X size={16} />
+                                                        </button>
+                                                    )}
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+
+                                    {/* Per-creative Headlines */}
+                                    <div>
+                                        <div className="flex items-center justify-between mb-2">
+                                            <label className="block text-sm font-medium text-gray-700">Headline *</label>
+                                            {(currentCreative.headlines || ['']).length < 6 && (
+                                                <button type="button" onClick={addPerCreativeHeadline}
+                                                    className="text-sm text-amber-600 hover:text-amber-700 font-medium flex items-center gap-1">
+                                                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                                                    </svg>
+                                                    Add Headline
+                                                </button>
+                                            )}
+                                        </div>
+                                        <div className="space-y-3">
+                                            {(currentCreative.headlines || ['']).map((headline, index) => (
+                                                <div key={index} className="relative">
+                                                    <input
+                                                        type="text"
+                                                        value={headline}
+                                                        onChange={(e) => handlePerCreativeHeadlineChange(index, e.target.value)}
+                                                        placeholder={`Headline ${index + 1}...`}
+                                                        className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                                                    />
+                                                    {index >= 1 && (
+                                                        <button type="button" onClick={() => removePerCreativeHeadline(index)}
+                                                            className="absolute top-2 right-2 text-red-500 hover:text-red-700" title="Remove">
+                                                            <X size={16} />
+                                                        </button>
+                                                    )}
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+
+                                    {/* Per-creative Description */}
+                                    <div>
+                                        <label className="block text-sm font-medium text-gray-700 mb-2">Description</label>
+                                        <input
+                                            type="text"
+                                            value={currentCreative.description || ''}
+                                            onChange={(e) => updateCreativeField(currentCreativeIndex, 'description', e.target.value)}
+                                            placeholder="Shop now and save!"
+                                            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                                        />
+                                    </div>
+
+                                    {/* Per-creative CTA */}
+                                    <div>
+                                        <label className="block text-sm font-medium text-gray-700 mb-2">Call to Action *</label>
+                                        <select
+                                            value={currentCreative.cta || creativeData.cta}
+                                            onChange={(e) => updateCreativeField(currentCreativeIndex, 'cta', e.target.value)}
+                                            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                                        >
+                                            {CTA_OPTIONS.map(cta => (
+                                                <option key={cta} value={cta}>{cta.replace(/_/g, ' ')}</option>
+                                            ))}
+                                        </select>
+                                    </div>
+                                </div>
+                            )}
+
+                            {/* Per-creative Ad Counter */}
+                            <div className="px-6 pb-4">
+                                <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+                                    <div className="flex items-center gap-2 text-amber-800">
+                                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                        </svg>
+                                        <span className="font-medium">
+                                            {(() => {
+                                                let totalAds = 0;
+                                                creativeData.creatives.forEach(c => {
+                                                    const h = (c.headlines || []).filter(x => x && x.trim()).length || 1;
+                                                    const b = (c.bodies || []).filter(x => x && x.trim()).length || 1;
+                                                    totalAds += h * b;
+                                                });
+                                                return `${totalAds} ad${totalAds !== 1 ? 's' : ''} will be created (1 per creative × headlines × bodies)`;
+                                            })()}
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    ) : (
+                        <div className="text-center py-8 text-gray-400 border-2 border-dashed border-gray-200 rounded-lg">
+                            Upload media above, then configure copy for each creative here.
+                        </div>
+                    )
+                ) : (
+                    /* ===== STANDARD (BULK) MODE ===== */
+                    <>
+                        {/* Body Text */}
+                        <div>
+                            <div className="flex items-center justify-between mb-2">
+                                <label className="block text-sm font-medium text-gray-700">
+                                    Primary Text *
+                                </label>
+                                {creativeData.bodies.length < 6 && (
+                                    <button
+                                        type="button"
+                                        onClick={addBodyField}
+                                        className="text-sm text-amber-600 hover:text-amber-700 font-medium flex items-center gap-1"
+                                    >
+                                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                                        </svg>
+                                        Add Body Copy
+                                    </button>
+                                )}
+                            </div>
+                            <div className="space-y-3">
+                                {creativeData.bodies.map((body, index) => (
+                                    <div key={index} className="relative">
+                                        <textarea
+                                            value={body}
+                                            onChange={(e) => handleBodyChange(index, e.target.value)}
+                                            placeholder={`Body copy ${index + 1}...`}
+                                            rows="3"
+                                            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                                        />
+                                        {index >= 1 && (
+                                            <button
+                                                type="button"
+                                                onClick={() => removeBodyField(index)}
+                                                className="absolute top-2 right-2 text-red-500 hover:text-red-700"
+                                                title="Remove this body copy"
+                                            >
+                                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                                                </svg>
+                                            </button>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+
+                        {/* Headline */}
+                        <div>
+                            <div className="flex items-center justify-between mb-2">
+                                <label className="block text-sm font-medium text-gray-700">
+                                    Headline *
+                                </label>
+                                {creativeData.headlines.length < 6 && (
+                                    <button
+                                        type="button"
+                                        onClick={addHeadlineField}
+                                        className="text-sm text-amber-600 hover:text-amber-700 font-medium flex items-center gap-1"
+                                    >
+                                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                                        </svg>
+                                        Add Headline
+                                    </button>
+                                )}
+                            </div>
+                            <div className="space-y-3">
+                                {creativeData.headlines.map((headline, index) => (
+                                    <div key={index} className="relative">
+                                        <input
+                                            type="text"
+                                            value={headline}
+                                            onChange={(e) => handleHeadlineChange(index, e.target.value)}
+                                            placeholder={`Headline ${index + 1}...`}
+                                            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                                        />
+                                        {index >= 1 && (
+                                            <button
+                                                type="button"
+                                                onClick={() => removeHeadlineField(index)}
+                                                className="absolute top-2 right-2 text-red-500 hover:text-red-700"
+                                                title="Remove this headline"
+                                            >
+                                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                                                </svg>
+                                            </button>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+
+                        {/* Description */}
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 mb-2">
+                                Description
+                            </label>
+                            <input
+                                type="text"
+                                value={creativeData.description}
+                                onChange={(e) => handleInputChange('description', e.target.value)}
+                                placeholder="Shop now and save!"
+                                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                            />
+                        </div>
+
+                        {/* Ad Permutation Counter */}
+                        {creativeData.creatives && creativeData.creatives.length > 0 && (
+                            <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+                                <div className="flex items-center gap-2 text-amber-800">
+                                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                    </svg>
+                                    <span className="font-medium">
+                                        {(() => {
+                                            const validHeadlines = creativeData.headlines.filter(h => h && h.trim() !== '').length;
+                                            const validBodies = creativeData.bodies.filter(b => b && b.trim() !== '').length;
+                                            const totalAds = creativeData.creatives.length * validHeadlines * validBodies;
+                                            const imageCount = creativeData.creatives.filter(c => c.mediaType !== 'video').length;
+                                            const videoCount = creativeData.creatives.filter(c => c.mediaType === 'video').length;
+                                            const mediaDesc = [];
+                                            if (imageCount > 0) mediaDesc.push(`${imageCount} image${imageCount !== 1 ? 's' : ''}`);
+                                            if (videoCount > 0) mediaDesc.push(`${videoCount} video${videoCount !== 1 ? 's' : ''}`);
+                                            return (
+                                                <>
+                                                    {totalAds} ad{totalAds !== 1 ? 's' : ''} will be created
+                                                    <span className="text-sm font-normal ml-2">
+                                                        ({mediaDesc.join(' + ')} × {validHeadlines} headline{validHeadlines !== 1 ? 's' : ''} × {validBodies} bod{validBodies !== 1 ? 'ies' : 'y'})
+                                                    </span>
+                                                </>
+                                            );
+                                        })()}
+                                    </span>
+                                </div>
+                            </div>
+                        )}
+
+                        {/* Call to Action */}
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 mb-2">
+                                Call to Action *
+                            </label>
+                            <select
+                                value={creativeData.cta}
+                                onChange={(e) => handleInputChange('cta', e.target.value)}
+                                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                            >
+                                {CTA_OPTIONS.map(cta => (
+                                    <option key={cta} value={cta}>{cta.replace(/_/g, ' ')}</option>
+                                ))}
+                            </select>
+                        </div>
+                    </>
+                )}
 
                 {/* Website URL */}
                 <div>

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -631,8 +631,9 @@ const AdCreativeStep = ({ onNext, onBack }) => {
     };
 
     const handleAnalyzeImage = async (creative, provider = 'haiku') => {
-        if (!creative.file) {
-            showWarning('Cannot analyze images added via URL');
+        const imageUrl = creative.imageUrl || creative.previewUrl;
+        if (!creative.file && !imageUrl) {
+            showWarning('No image file or URL available');
             return;
         }
 
@@ -641,7 +642,16 @@ const AdCreativeStep = ({ onNext, onBack }) => {
         setProviderMenuId(null);
         try {
             const formData = new FormData();
-            formData.append('file', creative.file);
+
+            if (creative.file) {
+                formData.append('file', creative.file);
+            } else {
+                // Fetch image from URL and convert to blob
+                const imgResponse = await fetch(imageUrl);
+                const blob = await imgResponse.blob();
+                const ext = imageUrl.split('.').pop()?.split('?')[0] || 'jpg';
+                formData.append('file', blob, `image.${ext}`);
+            }
 
             const response = await authFetch(`${API_URL}/video-analysis/analyze-image?provider=${provider}`, {
                 method: 'POST',

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -100,10 +100,22 @@ const AdCreativeStep = ({ onNext, onBack }) => {
             };
         });
 
-        setCreativeData(prev => ({
-            ...prev,
-            creatives: [...(prev.creatives || []), ...newCreatives]
-        }));
+        setCreativeData(prev => {
+            const updated = {
+                ...prev,
+                creatives: [...(prev.creatives || []), ...newCreatives]
+            };
+            // Auto-fill Creative Name from file name if empty or just the adset name
+            if (!prev.creativeName || prev.creativeName === adsetData?.name) {
+                const baseName = mediaFiles[0].name.replace(/\.[^/.]+$/, '');
+                if (mediaFiles.length === 1) {
+                    updated.creativeName = baseName;
+                } else {
+                    updated.creativeName = `${baseName} (+${mediaFiles.length - 1} more)`;
+                }
+            }
+            return updated;
+        });
     };
 
     // Ads Library import functions
@@ -146,10 +158,22 @@ const AdCreativeStep = ({ onNext, onBack }) => {
             mediaType: item.media_type,
         }));
 
-        setCreativeData(prev => ({
-            ...prev,
-            creatives: [...(prev.creatives || []), ...newCreatives],
-        }));
+        setCreativeData(prev => {
+            const updated = {
+                ...prev,
+                creatives: [...(prev.creatives || []), ...newCreatives],
+            };
+            // Auto-fill Creative Name from library item(s) if empty
+            if (!prev.creativeName || prev.creativeName === adsetData?.name) {
+                if (selected.length === 1) {
+                    updated.creativeName = selected[0].name || '';
+                } else {
+                    // Multiple items: use first name + count
+                    updated.creativeName = `${selected[0].name || 'Library Import'} (+${selected.length - 1} more)`;
+                }
+            }
+            return updated;
+        });
 
         // Pre-fill copy fields from first item if current fields are empty
         const firstWithCopy = selected.find(item => item.headline || item.body);
@@ -481,10 +505,22 @@ const AdCreativeStep = ({ onNext, onBack }) => {
             };
         });
 
-        setCreativeData(prev => ({
-            ...prev,
-            creatives: [...(prev.creatives || []), ...newCreatives]
-        }));
+        setCreativeData(prev => {
+            const updated = {
+                ...prev,
+                creatives: [...(prev.creatives || []), ...newCreatives]
+            };
+            // Auto-fill Creative Name from file name if empty or just the adset name
+            if (!prev.creativeName || prev.creativeName === adsetData?.name) {
+                const baseName = files[0].name.replace(/\.[^/.]+$/, ''); // strip extension
+                if (files.length === 1) {
+                    updated.creativeName = baseName;
+                } else {
+                    updated.creativeName = `${baseName} (+${files.length - 1} more)`;
+                }
+            }
+            return updated;
+        });
     };
 
     const removeCreative = (id) => {

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -1295,7 +1295,7 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                                                         rows="3"
                                                         className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
                                                     />
-                                                    {index >= 1 && (
+                                                    {(currentCreative.bodies || ['']).length > 1 && (
                                                         <button type="button" onClick={() => removePerCreativeBody(index)}
                                                             className="absolute top-2 right-2 text-red-500 hover:text-red-700" title="Remove">
                                                             <X size={16} />
@@ -1330,7 +1330,7 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                                                         placeholder={`Headline ${index + 1}...`}
                                                         className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
                                                     />
-                                                    {index >= 1 && (
+                                                    {(currentCreative.headlines || ['']).length > 1 && (
                                                         <button type="button" onClick={() => removePerCreativeHeadline(index)}
                                                             className="absolute top-2 right-2 text-red-500 hover:text-red-700" title="Remove">
                                                             <X size={16} />

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -1034,16 +1034,6 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                                                     {creative.mediaType === 'video' ? (
                                                         <>
                                                             <button
-                                                                onClick={() => handleAnalyzeVideo(creative, 'gemini')}
-                                                                className="w-full px-3 py-2 text-left text-sm hover:bg-amber-50 flex items-center gap-2"
-                                                            >
-                                                                <Sparkles size={14} className="text-amber-500" />
-                                                                <div>
-                                                                    <div className="font-medium text-gray-800">Gemini 2.0 Flash</div>
-                                                                    <div className="text-xs text-gray-500">Analyzes video + audio</div>
-                                                                </div>
-                                                            </button>
-                                                            <button
                                                                 onClick={() => handleAnalyzeVideo(creative, 'transcribe_haiku')}
                                                                 className="w-full px-3 py-2 text-left text-sm hover:bg-green-50 flex items-center gap-2"
                                                             >
@@ -1053,7 +1043,6 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                                                                     <div className="text-xs text-gray-500">Gemini transcribes → Haiku writes copy</div>
                                                                 </div>
                                                             </button>
-                                                            <div className="border-t border-gray-100 my-1"></div>
                                                             <button
                                                                 onClick={() => handleAnalyzeVideo(creative, 'claude')}
                                                                 className="w-full px-3 py-2 text-left text-sm hover:bg-purple-50 flex items-center gap-2"
@@ -1062,6 +1051,17 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                                                                 <div>
                                                                     <div className="font-medium text-gray-800">Claude Haiku</div>
                                                                     <div className="text-xs text-gray-500">Frames only (no audio)</div>
+                                                                </div>
+                                                            </button>
+                                                            <div className="border-t border-gray-100 my-1"></div>
+                                                            <button
+                                                                onClick={() => handleAnalyzeVideo(creative, 'gemini')}
+                                                                className="w-full px-3 py-2 text-left text-sm hover:bg-amber-50 flex items-center gap-2"
+                                                            >
+                                                                <Sparkles size={14} className="text-amber-500" />
+                                                                <div>
+                                                                    <div className="font-medium text-gray-800">Gemini 2.0 Flash</div>
+                                                                    <div className="text-xs text-gray-500">Analyzes video + audio</div>
                                                                 </div>
                                                             </button>
                                                         </>

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -1,9 +1,11 @@
 import { useToast } from '../context/ToastContext';
 import React, { useState, useEffect } from 'react';
-import { ChevronRight, Upload, X, Loader, Trash2, Film, Image, Sparkles, Play } from 'lucide-react';
+import { ChevronRight, Upload, X, Loader, Trash2, Film, Image, Sparkles, Play, FolderOpen, Check } from 'lucide-react';
 import { useCampaign } from '../context/CampaignContext';
 import { useAuth } from '../context/AuthContext';
 import { getPages } from '../lib/facebookApi';
+import { getLibraryItems } from '../api/adsLibrary';
+import { useBrands } from '../context/BrandContext';
 
 const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
 const ALLOWED_VIDEO_TYPES = ['video/mp4', 'video/quicktime', 'video/x-msvideo', 'video/webm'];
@@ -36,6 +38,15 @@ const AdCreativeStep = ({ onNext, onBack }) => {
     const [manualPageEntry, setManualPageEntry] = useState(false);
     const [isDragging, setIsDragging] = useState(false);
     const [playingVideo, setPlayingVideo] = useState(null);
+
+    // Ads Library import
+    const { brands } = useBrands();
+    const [showLibraryModal, setShowLibraryModal] = useState(false);
+    const [libraryItems, setLibraryItems] = useState([]);
+    const [libraryLoading, setLibraryLoading] = useState(false);
+    const [libraryFilterBrand, setLibraryFilterBrand] = useState('');
+    const [libraryFilterMediaType, setLibraryFilterMediaType] = useState('');
+    const [selectedLibraryItems, setSelectedLibraryItems] = useState(new Set());
 
     const handleDragEnter = (e) => {
         e.preventDefault();
@@ -90,6 +101,69 @@ const AdCreativeStep = ({ onNext, onBack }) => {
             ...prev,
             creatives: [...(prev.creatives || []), ...newCreatives]
         }));
+    };
+
+    // Ads Library import functions
+    const fetchLibraryItems = async (brandFilter, mediaFilter) => {
+        setLibraryLoading(true);
+        try {
+            const filters = {};
+            if (brandFilter) filters.brand_id = brandFilter;
+            if (mediaFilter) filters.media_type = mediaFilter;
+            const data = await getLibraryItems(filters);
+            setLibraryItems(data);
+        } catch (error) {
+            showError('Failed to load ads library');
+        } finally {
+            setLibraryLoading(false);
+        }
+    };
+
+    const toggleLibrarySelection = (itemId) => {
+        setSelectedLibraryItems(prev => {
+            const next = new Set(prev);
+            if (next.has(itemId)) next.delete(itemId);
+            else next.add(itemId);
+            return next;
+        });
+    };
+
+    const handleImportFromLibrary = () => {
+        const selected = libraryItems.filter(item => selectedLibraryItems.has(item.id));
+
+        const newCreatives = selected.map(item => ({
+            id: `creative_lib_${item.id}_${Date.now()}`,
+            previewUrl: item.media_type === 'video'
+                ? (item.thumbnail_url || item.media_url)
+                : item.media_url,
+            imageUrl: item.media_type === 'image' ? item.media_url : undefined,
+            videoUrl: item.media_type === 'video' ? item.media_url : undefined,
+            name: item.name || 'Library Import',
+            mediaType: item.media_type,
+        }));
+
+        setCreativeData(prev => ({
+            ...prev,
+            creatives: [...(prev.creatives || []), ...newCreatives],
+        }));
+
+        // Pre-fill copy fields from first item if current fields are empty
+        const firstWithCopy = selected.find(item => item.headline || item.body);
+        if (firstWithCopy) {
+            const bodiesEmpty = !creativeData.bodies || creativeData.bodies.every(b => !b?.trim());
+            const headlinesEmpty = !creativeData.headlines || creativeData.headlines.every(h => !h?.trim());
+
+            if (bodiesEmpty && firstWithCopy.body) {
+                setCreativeData(prev => ({ ...prev, bodies: [firstWithCopy.body] }));
+            }
+            if (headlinesEmpty && firstWithCopy.headline) {
+                setCreativeData(prev => ({ ...prev, headlines: [firstWithCopy.headline] }));
+            }
+        }
+
+        showSuccess(`Imported ${newCreatives.length} item${newCreatives.length > 1 ? 's' : ''} from library`);
+        setShowLibraryModal(false);
+        setSelectedLibraryItems(new Set());
     };
 
     // Prepopulate Creative Name with Ad Set Name if empty
@@ -586,6 +660,20 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                         </label>
                     </div>
 
+                    {/* Import from Ads Library */}
+                    <div className="flex items-center gap-3 mb-4">
+                        <button
+                            onClick={() => {
+                                setShowLibraryModal(true);
+                                fetchLibraryItems(libraryFilterBrand, libraryFilterMediaType);
+                            }}
+                            className="flex items-center gap-2 px-4 py-2 bg-indigo-50 text-indigo-700 rounded-lg hover:bg-indigo-100 border border-indigo-200 font-medium text-sm"
+                        >
+                            <FolderOpen size={18} />
+                            Import from Ads Library
+                        </button>
+                    </div>
+
                     {/* Media Grid */}
                     {creativeData.creatives && creativeData.creatives.length > 0 && (
                         <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-4">
@@ -942,6 +1030,128 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                     Next Step <ChevronRight size={20} />
                 </button>
             </div>
+
+            {/* Ads Library Import Modal */}
+            {showLibraryModal && (
+                <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
+                     onClick={() => { setShowLibraryModal(false); setSelectedLibraryItems(new Set()); }}>
+                    <div className="bg-white rounded-xl max-w-5xl w-full max-h-[85vh] flex flex-col"
+                         onClick={(e) => e.stopPropagation()}>
+
+                        {/* Modal Header */}
+                        <div className="p-6 border-b border-gray-200 flex items-center justify-between">
+                            <h3 className="text-xl font-bold text-gray-900 flex items-center gap-2">
+                                <FolderOpen size={24} className="text-indigo-600" />
+                                Import from Ads Library
+                            </h3>
+                            <button onClick={() => { setShowLibraryModal(false); setSelectedLibraryItems(new Set()); }}
+                                    className="text-gray-400 hover:text-gray-600">
+                                <X size={24} />
+                            </button>
+                        </div>
+
+                        {/* Filters Bar */}
+                        <div className="px-6 py-3 border-b border-gray-100 flex gap-3 items-center flex-wrap">
+                            <select value={libraryFilterBrand}
+                                    onChange={(e) => { setLibraryFilterBrand(e.target.value); fetchLibraryItems(e.target.value, libraryFilterMediaType); }}
+                                    className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg">
+                                <option value="">All Brands</option>
+                                {brands.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}
+                            </select>
+                            <div className="flex rounded-lg border border-gray-300 overflow-hidden">
+                                {[['', 'All'], ['image', 'Images'], ['video', 'Videos']].map(([type, label]) => (
+                                    <button key={type}
+                                            onClick={() => { setLibraryFilterMediaType(type); fetchLibraryItems(libraryFilterBrand, type); }}
+                                            className={`px-3 py-1.5 text-sm ${
+                                                libraryFilterMediaType === type
+                                                    ? 'bg-amber-600 text-white'
+                                                    : 'bg-white text-gray-600 hover:bg-gray-50'
+                                            }`}>
+                                        {label}
+                                    </button>
+                                ))}
+                            </div>
+                            {selectedLibraryItems.size > 0 && (
+                                <span className="ml-auto text-sm text-indigo-600 font-medium">
+                                    {selectedLibraryItems.size} selected
+                                </span>
+                            )}
+                        </div>
+
+                        {/* Items Grid */}
+                        <div className="flex-1 overflow-y-auto p-6">
+                            {libraryLoading ? (
+                                <div className="flex items-center justify-center py-12">
+                                    <Loader className="animate-spin text-amber-600" size={24} />
+                                </div>
+                            ) : libraryItems.length === 0 ? (
+                                <div className="text-center py-12 text-gray-500">
+                                    No library items found. Upload media in the Ads Library first.
+                                </div>
+                            ) : (
+                                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                                    {libraryItems.map(item => {
+                                        const isSelected = selectedLibraryItems.has(item.id);
+                                        return (
+                                            <div key={item.id}
+                                                 onClick={() => toggleLibrarySelection(item.id)}
+                                                 className={`relative rounded-lg border-2 overflow-hidden cursor-pointer transition-all ${
+                                                     isSelected
+                                                         ? 'border-indigo-600 ring-2 ring-indigo-200'
+                                                         : 'border-gray-200 hover:border-indigo-300'
+                                                 }`}>
+                                                <div className="aspect-square bg-gray-100">
+                                                    {item.media_type === 'video' ? (
+                                                        item.thumbnail_url ? (
+                                                            <img src={item.thumbnail_url} alt={item.name} className="w-full h-full object-cover" />
+                                                        ) : (
+                                                            <div className="w-full h-full flex items-center justify-center bg-gray-800">
+                                                                <Film size={32} className="text-gray-500" />
+                                                            </div>
+                                                        )
+                                                    ) : (
+                                                        <img src={item.media_url} alt={item.name} className="w-full h-full object-cover" />
+                                                    )}
+                                                </div>
+                                                {isSelected && (
+                                                    <div className="absolute top-2 right-2 w-6 h-6 bg-indigo-600 rounded-full flex items-center justify-center">
+                                                        <Check size={14} className="text-white" />
+                                                    </div>
+                                                )}
+                                                <span className="absolute top-2 left-2 px-2 py-0.5 bg-black/60 text-white text-xs rounded">
+                                                    {item.media_type}
+                                                </span>
+                                                {item.variants && Object.keys(item.variants).length > 1 && (
+                                                    <span className="absolute bottom-12 left-2 px-2 py-0.5 bg-purple-600/90 text-white text-xs rounded">
+                                                        {Object.keys(item.variants).length} sizes
+                                                    </span>
+                                                )}
+                                                <div className="p-2">
+                                                    <p className="text-sm font-medium text-gray-900 truncate">{item.name}</p>
+                                                    <p className="text-xs text-gray-500 truncate">{item.brand_name}</p>
+                                                </div>
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            )}
+                        </div>
+
+                        {/* Modal Footer */}
+                        <div className="p-4 border-t border-gray-200 flex justify-between items-center">
+                            <button onClick={() => { setShowLibraryModal(false); setSelectedLibraryItems(new Set()); }}
+                                    className="px-4 py-2 text-gray-600 hover:bg-gray-100 rounded-lg">
+                                Cancel
+                            </button>
+                            <button onClick={handleImportFromLibrary}
+                                    disabled={selectedLibraryItems.size === 0}
+                                    className="px-6 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 font-medium disabled:opacity-50 disabled:cursor-not-allowed">
+                                Import {selectedLibraryItems.size > 0 ? `(${selectedLibraryItems.size})` : ''}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
 
             {/* Video Playback Modal */}
             {playingVideo && (

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -570,8 +570,9 @@ const AdCreativeStep = ({ onNext, onBack }) => {
     };
 
     const handleAnalyzeVideo = async (creative, provider = 'gemini') => {
-        if (!creative.file) {
-            showWarning('Cannot analyze videos added via URL');
+        const videoUrl = creative.videoUrl || creative.previewUrl;
+        if (!creative.file && !videoUrl) {
+            showWarning('No video file or URL available');
             return;
         }
 
@@ -580,7 +581,11 @@ const AdCreativeStep = ({ onNext, onBack }) => {
         setProviderMenuId(null);
         try {
             const formData = new FormData();
-            formData.append('file', creative.file);
+            if (creative.file) {
+                formData.append('file', creative.file);
+            } else {
+                formData.append('url', videoUrl);
+            }
 
             const response = await authFetch(`${API_URL}/video-analysis/analyze?provider=${provider}`, {
                 method: 'POST',
@@ -646,11 +651,7 @@ const AdCreativeStep = ({ onNext, onBack }) => {
             if (creative.file) {
                 formData.append('file', creative.file);
             } else {
-                // Fetch image from URL and convert to blob
-                const imgResponse = await fetch(imageUrl);
-                const blob = await imgResponse.blob();
-                const ext = imageUrl.split('.').pop()?.split('?')[0] || 'jpg';
-                formData.append('file', blob, `image.${ext}`);
+                formData.append('url', imageUrl);
             }
 
             const response = await authFetch(`${API_URL}/video-analysis/analyze-image?provider=${provider}`, {

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -28,7 +28,7 @@ const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api/v1';
 const AdCreativeStep = ({ onNext, onBack }) => {
     const { showWarning, showError, showSuccess } = useToast();
     const { authFetch } = useAuth();
-    const { creativeData, setCreativeData, selectedAdAccount, selectedProduct, adsetData } = useCampaign();
+    const { creativeData, setCreativeData, selectedAdAccount, selectedProduct, adsetData, addingNewAd, setAddingNewAd } = useCampaign();
     const [pages, setPages] = useState([]);
     const [loadingPages, setLoadingPages] = useState(false);
     const [analyzingVideoId, setAnalyzingVideoId] = useState(null);
@@ -50,6 +50,14 @@ const AdCreativeStep = ({ onNext, onBack }) => {
     const [libraryFilterBrand, setLibraryFilterBrand] = useState('');
     const [libraryFilterMediaType, setLibraryFilterMediaType] = useState('');
     const [selectedLibraryItems, setSelectedLibraryItems] = useState(new Set());
+
+    // When coming from "Add Another Ad", auto-open library modal
+    useEffect(() => {
+        if (addingNewAd) {
+            setShowLibraryModal(true);
+            setAddingNewAd(false);
+        }
+    }, [addingNewAd]);
 
     const handleDragEnter = (e) => {
         e.preventDefault();

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -282,7 +282,7 @@ const AdCreativeStep = ({ onNext, onBack }) => {
     };
 
     const addBodyField = () => {
-        if (creativeData.bodies.length < 3) {
+        if (creativeData.bodies.length < 6) {
             setCreativeData(prev => ({
                 ...prev,
                 bodies: [...prev.bodies, '']
@@ -291,7 +291,7 @@ const AdCreativeStep = ({ onNext, onBack }) => {
     };
 
     const addHeadlineField = () => {
-        if (creativeData.headlines.length < 3) {
+        if (creativeData.headlines.length < 6) {
             setCreativeData(prev => ({
                 ...prev,
                 headlines: [...prev.headlines, '']
@@ -372,25 +372,33 @@ const AdCreativeStep = ({ onNext, onBack }) => {
 
             const data = await response.json();
 
-            // Ensure we have exactly 3 slots for bodies and headlines
-            const bodies = [...(data.bodies || [])];
-            while (bodies.length < 3) bodies.push('');
-            const headlines = [...(data.headlines || [])];
-            while (headlines.length < 3) headlines.push('');
+            const newBodies = (data.bodies || []).filter(b => b && b.trim());
+            const newHeadlines = (data.headlines || []).filter(h => h && h.trim());
 
-            setCreativeData(prev => ({
-                ...prev,
-                bodies: bodies.slice(0, 3),
-                headlines: headlines.slice(0, 3),
-            }));
+            setCreativeData(prev => {
+                // Keep existing non-empty entries, append new ones, cap at 6
+                const existingBodies = prev.bodies.filter(b => b && b.trim());
+                const existingHeadlines = prev.headlines.filter(h => h && h.trim());
+                const mergedBodies = [...existingBodies, ...newBodies].slice(0, 6);
+                const mergedHeadlines = [...existingHeadlines, ...newHeadlines].slice(0, 6);
+                // Ensure at least 1 slot
+                if (mergedBodies.length === 0) mergedBodies.push('');
+                if (mergedHeadlines.length === 0) mergedHeadlines.push('');
+                return { ...prev, bodies: mergedBodies, headlines: mergedHeadlines };
+            });
 
-            // Persist to localStorage
+            // Persist merged results to localStorage
             if (selectedAdAccount) {
-                localStorage.setItem(`defaultBodies_${selectedAdAccount.id}`, JSON.stringify(bodies.slice(0, 3)));
-                localStorage.setItem(`defaultHeadlines_${selectedAdAccount.id}`, JSON.stringify(headlines.slice(0, 3)));
+                const existingBodies = creativeData.bodies.filter(b => b && b.trim());
+                const existingHeadlines = creativeData.headlines.filter(h => h && h.trim());
+                const allBodies = [...existingBodies, ...newBodies].slice(0, 6);
+                const allHeadlines = [...existingHeadlines, ...newHeadlines].slice(0, 6);
+                localStorage.setItem(`defaultBodies_${selectedAdAccount.id}`, JSON.stringify(allBodies));
+                localStorage.setItem(`defaultHeadlines_${selectedAdAccount.id}`, JSON.stringify(allHeadlines));
             }
 
-            showSuccess('AI generated ad copy from video analysis');
+            const providerName = provider === 'claude' ? 'Claude Haiku' : 'Gemini';
+            showSuccess(`${providerName} ad copy appended (${newBodies.length} bodies, ${newHeadlines.length} headlines)`);
         } catch (error) {
             console.error('Video analysis error:', error);
             showError(error.message || 'Failed to analyze video');
@@ -726,7 +734,7 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                         <label className="block text-sm font-medium text-gray-700">
                             Primary Text *
                         </label>
-                        {creativeData.bodies.length < 3 && (
+                        {creativeData.bodies.length < 6 && (
                             <button
                                 type="button"
                                 onClick={addBodyField}
@@ -772,7 +780,7 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                         <label className="block text-sm font-medium text-gray-700">
                             Headline *
                         </label>
-                        {creativeData.headlines.length < 3 && (
+                        {creativeData.headlines.length < 6 && (
                             <button
                                 type="button"
                                 onClick={addHeadlineField}

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -1,7 +1,8 @@
 import { useToast } from '../context/ToastContext';
 import React, { useState, useEffect } from 'react';
-import { ChevronRight, Upload, X, Loader, Trash2, Film, Image } from 'lucide-react';
+import { ChevronRight, Upload, X, Loader, Trash2, Film, Image, Sparkles } from 'lucide-react';
 import { useCampaign } from '../context/CampaignContext';
+import { useAuth } from '../context/AuthContext';
 import { getPages } from '../lib/facebookApi';
 
 const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
@@ -20,11 +21,15 @@ const CTA_OPTIONS = [
     'DONATE_NOW',
 ];
 
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api/v1';
+
 const AdCreativeStep = ({ onNext, onBack }) => {
-    const { showWarning, showError } = useToast();
+    const { showWarning, showError, showSuccess } = useToast();
+    const { authFetch } = useAuth();
     const { creativeData, setCreativeData, selectedAdAccount, selectedProduct, adsetData } = useCampaign();
     const [pages, setPages] = useState([]);
     const [loadingPages, setLoadingPages] = useState(false);
+    const [analyzingVideoId, setAnalyzingVideoId] = useState(null);
 
     const [manualPageEntry, setManualPageEntry] = useState(false);
     const [isDragging, setIsDragging] = useState(false);
@@ -302,6 +307,56 @@ const AdCreativeStep = ({ onNext, onBack }) => {
         }));
     };
 
+    const handleAnalyzeVideo = async (creative) => {
+        if (!creative.file) {
+            showWarning('Cannot analyze videos added via URL');
+            return;
+        }
+
+        setAnalyzingVideoId(creative.id);
+        try {
+            const formData = new FormData();
+            formData.append('file', creative.file);
+
+            const response = await authFetch(`${API_URL}/video-analysis/analyze`, {
+                method: 'POST',
+                body: formData,
+            });
+
+            if (!response.ok) {
+                const err = await response.json().catch(() => ({}));
+                throw new Error(err.detail || 'Video analysis failed');
+            }
+
+            const data = await response.json();
+
+            // Ensure we have exactly 3 slots for bodies and headlines
+            const bodies = [...(data.bodies || [])];
+            while (bodies.length < 3) bodies.push('');
+            const headlines = [...(data.headlines || [])];
+            while (headlines.length < 3) headlines.push('');
+
+            setCreativeData(prev => ({
+                ...prev,
+                bodies: bodies.slice(0, 3),
+                headlines: headlines.slice(0, 3),
+            }));
+
+            // Persist to localStorage
+            if (selectedAdAccount) {
+                localStorage.setItem(`defaultBodies_${selectedAdAccount.id}`, JSON.stringify(bodies.slice(0, 3)));
+                localStorage.setItem(`defaultHeadlines_${selectedAdAccount.id}`, JSON.stringify(headlines.slice(0, 3)));
+            }
+
+            showSuccess('AI generated ad copy from video analysis');
+        } catch (error) {
+            console.error('Video analysis error:', error);
+            showError(error.message || 'Failed to analyze video');
+        } finally {
+            setAnalyzingVideoId(null);
+        }
+    };
+
     const handleNext = () => {
         // Validate required fields
         if (!creativeData.creativeName) {
@@ -503,7 +558,17 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                                             </span>
                                         )}
                                     </div>
-                                    <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-30 transition-all flex items-center justify-center opacity-0 group-hover:opacity-100">
+                                    <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-30 transition-all flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100">
+                                        {creative.mediaType === 'video' && (
+                                            <button
+                                                onClick={() => handleAnalyzeVideo(creative)}
+                                                disabled={analyzingVideoId !== null}
+                                                className="p-2 bg-amber-500 text-white rounded-full hover:bg-amber-600 transform scale-90 hover:scale-100 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                                                title="Analyze video with AI"
+                                            >
+                                                <Sparkles size={16} />
+                                            </button>
+                                        )}
                                         <button
                                             onClick={() => removeCreative(creative.id)}
                                             className="p-2 bg-red-500 text-white rounded-full hover:bg-red-600 transform scale-90 hover:scale-100 transition-all"
@@ -517,6 +582,17 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                                     </div>
                                 </div>
                             ))}
+                        </div>
+                    )}
+
+                    {/* AI Video Analysis Loading Banner */}
+                    {analyzingVideoId && (
+                        <div className="flex items-center gap-3 bg-amber-50 border border-amber-200 rounded-lg p-4 mb-4">
+                            <Loader className="animate-spin text-amber-600" size={20} />
+                            <div>
+                                <p className="text-amber-800 font-medium">Analyzing video with AI...</p>
+                                <p className="text-amber-600 text-sm">Gemini is watching your video and generating ad copy. This may take 30-60 seconds.</p>
+                            </div>
                         </div>
                     )}
 

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -598,9 +598,15 @@ const AdCreativeStep = ({ onNext, onBack }) => {
             }
 
             const data = await response.json();
+            console.log('[handleAnalyzeVideo] API response:', JSON.stringify(data));
 
             const newBodies = (data.bodies || []).filter(b => b && b.trim());
             const newHeadlines = (data.headlines || []).filter(h => h && h.trim());
+
+            if (newBodies.length === 0 && newHeadlines.length === 0) {
+                showWarning('AI returned no ad copy. Try a different provider or re-upload the video.');
+                return;
+            }
 
             if (isPerCreative) {
                 // In per-creative mode, put copy on the specific creative

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -1,6 +1,6 @@
 import { useToast } from '../context/ToastContext';
 import React, { useState, useEffect } from 'react';
-import { ChevronRight, Upload, X, Loader, Trash2, Film, Image, Sparkles } from 'lucide-react';
+import { ChevronRight, Upload, X, Loader, Trash2, Film, Image, Sparkles, Play } from 'lucide-react';
 import { useCampaign } from '../context/CampaignContext';
 import { useAuth } from '../context/AuthContext';
 import { getPages } from '../lib/facebookApi';
@@ -30,9 +30,12 @@ const AdCreativeStep = ({ onNext, onBack }) => {
     const [pages, setPages] = useState([]);
     const [loadingPages, setLoadingPages] = useState(false);
     const [analyzingVideoId, setAnalyzingVideoId] = useState(null);
+    const [analyzingProvider, setAnalyzingProvider] = useState(null);
+    const [providerMenuId, setProviderMenuId] = useState(null);
 
     const [manualPageEntry, setManualPageEntry] = useState(false);
     const [isDragging, setIsDragging] = useState(false);
+    const [playingVideo, setPlayingVideo] = useState(null);
 
     const handleDragEnter = (e) => {
         e.preventDefault();
@@ -121,23 +124,60 @@ const AdCreativeStep = ({ onNext, onBack }) => {
         }
     }, [selectedAdAccount]);
 
+    const loadSavedManualPages = () => {
+        try {
+            const saved = localStorage.getItem('savedManualPages');
+            return saved ? JSON.parse(saved) : [];
+        } catch { return []; }
+    };
+
+    const mergePages = (fetchedPages) => {
+        const savedPages = loadSavedManualPages();
+        const fetchedIds = new Set(fetchedPages.map(p => p.id));
+        const uniqueSaved = savedPages.filter(p => !fetchedIds.has(p.id));
+        return [...fetchedPages, ...uniqueSaved];
+    };
+
+    const handleSaveManualPage = () => {
+        const pageId = creativeData.pageId?.trim();
+        if (!pageId) return;
+        const savedPages = loadSavedManualPages();
+        if (savedPages.some(p => p.id === pageId)) {
+            showWarning('This Page ID is already saved');
+            return;
+        }
+        const updated = [...savedPages, { id: pageId, name: `Page ${pageId}` }];
+        localStorage.setItem('savedManualPages', JSON.stringify(updated));
+        setPages(prev => {
+            if (prev.some(p => p.id === pageId)) return prev;
+            return [...prev, { id: pageId, name: `Page ${pageId}` }];
+        });
+        showSuccess('Page ID saved to dropdown list');
+    };
+
     const fetchPages = async () => {
         setLoadingPages(true);
         try {
             const fetchedPages = await getPages(selectedAdAccount.id);
-            setPages(fetchedPages);
+            const combined = mergePages(fetchedPages);
+            setPages(combined);
 
             // If no page is selected and we have pages, select the first one (or the last used one if it exists in the list)
-            if (fetchedPages.length > 0 && !creativeData.pageId) {
+            if (combined.length > 0 && !creativeData.pageId) {
                 const lastUsedPageId = localStorage.getItem('lastUsedPageId');
-                const pageToSelect = fetchedPages.find(p => p.id === lastUsedPageId) || fetchedPages[0];
-                handlePageSelection(pageToSelect.id, fetchedPages);
-            } else if (fetchedPages.length === 0) {
+                const pageToSelect = combined.find(p => p.id === lastUsedPageId) || combined[0];
+                handlePageSelection(pageToSelect.id, combined);
+            } else if (combined.length === 0) {
                 // If no pages found, default to manual entry so user isn't blocked
                 setManualPageEntry(true);
             }
         } catch (error) {
             console.error('Error fetching pages:', error);
+            // Still load saved manual pages even if fetch fails
+            const savedPages = loadSavedManualPages();
+            if (savedPages.length > 0) {
+                setPages(savedPages);
+            }
             showError('Failed to load Facebook Pages. You can enter Page ID manually.');
             setManualPageEntry(true); // Auto-switch to manual entry
         } finally {
@@ -307,18 +347,20 @@ const AdCreativeStep = ({ onNext, onBack }) => {
         }));
     };
 
-    const handleAnalyzeVideo = async (creative) => {
+    const handleAnalyzeVideo = async (creative, provider = 'gemini') => {
         if (!creative.file) {
             showWarning('Cannot analyze videos added via URL');
             return;
         }
 
         setAnalyzingVideoId(creative.id);
+        setAnalyzingProvider(provider);
+        setProviderMenuId(null);
         try {
             const formData = new FormData();
             formData.append('file', creative.file);
 
-            const response = await authFetch(`${API_URL}/video-analysis/analyze`, {
+            const response = await authFetch(`${API_URL}/video-analysis/analyze?provider=${provider}`, {
                 method: 'POST',
                 body: formData,
             });
@@ -354,6 +396,7 @@ const AdCreativeStep = ({ onNext, onBack }) => {
             showError(error.message || 'Failed to analyze video');
         } finally {
             setAnalyzingVideoId(null);
+            setAnalyzingProvider(null);
         }
     };
 
@@ -447,13 +490,23 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                     </div>
 
                     {manualPageEntry ? (
-                        <input
-                            type="text"
-                            value={creativeData.pageId}
-                            onChange={(e) => handleInputChange('pageId', e.target.value)}
-                            placeholder="Enter Facebook Page ID (e.g., 933995649786806)"
-                            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
-                        />
+                        <div className="flex gap-2">
+                            <input
+                                type="text"
+                                value={creativeData.pageId}
+                                onChange={(e) => handleInputChange('pageId', e.target.value)}
+                                placeholder="Enter Facebook Page ID (e.g., 933995649786806)"
+                                className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                            />
+                            {creativeData.pageId?.trim() && (
+                                <button
+                                    onClick={handleSaveManualPage}
+                                    className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 text-sm font-medium whitespace-nowrap"
+                                >
+                                    Save
+                                </button>
+                            )}
+                        </div>
                     ) : loadingPages ? (
                         <div className="flex items-center gap-2 text-gray-500 py-2">
                             <Loader className="animate-spin" size={20} />
@@ -560,13 +613,48 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                                     </div>
                                     <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-30 transition-all flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100">
                                         {creative.mediaType === 'video' && (
+                                            <div className="relative">
+                                                <button
+                                                    onClick={() => setProviderMenuId(providerMenuId === creative.id ? null : creative.id)}
+                                                    disabled={analyzingVideoId !== null}
+                                                    className="p-2 bg-amber-500 text-white rounded-full hover:bg-amber-600 transform scale-90 hover:scale-100 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                                                    title="Analyze video with AI"
+                                                >
+                                                    <Sparkles size={16} />
+                                                </button>
+                                                {providerMenuId === creative.id && (
+                                                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 bg-white rounded-lg shadow-xl border border-gray-200 py-1 w-52 z-50">
+                                                        <button
+                                                            onClick={() => handleAnalyzeVideo(creative, 'gemini')}
+                                                            className="w-full px-3 py-2 text-left text-sm hover:bg-amber-50 flex items-center gap-2"
+                                                        >
+                                                            <Sparkles size={14} className="text-amber-500" />
+                                                            <div>
+                                                                <div className="font-medium text-gray-800">Gemini 2.0 Flash</div>
+                                                                <div className="text-xs text-gray-500">Analyzes video + audio</div>
+                                                            </div>
+                                                        </button>
+                                                        <button
+                                                            onClick={() => handleAnalyzeVideo(creative, 'claude')}
+                                                            className="w-full px-3 py-2 text-left text-sm hover:bg-purple-50 flex items-center gap-2"
+                                                        >
+                                                            <Sparkles size={14} className="text-purple-500" />
+                                                            <div>
+                                                                <div className="font-medium text-gray-800">Claude Haiku</div>
+                                                                <div className="text-xs text-gray-500">Analyzes video frames</div>
+                                                            </div>
+                                                        </button>
+                                                    </div>
+                                                )}
+                                            </div>
+                                        )}
+                                        {creative.mediaType === 'video' && (
                                             <button
-                                                onClick={() => handleAnalyzeVideo(creative)}
-                                                disabled={analyzingVideoId !== null}
-                                                className="p-2 bg-amber-500 text-white rounded-full hover:bg-amber-600 transform scale-90 hover:scale-100 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-                                                title="Analyze video with AI"
+                                                onClick={() => setPlayingVideo(creative)}
+                                                className="p-2 bg-blue-500 text-white rounded-full hover:bg-blue-600 transform scale-90 hover:scale-100 transition-all"
+                                                title="Play video"
                                             >
-                                                <Sparkles size={16} />
+                                                <Play size={16} />
                                             </button>
                                         )}
                                         <button
@@ -587,11 +675,17 @@ const AdCreativeStep = ({ onNext, onBack }) => {
 
                     {/* AI Video Analysis Loading Banner */}
                     {analyzingVideoId && (
-                        <div className="flex items-center gap-3 bg-amber-50 border border-amber-200 rounded-lg p-4 mb-4">
-                            <Loader className="animate-spin text-amber-600" size={20} />
+                        <div className={`flex items-center gap-3 ${analyzingProvider === 'claude' ? 'bg-purple-50 border-purple-200' : 'bg-amber-50 border-amber-200'} border rounded-lg p-4 mb-4`}>
+                            <Loader className={`animate-spin ${analyzingProvider === 'claude' ? 'text-purple-600' : 'text-amber-600'}`} size={20} />
                             <div>
-                                <p className="text-amber-800 font-medium">Analyzing video with AI...</p>
-                                <p className="text-amber-600 text-sm">Gemini is watching your video and generating ad copy. This may take 30-60 seconds.</p>
+                                <p className={`${analyzingProvider === 'claude' ? 'text-purple-800' : 'text-amber-800'} font-medium`}>
+                                    Analyzing video with {analyzingProvider === 'claude' ? 'Claude Haiku' : 'Gemini 2.0 Flash'}...
+                                </p>
+                                <p className={`${analyzingProvider === 'claude' ? 'text-purple-600' : 'text-amber-600'} text-sm`}>
+                                    {analyzingProvider === 'claude'
+                                        ? 'Extracting key frames and generating ad copy. This may take 30-60 seconds.'
+                                        : 'Watching your video and generating ad copy. This may take 30-60 seconds.'}
+                                </p>
                             </div>
                         </div>
                     )}
@@ -809,6 +903,30 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                     Next Step <ChevronRight size={20} />
                 </button>
             </div>
+
+            {/* Video Playback Modal */}
+            {playingVideo && (
+                <div
+                    className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4"
+                    onClick={() => setPlayingVideo(null)}
+                >
+                    <div className="relative w-full max-w-4xl" onClick={(e) => e.stopPropagation()}>
+                        <button
+                            onClick={() => setPlayingVideo(null)}
+                            className="absolute -top-10 right-0 text-white hover:text-gray-300 transition-colors"
+                            title="Close"
+                        >
+                            <X size={28} />
+                        </button>
+                        <video
+                            src={playingVideo.previewUrl}
+                            controls
+                            autoPlay
+                            className="w-full rounded-lg"
+                        />
+                    </div>
+                </div>
+            )}
         </div>
     );
 };

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -1,10 +1,11 @@
 import { useToast } from '../context/ToastContext';
 import React, { useState, useEffect } from 'react';
-import { ChevronRight, ChevronLeft, Upload, X, Loader, Trash2, Film, Image, Sparkles, Play, FolderOpen, Check } from 'lucide-react';
+import { ChevronRight, ChevronLeft, Upload, X, Loader, Trash2, Film, Image, Sparkles, Play, FolderOpen, Check, Link } from 'lucide-react';
 import { useCampaign } from '../context/CampaignContext';
 import { useAuth } from '../context/AuthContext';
 import { getPages, getPageInfo } from '../lib/facebookApi';
 import { getLibraryItems } from '../api/adsLibrary';
+import { getClickflareStatus } from '../api/clickflare';
 import { useBrands } from '../context/BrandContext';
 
 const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
@@ -41,6 +42,12 @@ const AdCreativeStep = ({ onNext, onBack }) => {
 
     // Per-creative mode
     const [currentCreativeIndex, setCurrentCreativeIndex] = useState(0);
+
+    // Clickflare status
+    const [clickflareEnabled, setClickflareEnabled] = useState(false);
+    useEffect(() => {
+        getClickflareStatus().then(s => setClickflareEnabled(s.enabled)).catch(() => {});
+    }, []);
 
     // Ads Library import
     const { brands } = useBrands();
@@ -1574,6 +1581,12 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                         placeholder="https://yourwebsite.com/landing"
                         className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
                     />
+                    {clickflareEnabled && (
+                        <p className="text-xs text-green-600 mt-1 flex items-center gap-1">
+                            <Link size={12} />
+                            Clickflare tracking will be applied automatically
+                        </p>
+                    )}
                 </div>
             </div>
 

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -793,8 +793,8 @@ const AdCreativeStep = ({ onNext, onBack }) => {
         <div>
             <h2 className="text-2xl font-bold mb-4">Ad Creative</h2>
 
-            {/* Mode Toggle */}
-            <div className="flex items-center gap-1 bg-gray-100 p-1 rounded-lg mb-6 w-fit">
+            {/* Mode Toggle — hidden for now, default to per_creative. Unhide by removing the hidden class */}
+            <div className="hidden items-center gap-1 bg-gray-100 p-1 rounded-lg mb-6 w-fit">
                 <button
                     onClick={() => setCreativeData(prev => ({ ...prev, creativeMode: 'standard' }))}
                     className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -4,7 +4,7 @@ import { ChevronRight, ChevronLeft, Upload, X, Loader, Trash2, Film, Image, Spar
 import { useCampaign } from '../context/CampaignContext';
 import { useAuth } from '../context/AuthContext';
 import { getPages, getPageInfo } from '../lib/facebookApi';
-import { getLibraryItems } from '../api/adsLibrary';
+import { getLibraryItems, getLibraryStats, getFolders } from '../api/adsLibrary';
 import { getClickflareStatus } from '../api/clickflare';
 import { useBrands } from '../context/BrandContext';
 
@@ -54,9 +54,13 @@ const AdCreativeStep = ({ onNext, onBack }) => {
     const [showLibraryModal, setShowLibraryModal] = useState(false);
     const [libraryItems, setLibraryItems] = useState([]);
     const [libraryLoading, setLibraryLoading] = useState(false);
-    const [libraryFilterBrand, setLibraryFilterBrand] = useState('');
-    const [libraryFilterMediaType, setLibraryFilterMediaType] = useState('');
     const [selectedLibraryItems, setSelectedLibraryItems] = useState(new Set());
+    const [libraryStep, setLibraryStep] = useState('brand'); // 'brand' | 'mediaType' | 'items'
+    const [librarySelectedBrand, setLibrarySelectedBrand] = useState(null);
+    const [librarySelectedMediaType, setLibrarySelectedMediaType] = useState('');
+    const [libraryStats, setLibraryStats] = useState(null);
+    const [libraryFolders, setLibraryFolders] = useState([]);
+    const [librarySelectedFolder, setLibrarySelectedFolder] = useState(null);
 
     // When coming from "Add Another Ad", auto-open library modal
     useEffect(() => {
@@ -134,12 +138,13 @@ const AdCreativeStep = ({ onNext, onBack }) => {
     };
 
     // Ads Library import functions
-    const fetchLibraryItems = async (brandFilter, mediaFilter) => {
+    const fetchLibraryItems = async (brandId, mediaType, folderId = null) => {
         setLibraryLoading(true);
         try {
             const filters = {};
-            if (brandFilter) filters.brand_id = brandFilter;
-            if (mediaFilter) filters.media_type = mediaFilter;
+            if (brandId) filters.brand_id = brandId;
+            if (mediaType) filters.media_type = mediaType;
+            if (folderId) filters.folder_id = folderId;
             const data = await getLibraryItems(filters);
             setLibraryItems(data);
         } catch (error) {
@@ -147,6 +152,47 @@ const AdCreativeStep = ({ onNext, onBack }) => {
         } finally {
             setLibraryLoading(false);
         }
+    };
+
+    const handleLibrarySelectBrand = async (brand) => {
+        setLibrarySelectedBrand(brand);
+        setLibraryStep('mediaType');
+        try {
+            const stats = await getLibraryStats({ brand_id: brand.id });
+            setLibraryStats(stats);
+        } catch {
+            setLibraryStats({ images: 0, videos: 0 });
+        }
+    };
+
+    const handleLibrarySelectMediaType = async (mediaType) => {
+        setLibrarySelectedMediaType(mediaType);
+        setLibraryStep('items');
+        setLibrarySelectedFolder(null);
+        try {
+            const folders = await getFolders({ brand_id: librarySelectedBrand.id, media_type: mediaType });
+            setLibraryFolders(folders);
+        } catch {
+            setLibraryFolders([]);
+        }
+        fetchLibraryItems(librarySelectedBrand.id, mediaType);
+    };
+
+    const handleLibraryFolderChange = (folderId) => {
+        setLibrarySelectedFolder(folderId);
+        fetchLibraryItems(librarySelectedBrand.id, librarySelectedMediaType, folderId);
+    };
+
+    const resetLibraryModal = () => {
+        setShowLibraryModal(false);
+        setLibraryStep('brand');
+        setLibrarySelectedBrand(null);
+        setLibrarySelectedMediaType('');
+        setLibraryStats(null);
+        setLibraryFolders([]);
+        setLibrarySelectedFolder(null);
+        setLibraryItems([]);
+        setSelectedLibraryItems(new Set());
     };
 
     const toggleLibrarySelection = (itemId) => {
@@ -683,7 +729,7 @@ const AdCreativeStep = ({ onNext, onBack }) => {
         }
 
         setAnalyzingVideoId(creative.id);
-        setAnalyzingProvider(provider === 'gemini' ? 'gemini' : 'haiku');
+        setAnalyzingProvider(provider);
         setProviderMenuId(null);
         try {
             const formData = new FormData();
@@ -924,7 +970,7 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                             <option value="">Select a Facebook Page...</option>
                             {pages.map(page => (
                                 <option key={page.id} value={page.id}>
-                                    {page.name}
+                                    {page.name} - {page.id}
                                 </option>
                             ))}
                         </select>
@@ -985,8 +1031,8 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                     <div className="flex items-center gap-3 mb-4">
                         <button
                             onClick={() => {
+                                setLibraryStep('brand');
                                 setShowLibraryModal(true);
-                                fetchLibraryItems(libraryFilterBrand, libraryFilterMediaType);
                             }}
                             className="flex items-center gap-2 px-4 py-2 bg-indigo-50 text-indigo-700 rounded-lg hover:bg-indigo-100 border border-indigo-200 font-medium text-sm"
                         >
@@ -1085,6 +1131,17 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                                                                     <div className="text-xs text-gray-500">Analyzes video + audio</div>
                                                                 </div>
                                                             </button>
+                                                            <div className="border-t border-gray-100 my-1"></div>
+                                                            <button
+                                                                onClick={() => handleAnalyzeVideo(creative, 'safe')}
+                                                                className="w-full px-3 py-2 text-left text-sm hover:bg-blue-50 flex items-center gap-2"
+                                                            >
+                                                                <Sparkles size={14} className="text-blue-500" />
+                                                                <div>
+                                                                    <div className="font-medium text-gray-800">Safe Copy</div>
+                                                                    <div className="text-xs text-gray-500">Policy-friendly, low-risk copy</div>
+                                                                </div>
+                                                            </button>
                                                         </>
                                                     ) : (
                                                         <>
@@ -1106,6 +1163,17 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                                                                 <div>
                                                                     <div className="font-medium text-gray-800">Gemini 2.0 Flash</div>
                                                                     <div className="text-xs text-gray-500">Analyzes image + generates DR copy</div>
+                                                                </div>
+                                                            </button>
+                                                            <div className="border-t border-gray-100 my-1"></div>
+                                                            <button
+                                                                onClick={() => handleAnalyzeImage(creative, 'safe')}
+                                                                className="w-full px-3 py-2 text-left text-sm hover:bg-blue-50 flex items-center gap-2"
+                                                            >
+                                                                <Sparkles size={14} className="text-blue-500" />
+                                                                <div>
+                                                                    <div className="font-medium text-gray-800">Safe Copy</div>
+                                                                    <div className="text-xs text-gray-500">Policy-friendly, low-risk copy</div>
                                                                 </div>
                                                             </button>
                                                         </>
@@ -1141,22 +1209,27 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                     {/* AI Analysis Loading Banner */}
                     {analyzingVideoId && (
                         <div className={`flex items-center gap-3 ${
-                            analyzingProvider === 'transcribe_haiku' ? 'bg-green-50 border-green-200'
+                            analyzingProvider === 'safe' ? 'bg-blue-50 border-blue-200'
+                            : analyzingProvider === 'transcribe_haiku' ? 'bg-green-50 border-green-200'
                             : analyzingProvider === 'haiku' || analyzingProvider === 'claude' ? 'bg-purple-50 border-purple-200'
                             : 'bg-amber-50 border-amber-200'
                         } border rounded-lg p-4 mb-4`}>
                             <Loader className={`animate-spin ${
-                                analyzingProvider === 'transcribe_haiku' ? 'text-green-600'
+                                analyzingProvider === 'safe' ? 'text-blue-600'
+                                : analyzingProvider === 'transcribe_haiku' ? 'text-green-600'
                                 : analyzingProvider === 'haiku' || analyzingProvider === 'claude' ? 'text-purple-600'
                                 : 'text-amber-600'
                             }`} size={20} />
                             <div>
                                 <p className={`${
-                                    analyzingProvider === 'transcribe_haiku' ? 'text-green-800'
+                                    analyzingProvider === 'safe' ? 'text-blue-800'
+                                    : analyzingProvider === 'transcribe_haiku' ? 'text-green-800'
                                     : analyzingProvider === 'haiku' || analyzingProvider === 'claude' ? 'text-purple-800'
                                     : 'text-amber-800'
                                 } font-medium`}>
-                                    {analyzingProvider === 'transcribe_haiku'
+                                    {analyzingProvider === 'safe'
+                                        ? 'Generating safe, policy-friendly copy...'
+                                        : analyzingProvider === 'transcribe_haiku'
                                         ? 'Transcribing audio + generating copy with Haiku...'
                                         : analyzingProvider === 'haiku'
                                         ? 'Analyzing image with Claude Haiku...'
@@ -1165,11 +1238,14 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                                         : 'Analyzing with Gemini 2.0 Flash...'}
                                 </p>
                                 <p className={`${
-                                    analyzingProvider === 'transcribe_haiku' ? 'text-green-600'
+                                    analyzingProvider === 'safe' ? 'text-blue-600'
+                                    : analyzingProvider === 'transcribe_haiku' ? 'text-green-600'
                                     : analyzingProvider === 'haiku' || analyzingProvider === 'claude' ? 'text-purple-600'
                                     : 'text-amber-600'
                                 } text-sm`}>
-                                    {analyzingProvider === 'transcribe_haiku'
+                                    {analyzingProvider === 'safe'
+                                        ? 'Clean copy optimized for ad approval. This may take 10-15 seconds.'
+                                        : analyzingProvider === 'transcribe_haiku'
                                         ? 'Step 1: Gemini transcribes audio → Step 2: Haiku writes DR copy. This may take 60-90 seconds.'
                                         : analyzingProvider === 'haiku'
                                         ? 'Generating direct-response ad copy from your image. This may take 10-20 seconds.'
@@ -1609,120 +1685,202 @@ const AdCreativeStep = ({ onNext, onBack }) => {
             {/* Ads Library Import Modal */}
             {showLibraryModal && (
                 <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4"
-                     onClick={() => { setShowLibraryModal(false); setSelectedLibraryItems(new Set()); }}>
+                     onClick={resetLibraryModal}>
                     <div className="bg-white rounded-xl max-w-5xl w-full max-h-[85vh] flex flex-col"
                          onClick={(e) => e.stopPropagation()}>
 
-                        {/* Modal Header */}
+                        {/* Modal Header with Breadcrumb */}
                         <div className="p-6 border-b border-gray-200 flex items-center justify-between">
-                            <h3 className="text-xl font-bold text-gray-900 flex items-center gap-2">
-                                <FolderOpen size={24} className="text-indigo-600" />
-                                Import from Ads Library
-                            </h3>
-                            <button onClick={() => { setShowLibraryModal(false); setSelectedLibraryItems(new Set()); }}
+                            <div>
+                                <h3 className="text-xl font-bold text-gray-900 flex items-center gap-2">
+                                    <FolderOpen size={24} className="text-indigo-600" />
+                                    Import from Ads Library
+                                </h3>
+                                {libraryStep !== 'brand' && (
+                                    <div className="flex items-center gap-1 mt-1 text-sm">
+                                        <button onClick={() => { setLibraryStep('brand'); setLibrarySelectedBrand(null); setLibraryItems([]); setSelectedLibraryItems(new Set()); }}
+                                                className="text-indigo-600 hover:underline">Brands</button>
+                                        {librarySelectedBrand && (
+                                            <>
+                                                <ChevronRight size={14} className="text-gray-400" />
+                                                {libraryStep === 'mediaType' ? (
+                                                    <span className="text-gray-700 font-medium">{librarySelectedBrand.name}</span>
+                                                ) : (
+                                                    <button onClick={() => { setLibraryStep('mediaType'); setLibraryItems([]); setSelectedLibraryItems(new Set()); }}
+                                                            className="text-indigo-600 hover:underline">{librarySelectedBrand.name}</button>
+                                                )}
+                                            </>
+                                        )}
+                                        {libraryStep === 'items' && (
+                                            <>
+                                                <ChevronRight size={14} className="text-gray-400" />
+                                                <span className="text-gray-700 font-medium">{librarySelectedMediaType === 'image' ? 'Images' : 'Videos'}</span>
+                                            </>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                            <button onClick={resetLibraryModal}
                                     className="text-gray-400 hover:text-gray-600">
                                 <X size={24} />
                             </button>
                         </div>
 
-                        {/* Filters Bar */}
-                        <div className="px-6 py-3 border-b border-gray-100 flex gap-3 items-center flex-wrap">
-                            <select value={libraryFilterBrand}
-                                    onChange={(e) => { setLibraryFilterBrand(e.target.value); fetchLibraryItems(e.target.value, libraryFilterMediaType); }}
-                                    className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg">
-                                <option value="">All Brands</option>
-                                {brands.map(b => <option key={b.id} value={b.id}>{b.name}</option>)}
-                            </select>
-                            <div className="flex rounded-lg border border-gray-300 overflow-hidden">
-                                {[['', 'All'], ['image', 'Images'], ['video', 'Videos']].map(([type, label]) => (
-                                    <button key={type}
-                                            onClick={() => { setLibraryFilterMediaType(type); fetchLibraryItems(libraryFilterBrand, type); }}
-                                            className={`px-3 py-1.5 text-sm ${
-                                                libraryFilterMediaType === type
-                                                    ? 'bg-amber-600 text-white'
-                                                    : 'bg-white text-gray-600 hover:bg-gray-50'
-                                            }`}>
-                                        {label}
-                                    </button>
-                                ))}
-                            </div>
-                            {selectedLibraryItems.size > 0 && (
-                                <span className="ml-auto text-sm text-indigo-600 font-medium">
-                                    {selectedLibraryItems.size} selected
-                                </span>
-                            )}
-                        </div>
-
-                        {/* Items Grid */}
+                        {/* Step Content */}
                         <div className="flex-1 overflow-y-auto p-6">
-                            {libraryLoading ? (
-                                <div className="flex items-center justify-center py-12">
-                                    <Loader className="animate-spin text-amber-600" size={24} />
-                                </div>
-                            ) : libraryItems.length === 0 ? (
-                                <div className="text-center py-12 text-gray-500">
-                                    No library items found. Upload media in the Ads Library first.
-                                </div>
-                            ) : (
-                                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-                                    {libraryItems.map(item => {
-                                        const isSelected = selectedLibraryItems.has(item.id);
-                                        return (
-                                            <div key={item.id}
-                                                 onClick={() => toggleLibrarySelection(item.id)}
-                                                 className={`relative rounded-lg border-2 overflow-hidden cursor-pointer transition-all ${
-                                                     isSelected
-                                                         ? 'border-indigo-600 ring-2 ring-indigo-200'
-                                                         : 'border-gray-200 hover:border-indigo-300'
-                                                 }`}>
-                                                <div className="aspect-square bg-gray-100">
-                                                    {item.media_type === 'video' ? (
-                                                        item.thumbnail_url ? (
-                                                            <img src={item.thumbnail_url} alt={item.name} className="w-full h-full object-cover" />
+                            {/* Step 1: Brand Selection */}
+                            {libraryStep === 'brand' && (
+                                <div>
+                                    <p className="text-sm text-gray-500 mb-4">Select a brand to browse its library</p>
+                                    {brands.length === 0 ? (
+                                        <div className="text-center py-12 text-gray-500">No brands found. Create a brand first.</div>
+                                    ) : (
+                                        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                                            {brands.map(brand => (
+                                                <div key={brand.id}
+                                                     onClick={() => handleLibrarySelectBrand(brand)}
+                                                     className="border-2 border-gray-200 rounded-lg p-4 cursor-pointer hover:border-indigo-300 hover:bg-indigo-50 transition-all">
+                                                    <div className="flex items-center gap-3">
+                                                        {brand.logo_url ? (
+                                                            <img src={brand.logo_url} alt={brand.name}
+                                                                 className="w-12 h-12 rounded-lg object-cover border border-gray-200" />
                                                         ) : (
-                                                            <div className="w-full h-full flex items-center justify-center bg-gray-800">
-                                                                <Film size={32} className="text-gray-500" />
+                                                            <div className="w-12 h-12 rounded-lg flex items-center justify-center text-white font-bold text-lg"
+                                                                 style={{ backgroundColor: brand.primary_color || '#d97706' }}>
+                                                                {brand.name?.charAt(0)?.toUpperCase() || 'B'}
                                                             </div>
-                                                        )
-                                                    ) : (
-                                                        <img src={item.media_url} alt={item.name} className="w-full h-full object-cover" />
-                                                    )}
-                                                </div>
-                                                {isSelected && (
-                                                    <div className="absolute top-2 right-2 w-6 h-6 bg-indigo-600 rounded-full flex items-center justify-center">
-                                                        <Check size={14} className="text-white" />
+                                                        )}
+                                                        <div>
+                                                            <p className="font-medium text-gray-900">{brand.name}</p>
+                                                        </div>
                                                     </div>
-                                                )}
-                                                <span className="absolute top-2 left-2 px-2 py-0.5 bg-black/60 text-white text-xs rounded">
-                                                    {item.media_type}
-                                                </span>
-                                                {item.variants && Object.keys(item.variants).length > 1 && (
-                                                    <span className="absolute bottom-12 left-2 px-2 py-0.5 bg-purple-600/90 text-white text-xs rounded">
-                                                        {Object.keys(item.variants).length} sizes
-                                                    </span>
-                                                )}
-                                                <div className="p-2">
-                                                    <p className="text-sm font-medium text-gray-900 truncate">{item.name}</p>
-                                                    <p className="text-xs text-gray-500 truncate">{item.brand_name}</p>
                                                 </div>
-                                            </div>
-                                        );
-                                    })}
+                                            ))}
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+
+                            {/* Step 2: Media Type Selection */}
+                            {libraryStep === 'mediaType' && (
+                                <div>
+                                    <p className="text-sm text-gray-500 mb-4">What type of media do you want to import?</p>
+                                    <div className="grid grid-cols-2 gap-6 max-w-lg mx-auto">
+                                        <div onClick={() => handleLibrarySelectMediaType('image')}
+                                             className="border-2 border-gray-200 rounded-xl p-8 cursor-pointer hover:border-indigo-300 hover:bg-indigo-50 transition-all text-center">
+                                            <Image size={48} className="mx-auto mb-3 text-indigo-600" />
+                                            <p className="font-semibold text-gray-900 text-lg">Images</p>
+                                            <p className="text-sm text-gray-500 mt-1">{libraryStats?.images ?? '...'} items</p>
+                                        </div>
+                                        <div onClick={() => handleLibrarySelectMediaType('video')}
+                                             className="border-2 border-gray-200 rounded-xl p-8 cursor-pointer hover:border-indigo-300 hover:bg-indigo-50 transition-all text-center">
+                                            <Film size={48} className="mx-auto mb-3 text-indigo-600" />
+                                            <p className="font-semibold text-gray-900 text-lg">Videos</p>
+                                            <p className="text-sm text-gray-500 mt-1">{libraryStats?.videos ?? '...'} items</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+
+                            {/* Step 3: Browse & Select Items */}
+                            {libraryStep === 'items' && (
+                                <div>
+                                    {/* Folder tabs */}
+                                    {libraryFolders.length > 0 && (
+                                        <div className="flex gap-2 mb-4 flex-wrap">
+                                            <button onClick={() => handleLibraryFolderChange(null)}
+                                                    className={`px-3 py-1.5 text-sm rounded-lg ${!librarySelectedFolder ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>
+                                                All
+                                            </button>
+                                            {libraryFolders.map(folder => (
+                                                <button key={folder.id}
+                                                        onClick={() => handleLibraryFolderChange(folder.id)}
+                                                        className={`px-3 py-1.5 text-sm rounded-lg ${librarySelectedFolder === folder.id ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>
+                                                    {folder.name} ({folder.item_count})
+                                                </button>
+                                            ))}
+                                            <button onClick={() => handleLibraryFolderChange('__none__')}
+                                                    className={`px-3 py-1.5 text-sm rounded-lg ${librarySelectedFolder === '__none__' ? 'bg-indigo-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>
+                                                Uncategorized
+                                            </button>
+                                        </div>
+                                    )}
+
+                                    {libraryLoading ? (
+                                        <div className="flex items-center justify-center py-12">
+                                            <Loader className="animate-spin text-amber-600" size={24} />
+                                        </div>
+                                    ) : libraryItems.length === 0 ? (
+                                        <div className="text-center py-12 text-gray-500">
+                                            No items found. Upload media in the Ads Library first.
+                                        </div>
+                                    ) : (
+                                        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                                            {libraryItems.map(item => {
+                                                const isSelected = selectedLibraryItems.has(item.id);
+                                                return (
+                                                    <div key={item.id}
+                                                         onClick={() => toggleLibrarySelection(item.id)}
+                                                         className={`relative rounded-lg border-2 overflow-hidden cursor-pointer transition-all ${
+                                                             isSelected
+                                                                 ? 'border-indigo-600 ring-2 ring-indigo-200'
+                                                                 : 'border-gray-200 hover:border-indigo-300'
+                                                         }`}>
+                                                        <div className="aspect-square bg-gray-100">
+                                                            {item.media_type === 'video' ? (
+                                                                item.thumbnail_url ? (
+                                                                    <img src={item.thumbnail_url} alt={item.name} className="w-full h-full object-cover" />
+                                                                ) : (
+                                                                    <div className="w-full h-full flex items-center justify-center bg-gray-800">
+                                                                        <Film size={32} className="text-gray-500" />
+                                                                    </div>
+                                                                )
+                                                            ) : (
+                                                                <img src={item.media_url} alt={item.name} className="w-full h-full object-cover" loading="lazy" />
+                                                            )}
+                                                        </div>
+                                                        {isSelected && (
+                                                            <div className="absolute top-2 right-2 w-6 h-6 bg-indigo-600 rounded-full flex items-center justify-center">
+                                                                <Check size={14} className="text-white" />
+                                                            </div>
+                                                        )}
+                                                        {item.variants && Object.keys(item.variants).length > 1 && (
+                                                            <span className="absolute bottom-12 left-2 px-2 py-0.5 bg-purple-600/90 text-white text-xs rounded">
+                                                                {Object.keys(item.variants).length} sizes
+                                                            </span>
+                                                        )}
+                                                        <div className="p-2">
+                                                            <p className="text-sm font-medium text-gray-900 truncate">{item.name}</p>
+                                                        </div>
+                                                    </div>
+                                                );
+                                            })}
+                                        </div>
+                                    )}
                                 </div>
                             )}
                         </div>
 
                         {/* Modal Footer */}
                         <div className="p-4 border-t border-gray-200 flex justify-between items-center">
-                            <button onClick={() => { setShowLibraryModal(false); setSelectedLibraryItems(new Set()); }}
+                            <button onClick={resetLibraryModal}
                                     className="px-4 py-2 text-gray-600 hover:bg-gray-100 rounded-lg">
                                 Cancel
                             </button>
-                            <button onClick={handleImportFromLibrary}
-                                    disabled={selectedLibraryItems.size === 0}
-                                    className="px-6 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 font-medium disabled:opacity-50 disabled:cursor-not-allowed">
-                                Import {selectedLibraryItems.size > 0 ? `(${selectedLibraryItems.size})` : ''}
-                            </button>
+                            {libraryStep === 'items' && (
+                                <div className="flex items-center gap-3">
+                                    {selectedLibraryItems.size > 0 && (
+                                        <span className="text-sm text-indigo-600 font-medium">
+                                            {selectedLibraryItems.size} selected
+                                        </span>
+                                    )}
+                                    <button onClick={handleImportFromLibrary}
+                                            disabled={selectedLibraryItems.size === 0}
+                                            className="px-6 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 font-medium disabled:opacity-50 disabled:cursor-not-allowed">
+                                        Import {selectedLibraryItems.size > 0 ? `(${selectedLibraryItems.size})` : ''}
+                                    </button>
+                                </div>
+                            )}
                         </div>
                     </div>
                 </div>

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { ChevronRight, ChevronLeft, Upload, X, Loader, Trash2, Film, Image, Sparkles, Play, FolderOpen, Check } from 'lucide-react';
 import { useCampaign } from '../context/CampaignContext';
 import { useAuth } from '../context/AuthContext';
-import { getPages } from '../lib/facebookApi';
+import { getPages, getPageInfo } from '../lib/facebookApi';
 import { getLibraryItems } from '../api/adsLibrary';
 import { useBrands } from '../context/BrandContext';
 
@@ -233,20 +233,33 @@ const AdCreativeStep = ({ onNext, onBack }) => {
         } catch { return []; }
     };
 
-    const mergePages = (fetchedPages) => {
+    const mergePages = async (fetchedPages) => {
         const savedPages = loadSavedManualPages();
         const fetchedIds = new Set(fetchedPages.map(p => p.id));
 
-        // Update saved pages with real names from API if they had generic names
+        // Update saved pages with real names - from fetched list or individual lookup
         let needsSave = false;
-        const updatedSaved = savedPages.map(sp => {
+        const updatedSaved = await Promise.all(savedPages.map(async (sp) => {
+            if (!sp.name.startsWith('Page ')) return sp; // already has real name
+
+            // Check fetched pages first
             const fetched = fetchedPages.find(fp => fp.id === sp.id);
-            if (fetched && sp.name.startsWith('Page ')) {
+            if (fetched) {
                 needsSave = true;
                 return { ...sp, name: fetched.name };
             }
+
+            // Look up individually via Graph API
+            try {
+                const info = await getPageInfo(sp.id);
+                if (info?.name) {
+                    needsSave = true;
+                    return { ...sp, name: info.name };
+                }
+            } catch (e) { /* keep generic name */ }
             return sp;
-        });
+        }));
+
         if (needsSave) {
             localStorage.setItem('savedManualPages', JSON.stringify(updatedSaved));
         }
@@ -264,14 +277,14 @@ const AdCreativeStep = ({ onNext, onBack }) => {
             return;
         }
 
-        // Try to fetch the page name from the API
+        // Fetch the real page name from Facebook Graph API
         let pageName = `Page ${pageId}`;
         try {
-            const fetchedPages = await getPages(selectedAdAccount?.id);
-            const match = fetchedPages.find(p => p.id === pageId);
-            if (match?.name) pageName = match.name;
+            const pageInfo = await getPageInfo(pageId);
+            if (pageInfo?.name) pageName = pageInfo.name;
         } catch (e) {
-            // Silently fall back to generic name
+            // Fall back to generic name if lookup fails
+            console.warn('Could not look up page name:', e);
         }
 
         const updated = [...savedPages, { id: pageId, name: pageName }];
@@ -280,14 +293,14 @@ const AdCreativeStep = ({ onNext, onBack }) => {
             if (prev.some(p => p.id === pageId)) return prev;
             return [...prev, { id: pageId, name: pageName }];
         });
-        showSuccess('Page ID saved to dropdown list');
+        showSuccess(`Saved: ${pageName}`);
     };
 
     const fetchPages = async () => {
         setLoadingPages(true);
         try {
             const fetchedPages = await getPages(selectedAdAccount.id);
-            const combined = mergePages(fetchedPages);
+            const combined = await mergePages(fetchedPages);
             setPages(combined);
 
             // If no page is selected and we have pages, select the first one (or the last used one if it exists in the list)

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -397,7 +397,7 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                 localStorage.setItem(`defaultHeadlines_${selectedAdAccount.id}`, JSON.stringify(allHeadlines));
             }
 
-            const providerName = provider === 'claude' ? 'Claude Haiku' : 'Gemini';
+            const providerName = provider === 'transcribe_haiku' ? 'Transcribe + Haiku' : provider === 'claude' ? 'Claude Haiku' : 'Gemini';
             showSuccess(`${providerName} ad copy appended (${newBodies.length} bodies, ${newHeadlines.length} headlines)`);
         } catch (error) {
             console.error('Video analysis error:', error);
@@ -643,13 +643,24 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                                                             </div>
                                                         </button>
                                                         <button
+                                                            onClick={() => handleAnalyzeVideo(creative, 'transcribe_haiku')}
+                                                            className="w-full px-3 py-2 text-left text-sm hover:bg-green-50 flex items-center gap-2"
+                                                        >
+                                                            <Sparkles size={14} className="text-green-500" />
+                                                            <div>
+                                                                <div className="font-medium text-gray-800">Transcribe + Haiku</div>
+                                                                <div className="text-xs text-gray-500">Gemini transcribes → Haiku writes copy</div>
+                                                            </div>
+                                                        </button>
+                                                        <div className="border-t border-gray-100 my-1"></div>
+                                                        <button
                                                             onClick={() => handleAnalyzeVideo(creative, 'claude')}
                                                             className="w-full px-3 py-2 text-left text-sm hover:bg-purple-50 flex items-center gap-2"
                                                         >
                                                             <Sparkles size={14} className="text-purple-500" />
                                                             <div>
                                                                 <div className="font-medium text-gray-800">Claude Haiku</div>
-                                                                <div className="text-xs text-gray-500">Analyzes video frames</div>
+                                                                <div className="text-xs text-gray-500">Frames only (no audio)</div>
                                                             </div>
                                                         </button>
                                                     </div>
@@ -683,14 +694,34 @@ const AdCreativeStep = ({ onNext, onBack }) => {
 
                     {/* AI Video Analysis Loading Banner */}
                     {analyzingVideoId && (
-                        <div className={`flex items-center gap-3 ${analyzingProvider === 'claude' ? 'bg-purple-50 border-purple-200' : 'bg-amber-50 border-amber-200'} border rounded-lg p-4 mb-4`}>
-                            <Loader className={`animate-spin ${analyzingProvider === 'claude' ? 'text-purple-600' : 'text-amber-600'}`} size={20} />
+                        <div className={`flex items-center gap-3 ${
+                            analyzingProvider === 'transcribe_haiku' ? 'bg-green-50 border-green-200'
+                            : analyzingProvider === 'claude' ? 'bg-purple-50 border-purple-200'
+                            : 'bg-amber-50 border-amber-200'
+                        } border rounded-lg p-4 mb-4`}>
+                            <Loader className={`animate-spin ${
+                                analyzingProvider === 'transcribe_haiku' ? 'text-green-600'
+                                : analyzingProvider === 'claude' ? 'text-purple-600'
+                                : 'text-amber-600'
+                            }`} size={20} />
                             <div>
-                                <p className={`${analyzingProvider === 'claude' ? 'text-purple-800' : 'text-amber-800'} font-medium`}>
-                                    Analyzing video with {analyzingProvider === 'claude' ? 'Claude Haiku' : 'Gemini 2.0 Flash'}...
+                                <p className={`${
+                                    analyzingProvider === 'transcribe_haiku' ? 'text-green-800'
+                                    : analyzingProvider === 'claude' ? 'text-purple-800'
+                                    : 'text-amber-800'
+                                } font-medium`}>
+                                    {analyzingProvider === 'transcribe_haiku'
+                                        ? 'Transcribing audio + generating copy with Haiku...'
+                                        : `Analyzing video with ${analyzingProvider === 'claude' ? 'Claude Haiku' : 'Gemini 2.0 Flash'}...`}
                                 </p>
-                                <p className={`${analyzingProvider === 'claude' ? 'text-purple-600' : 'text-amber-600'} text-sm`}>
-                                    {analyzingProvider === 'claude'
+                                <p className={`${
+                                    analyzingProvider === 'transcribe_haiku' ? 'text-green-600'
+                                    : analyzingProvider === 'claude' ? 'text-purple-600'
+                                    : 'text-amber-600'
+                                } text-sm`}>
+                                    {analyzingProvider === 'transcribe_haiku'
+                                        ? 'Step 1: Gemini transcribes audio → Step 2: Haiku writes DR copy. This may take 60-90 seconds.'
+                                        : analyzingProvider === 'claude'
                                         ? 'Extracting key frames and generating ad copy. This may take 30-60 seconds.'
                                         : 'Watching your video and generating ad copy. This may take 30-60 seconds.'}
                                 </p>

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -630,6 +630,84 @@ const AdCreativeStep = ({ onNext, onBack }) => {
         }
     };
 
+    const handleAnalyzeImage = async (creative, provider = 'haiku') => {
+        if (!creative.file) {
+            showWarning('Cannot analyze images added via URL');
+            return;
+        }
+
+        setAnalyzingVideoId(creative.id);
+        setAnalyzingProvider(provider === 'gemini' ? 'gemini' : 'haiku');
+        setProviderMenuId(null);
+        try {
+            const formData = new FormData();
+            formData.append('file', creative.file);
+
+            const response = await authFetch(`${API_URL}/video-analysis/analyze-image?provider=${provider}`, {
+                method: 'POST',
+                body: formData,
+            });
+
+            if (!response.ok) {
+                const err = await response.json().catch(() => ({}));
+                throw new Error(err.detail || 'Image analysis failed');
+            }
+
+            const data = await response.json();
+            const newBodies = (data.bodies || []).filter(b => b && b.trim());
+            const newHeadlines = (data.headlines || []).filter(h => h && h.trim());
+
+            if (isPerCreative) {
+                // In per-creative mode, put copy on the specific creative
+                const idx = creativeData.creatives.findIndex(c => c.id === creative.id);
+                if (idx !== -1) {
+                    setCreativeData(prev => {
+                        const updated = [...prev.creatives];
+                        const existing = updated[idx];
+                        const existingBodies = (existing.bodies || []).filter(b => b && b.trim());
+                        const existingHeadlines = (existing.headlines || []).filter(h => h && h.trim());
+                        updated[idx] = {
+                            ...existing,
+                            bodies: [...existingBodies, ...newBodies].slice(0, 6),
+                            headlines: [...existingHeadlines, ...newHeadlines].slice(0, 6),
+                        };
+                        if (updated[idx].bodies.length === 0) updated[idx].bodies = [''];
+                        if (updated[idx].headlines.length === 0) updated[idx].headlines = [''];
+                        return { ...prev, creatives: updated };
+                    });
+                    setCurrentCreativeIndex(idx);
+                }
+            } else {
+                // Standard mode: merge into global copy fields
+                setCreativeData(prev => {
+                    const existingBodies = prev.bodies.filter(b => b && b.trim());
+                    const existingHeadlines = prev.headlines.filter(h => h && h.trim());
+                    const mergedBodies = [...existingBodies, ...newBodies].slice(0, 6);
+                    const mergedHeadlines = [...existingHeadlines, ...newHeadlines].slice(0, 6);
+                    if (mergedBodies.length === 0) mergedBodies.push('');
+                    if (mergedHeadlines.length === 0) mergedHeadlines.push('');
+                    return { ...prev, bodies: mergedBodies, headlines: mergedHeadlines };
+                });
+
+                if (selectedAdAccount) {
+                    const existingBodies = creativeData.bodies.filter(b => b && b.trim());
+                    const existingHeadlines = creativeData.headlines.filter(h => h && h.trim());
+                    localStorage.setItem(`defaultBodies_${selectedAdAccount.id}`, JSON.stringify([...existingBodies, ...newBodies].slice(0, 6)));
+                    localStorage.setItem(`defaultHeadlines_${selectedAdAccount.id}`, JSON.stringify([...existingHeadlines, ...newHeadlines].slice(0, 6)));
+                }
+            }
+
+            const providerName = provider === 'gemini' ? 'Gemini' : 'Claude Haiku';
+            showSuccess(`${providerName} ad copy generated (${newBodies.length} bodies, ${newHeadlines.length} headlines)`);
+        } catch (error) {
+            console.error('Image analysis error:', error);
+            showError(error.message || 'Failed to analyze image');
+        } finally {
+            setAnalyzingVideoId(null);
+            setAnalyzingProvider(null);
+        }
+    };
+
     const handleNext = () => {
         // Validate required fields
         if (!creativeData.creativeName) {
@@ -909,53 +987,79 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                                         )}
                                     </div>
                                     <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-30 transition-all flex items-center justify-center gap-2 opacity-0 group-hover:opacity-100">
-                                        {creative.mediaType === 'video' && (
-                                            <div className="relative">
-                                                <button
-                                                    onClick={() => setProviderMenuId(providerMenuId === creative.id ? null : creative.id)}
-                                                    disabled={analyzingVideoId !== null}
-                                                    className="p-2 bg-amber-500 text-white rounded-full hover:bg-amber-600 transform scale-90 hover:scale-100 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-                                                    title="Analyze video with AI"
-                                                >
-                                                    <Sparkles size={16} />
-                                                </button>
-                                                {providerMenuId === creative.id && (
-                                                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 bg-white rounded-lg shadow-xl border border-gray-200 py-1 w-52 z-50">
-                                                        <button
-                                                            onClick={() => handleAnalyzeVideo(creative, 'gemini')}
-                                                            className="w-full px-3 py-2 text-left text-sm hover:bg-amber-50 flex items-center gap-2"
-                                                        >
-                                                            <Sparkles size={14} className="text-amber-500" />
-                                                            <div>
-                                                                <div className="font-medium text-gray-800">Gemini 2.0 Flash</div>
-                                                                <div className="text-xs text-gray-500">Analyzes video + audio</div>
-                                                            </div>
-                                                        </button>
-                                                        <button
-                                                            onClick={() => handleAnalyzeVideo(creative, 'transcribe_haiku')}
-                                                            className="w-full px-3 py-2 text-left text-sm hover:bg-green-50 flex items-center gap-2"
-                                                        >
-                                                            <Sparkles size={14} className="text-green-500" />
-                                                            <div>
-                                                                <div className="font-medium text-gray-800">Transcribe + Haiku</div>
-                                                                <div className="text-xs text-gray-500">Gemini transcribes → Haiku writes copy</div>
-                                                            </div>
-                                                        </button>
-                                                        <div className="border-t border-gray-100 my-1"></div>
-                                                        <button
-                                                            onClick={() => handleAnalyzeVideo(creative, 'claude')}
-                                                            className="w-full px-3 py-2 text-left text-sm hover:bg-purple-50 flex items-center gap-2"
-                                                        >
-                                                            <Sparkles size={14} className="text-purple-500" />
-                                                            <div>
-                                                                <div className="font-medium text-gray-800">Claude Haiku</div>
-                                                                <div className="text-xs text-gray-500">Frames only (no audio)</div>
-                                                            </div>
-                                                        </button>
-                                                    </div>
-                                                )}
-                                            </div>
-                                        )}
+                                        {/* AI Analyze Button — works for both images and videos */}
+                                        <div className="relative">
+                                            <button
+                                                onClick={() => setProviderMenuId(providerMenuId === creative.id ? null : creative.id)}
+                                                disabled={analyzingVideoId !== null}
+                                                className="p-2 bg-amber-500 text-white rounded-full hover:bg-amber-600 transform scale-90 hover:scale-100 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                                                title={`Generate ad copy with AI`}
+                                            >
+                                                <Sparkles size={16} />
+                                            </button>
+                                            {providerMenuId === creative.id && (
+                                                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 bg-white rounded-lg shadow-xl border border-gray-200 py-1 w-52 z-50">
+                                                    {creative.mediaType === 'video' ? (
+                                                        <>
+                                                            <button
+                                                                onClick={() => handleAnalyzeVideo(creative, 'gemini')}
+                                                                className="w-full px-3 py-2 text-left text-sm hover:bg-amber-50 flex items-center gap-2"
+                                                            >
+                                                                <Sparkles size={14} className="text-amber-500" />
+                                                                <div>
+                                                                    <div className="font-medium text-gray-800">Gemini 2.0 Flash</div>
+                                                                    <div className="text-xs text-gray-500">Analyzes video + audio</div>
+                                                                </div>
+                                                            </button>
+                                                            <button
+                                                                onClick={() => handleAnalyzeVideo(creative, 'transcribe_haiku')}
+                                                                className="w-full px-3 py-2 text-left text-sm hover:bg-green-50 flex items-center gap-2"
+                                                            >
+                                                                <Sparkles size={14} className="text-green-500" />
+                                                                <div>
+                                                                    <div className="font-medium text-gray-800">Transcribe + Haiku</div>
+                                                                    <div className="text-xs text-gray-500">Gemini transcribes → Haiku writes copy</div>
+                                                                </div>
+                                                            </button>
+                                                            <div className="border-t border-gray-100 my-1"></div>
+                                                            <button
+                                                                onClick={() => handleAnalyzeVideo(creative, 'claude')}
+                                                                className="w-full px-3 py-2 text-left text-sm hover:bg-purple-50 flex items-center gap-2"
+                                                            >
+                                                                <Sparkles size={14} className="text-purple-500" />
+                                                                <div>
+                                                                    <div className="font-medium text-gray-800">Claude Haiku</div>
+                                                                    <div className="text-xs text-gray-500">Frames only (no audio)</div>
+                                                                </div>
+                                                            </button>
+                                                        </>
+                                                    ) : (
+                                                        <>
+                                                            <button
+                                                                onClick={() => handleAnalyzeImage(creative, 'haiku')}
+                                                                className="w-full px-3 py-2 text-left text-sm hover:bg-purple-50 flex items-center gap-2"
+                                                            >
+                                                                <Sparkles size={14} className="text-purple-500" />
+                                                                <div>
+                                                                    <div className="font-medium text-gray-800">Claude Haiku</div>
+                                                                    <div className="text-xs text-gray-500">Analyzes image + generates DR copy</div>
+                                                                </div>
+                                                            </button>
+                                                            <button
+                                                                onClick={() => handleAnalyzeImage(creative, 'gemini')}
+                                                                className="w-full px-3 py-2 text-left text-sm hover:bg-amber-50 flex items-center gap-2"
+                                                            >
+                                                                <Sparkles size={14} className="text-amber-500" />
+                                                                <div>
+                                                                    <div className="font-medium text-gray-800">Gemini 2.0 Flash</div>
+                                                                    <div className="text-xs text-gray-500">Analyzes image + generates DR copy</div>
+                                                                </div>
+                                                            </button>
+                                                        </>
+                                                    )}
+                                                </div>
+                                            )}
+                                        </div>
                                         {creative.mediaType === 'video' && (
                                             <button
                                                 onClick={() => setPlayingVideo(creative)}
@@ -981,38 +1085,44 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                         </div>
                     )}
 
-                    {/* AI Video Analysis Loading Banner */}
+                    {/* AI Analysis Loading Banner */}
                     {analyzingVideoId && (
                         <div className={`flex items-center gap-3 ${
                             analyzingProvider === 'transcribe_haiku' ? 'bg-green-50 border-green-200'
-                            : analyzingProvider === 'claude' ? 'bg-purple-50 border-purple-200'
+                            : analyzingProvider === 'haiku' || analyzingProvider === 'claude' ? 'bg-purple-50 border-purple-200'
                             : 'bg-amber-50 border-amber-200'
                         } border rounded-lg p-4 mb-4`}>
                             <Loader className={`animate-spin ${
                                 analyzingProvider === 'transcribe_haiku' ? 'text-green-600'
-                                : analyzingProvider === 'claude' ? 'text-purple-600'
+                                : analyzingProvider === 'haiku' || analyzingProvider === 'claude' ? 'text-purple-600'
                                 : 'text-amber-600'
                             }`} size={20} />
                             <div>
                                 <p className={`${
                                     analyzingProvider === 'transcribe_haiku' ? 'text-green-800'
-                                    : analyzingProvider === 'claude' ? 'text-purple-800'
+                                    : analyzingProvider === 'haiku' || analyzingProvider === 'claude' ? 'text-purple-800'
                                     : 'text-amber-800'
                                 } font-medium`}>
                                     {analyzingProvider === 'transcribe_haiku'
                                         ? 'Transcribing audio + generating copy with Haiku...'
-                                        : `Analyzing video with ${analyzingProvider === 'claude' ? 'Claude Haiku' : 'Gemini 2.0 Flash'}...`}
+                                        : analyzingProvider === 'haiku'
+                                        ? 'Analyzing image with Claude Haiku...'
+                                        : analyzingProvider === 'claude'
+                                        ? 'Analyzing video with Claude Haiku...'
+                                        : 'Analyzing with Gemini 2.0 Flash...'}
                                 </p>
                                 <p className={`${
                                     analyzingProvider === 'transcribe_haiku' ? 'text-green-600'
-                                    : analyzingProvider === 'claude' ? 'text-purple-600'
+                                    : analyzingProvider === 'haiku' || analyzingProvider === 'claude' ? 'text-purple-600'
                                     : 'text-amber-600'
                                 } text-sm`}>
                                     {analyzingProvider === 'transcribe_haiku'
                                         ? 'Step 1: Gemini transcribes audio → Step 2: Haiku writes DR copy. This may take 60-90 seconds.'
+                                        : analyzingProvider === 'haiku'
+                                        ? 'Generating direct-response ad copy from your image. This may take 10-20 seconds.'
                                         : analyzingProvider === 'claude'
                                         ? 'Extracting key frames and generating ad copy. This may take 30-60 seconds.'
-                                        : 'Watching your video and generating ad copy. This may take 30-60 seconds.'}
+                                        : 'Generating ad copy. This may take 15-30 seconds.'}
                                 </p>
                             </div>
                         </div>

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -134,8 +134,9 @@ const AdCreativeStep = ({ onNext, onBack }) => {
         const newCreatives = selected.map(item => ({
             id: `creative_lib_${item.id}_${Date.now()}`,
             previewUrl: item.media_type === 'video'
-                ? (item.thumbnail_url || item.media_url)
+                ? item.media_url
                 : item.media_url,
+            thumbnailUrl: item.media_type === 'video' ? item.thumbnail_url : undefined,
             imageUrl: item.media_type === 'image' ? item.media_url : undefined,
             videoUrl: item.media_type === 'video' ? item.media_url : undefined,
             name: item.name || 'Library Import',
@@ -680,14 +681,23 @@ const AdCreativeStep = ({ onNext, onBack }) => {
                             {creativeData.creatives.map((creative) => (
                                 <div key={creative.id} className="relative group border rounded-lg overflow-hidden aspect-square bg-gray-100">
                                     {creative.mediaType === 'video' ? (
-                                        <video
-                                            src={creative.previewUrl}
-                                            className="w-full h-full object-cover"
-                                            muted
-                                            playsInline
-                                            onMouseEnter={(e) => e.target.play()}
-                                            onMouseLeave={(e) => { e.target.pause(); e.target.currentTime = 0; }}
-                                        />
+                                        creative.thumbnailUrl ? (
+                                            <img
+                                                src={creative.thumbnailUrl}
+                                                alt={creative.name}
+                                                className="w-full h-full object-cover"
+                                            />
+                                        ) : (
+                                            <video
+                                                src={creative.previewUrl}
+                                                className="w-full h-full object-cover"
+                                                muted
+                                                playsInline
+                                                poster={creative.thumbnailUrl || undefined}
+                                                onMouseEnter={(e) => e.target.play().catch(() => {})}
+                                                onMouseLeave={(e) => { e.target.pause(); e.target.currentTime = 0; }}
+                                            />
+                                        )
                                     ) : (
                                         <img
                                             src={creative.previewUrl}

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -236,11 +236,26 @@ const AdCreativeStep = ({ onNext, onBack }) => {
     const mergePages = (fetchedPages) => {
         const savedPages = loadSavedManualPages();
         const fetchedIds = new Set(fetchedPages.map(p => p.id));
-        const uniqueSaved = savedPages.filter(p => !fetchedIds.has(p.id));
+
+        // Update saved pages with real names from API if they had generic names
+        let needsSave = false;
+        const updatedSaved = savedPages.map(sp => {
+            const fetched = fetchedPages.find(fp => fp.id === sp.id);
+            if (fetched && sp.name.startsWith('Page ')) {
+                needsSave = true;
+                return { ...sp, name: fetched.name };
+            }
+            return sp;
+        });
+        if (needsSave) {
+            localStorage.setItem('savedManualPages', JSON.stringify(updatedSaved));
+        }
+
+        const uniqueSaved = updatedSaved.filter(p => !fetchedIds.has(p.id));
         return [...fetchedPages, ...uniqueSaved];
     };
 
-    const handleSaveManualPage = () => {
+    const handleSaveManualPage = async () => {
         const pageId = creativeData.pageId?.trim();
         if (!pageId) return;
         const savedPages = loadSavedManualPages();
@@ -248,11 +263,22 @@ const AdCreativeStep = ({ onNext, onBack }) => {
             showWarning('This Page ID is already saved');
             return;
         }
-        const updated = [...savedPages, { id: pageId, name: `Page ${pageId}` }];
+
+        // Try to fetch the page name from the API
+        let pageName = `Page ${pageId}`;
+        try {
+            const fetchedPages = await getPages(selectedAdAccount?.id);
+            const match = fetchedPages.find(p => p.id === pageId);
+            if (match?.name) pageName = match.name;
+        } catch (e) {
+            // Silently fall back to generic name
+        }
+
+        const updated = [...savedPages, { id: pageId, name: pageName }];
         localStorage.setItem('savedManualPages', JSON.stringify(updated));
         setPages(prev => {
             if (prev.some(p => p.id === pageId)) return prev;
-            return [...prev, { id: pageId, name: `Page ${pageId}` }];
+            return [...prev, { id: pageId, name: pageName }];
         });
         showSuccess('Page ID saved to dropdown list');
     };

--- a/frontend/src/components/BulkAdCreation.jsx
+++ b/frontend/src/components/BulkAdCreation.jsx
@@ -10,7 +10,7 @@ const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api/v1';
 const BulkAdCreation = ({ onNext, onBack }) => {
     const { showWarning, showError } = useToast();
     const { authFetch } = useAuth();
-    const { campaignData, adsetData, creativeData, adsData, setAdsData, selectedAdAccount } = useCampaign();
+    const { campaignData, adsetData, creativeData, adsData, setAdsData, selectedAdAccount, setAddingNewAd } = useCampaign();
     const [loading, setLoading] = useState(false);
     const [progress, setProgress] = useState({ current: 0, total: 0, status: '' });
     const [errors, setErrors] = useState([]);
@@ -403,7 +403,7 @@ const BulkAdCreation = ({ onNext, onBack }) => {
 
                     {/* Add Ad Button — goes back to Ad Creative to add more media/copy */}
                     <button
-                        onClick={onBack}
+                        onClick={() => { setAddingNewAd(true); onBack(); }}
                         className="w-full p-4 border-2 border-dashed border-gray-300 rounded-lg text-gray-600 hover:border-amber-500 hover:text-amber-600 transition-colors flex items-center justify-center gap-2"
                     >
                         <Plus size={20} />

--- a/frontend/src/components/BulkAdCreation.jsx
+++ b/frontend/src/components/BulkAdCreation.jsx
@@ -18,39 +18,61 @@ const BulkAdCreation = ({ onNext, onBack }) => {
     // Initialize ads based on creatives - generate all permutations
     React.useEffect(() => {
         if (creativeData.creatives && creativeData.creatives.length > 0) {
-            // Filter out empty headlines and bodies
-            const validHeadlines = creativeData.headlines.filter(h => h && h.trim() !== '');
-            const validBodies = creativeData.bodies.filter(b => b && b.trim() !== '');
-
-            // Generate all permutations: media × headlines × bodies
             const permutations = [];
-            creativeData.creatives.forEach((creative, creativeIndex) => {
-                validHeadlines.forEach((headline, hIndex) => {
-                    validBodies.forEach((body, bIndex) => {
-                        const isVideo = creative.mediaType === 'video';
-                        const mediaLabel = isVideo ? 'Video' : 'Image';
-                        permutations.push({
-                            id: `ad_${Date.now()}_${creativeIndex}_${hIndex}_${bIndex}`,
-                            name: `${creative.name || `${mediaLabel} ${creativeIndex + 1}`} - H${hIndex + 1}B${bIndex + 1}`,
-                            creativeId: creative.id,
-                            headlineIndex: hIndex,
-                            bodyIndex: bIndex,
-                            mediaType: creative.mediaType || 'image',
-                            useDefaultCreative: true
+
+            if (creativeData.creativeMode === 'per_creative') {
+                // Per-creative mode: each creative has its own headlines/bodies
+                creativeData.creatives.forEach((creative, creativeIndex) => {
+                    const validHeadlines = (creative.headlines || ['']).filter(h => h && h.trim() !== '');
+                    const validBodies = (creative.bodies || ['']).filter(b => b && b.trim() !== '');
+                    const isVideo = creative.mediaType === 'video';
+                    const mediaLabel = isVideo ? 'Video' : 'Image';
+
+                    validHeadlines.forEach((headline, hIndex) => {
+                        validBodies.forEach((body, bIndex) => {
+                            permutations.push({
+                                id: `ad_${Date.now()}_${creativeIndex}_${hIndex}_${bIndex}`,
+                                name: `${creative.name || `${mediaLabel} ${creativeIndex + 1}`}${validHeadlines.length > 1 || validBodies.length > 1 ? ` - H${hIndex + 1}B${bIndex + 1}` : ''}`,
+                                creativeId: creative.id,
+                                headlineIndex: hIndex,
+                                bodyIndex: bIndex,
+                                mediaType: creative.mediaType || 'image',
+                                useDefaultCreative: true,
+                                perCreative: true
+                            });
                         });
                     });
                 });
-            });
+            } else {
+                // Standard mode: shared headlines/bodies across all creatives
+                const validHeadlines = creativeData.headlines.filter(h => h && h.trim() !== '');
+                const validBodies = creativeData.bodies.filter(b => b && b.trim() !== '');
+
+                creativeData.creatives.forEach((creative, creativeIndex) => {
+                    validHeadlines.forEach((headline, hIndex) => {
+                        validBodies.forEach((body, bIndex) => {
+                            const isVideo = creative.mediaType === 'video';
+                            const mediaLabel = isVideo ? 'Video' : 'Image';
+                            permutations.push({
+                                id: `ad_${Date.now()}_${creativeIndex}_${hIndex}_${bIndex}`,
+                                name: `${creative.name || `${mediaLabel} ${creativeIndex + 1}`} - H${hIndex + 1}B${bIndex + 1}`,
+                                creativeId: creative.id,
+                                headlineIndex: hIndex,
+                                bodyIndex: bIndex,
+                                mediaType: creative.mediaType || 'image',
+                                useDefaultCreative: true
+                            });
+                        });
+                    });
+                });
+            }
 
             setAdsData(permutations);
-            const imageCount = creativeData.creatives.filter(c => c.mediaType !== 'video').length;
-            const videoCount = creativeData.creatives.filter(c => c.mediaType === 'video').length;
-            console.log(`Generated ${permutations.length} ad permutations (${imageCount} images + ${videoCount} videos × ${validHeadlines.length} headlines × ${validBodies.length} bodies)`);
+            console.log(`Generated ${permutations.length} ad permutations (${creativeData.creativeMode} mode)`);
         } else {
-            // Fallback if no creatives (shouldn't happen due to validation)
             setAdsData([]);
         }
-    }, [creativeData.creatives, creativeData.headlines, creativeData.bodies]);
+    }, [creativeData.creatives, creativeData.headlines, creativeData.bodies, creativeData.creativeMode]);
 
     const addAd = () => {
         setAdsData(prev => [
@@ -167,6 +189,23 @@ const BulkAdCreation = ({ onNext, onBack }) => {
                     const isVideo = specificCreative?.mediaType === 'video';
 
                     // Construct creative data for this specific ad with specific headline and body
+                    let adHeadlines, adBodies, adDescription, adCta;
+                    if (ad.perCreative && specificCreative) {
+                        // Per-creative mode: pull copy from the creative object
+                        const cHeadlines = (specificCreative.headlines || []).filter(h => h && h.trim());
+                        const cBodies = (specificCreative.bodies || []).filter(b => b && b.trim());
+                        adHeadlines = [cHeadlines[ad.headlineIndex] || cHeadlines[0]];
+                        adBodies = [cBodies[ad.bodyIndex] || cBodies[0]];
+                        adDescription = specificCreative.description || creativeData.description;
+                        adCta = specificCreative.cta || creativeData.cta;
+                    } else {
+                        // Standard mode: pull from global copy fields
+                        adHeadlines = [creativeData.headlines[ad.headlineIndex]];
+                        adBodies = [creativeData.bodies[ad.bodyIndex]];
+                        adDescription = creativeData.description;
+                        adCta = creativeData.cta;
+                    }
+
                     const adSpecificCreativeData = {
                         ...creativeData,
                         mediaType: isVideo ? 'video' : 'image',
@@ -174,9 +213,10 @@ const BulkAdCreation = ({ onNext, onBack }) => {
                         videoUrl: isVideo ? (specificCreative?.videoUrl || specificCreative?.previewUrl) : undefined,
                         imageFile: !isVideo && specificCreative ? specificCreative.file : null,
                         videoFile: isVideo && specificCreative ? specificCreative.file : null,
-                        // Use specific headline and body for this ad permutation
-                        headlines: [creativeData.headlines[ad.headlineIndex]],
-                        bodies: [creativeData.bodies[ad.bodyIndex]]
+                        headlines: adHeadlines,
+                        bodies: adBodies,
+                        description: adDescription,
+                        cta: adCta
                     };
 
                     if (!creativeData.pageId) {
@@ -218,10 +258,10 @@ const BulkAdCreation = ({ onNext, onBack }) => {
                             videoUrl: adSpecificCreativeData.videoUrl,
                             videoId: result.videoId,
                             thumbnailUrl: result.thumbnailUrl,
-                            bodies: creativeData.bodies.filter(b => b.trim() !== ''),
-                            headlines: creativeData.headlines.filter(h => h.trim() !== ''),
-                            description: creativeData.description,
-                            cta: creativeData.cta,
+                            bodies: adBodies,
+                            headlines: adHeadlines,
+                            description: adDescription,
+                            cta: adCta,
                             websiteUrl: creativeData.websiteUrl,
                             status: 'PAUSED',
                             fbAdId: result.adId,
@@ -290,7 +330,7 @@ const BulkAdCreation = ({ onNext, onBack }) => {
                             return parts.join(', ') || '0 files';
                         })()}
                     </div>
-                    <div><strong>Ad Copy:</strong> Standard (Single Body & Headline)</div>
+                    <div><strong>Ad Copy:</strong> {creativeData.creativeMode === 'per_creative' ? 'Per Creative (unique copy per media)' : 'Standard (shared copy across all media)'}</div>
                 </div>
             </div>
 

--- a/frontend/src/components/BulkAdCreation.jsx
+++ b/frontend/src/components/BulkAdCreation.jsx
@@ -401,10 +401,10 @@ const BulkAdCreation = ({ onNext, onBack }) => {
                         })}
                     </div>
 
-                    {/* Add Ad Button */}
+                    {/* Add Ad Button — goes back to Ad Creative to add more media/copy */}
                     <button
-                        onClick={addAd}
-                        className="w-full p-4 border-2 border-dashed border-gray-300 rounded-lg text-gray-600 hover:border-blue-500 hover:text-blue-600 transition-colors flex items-center justify-center gap-2"
+                        onClick={onBack}
+                        className="w-full p-4 border-2 border-dashed border-gray-300 rounded-lg text-gray-600 hover:border-amber-500 hover:text-amber-600 transition-colors flex items-center justify-center gap-2"
                     >
                         <Plus size={20} />
                         Add Another Ad

--- a/frontend/src/components/BulkAdCreation.jsx
+++ b/frontend/src/components/BulkAdCreation.jsx
@@ -75,12 +75,22 @@ const BulkAdCreation = ({ onNext, onBack }) => {
     }, [creativeData.creatives, creativeData.headlines, creativeData.bodies, creativeData.creativeMode]);
 
     const addAd = () => {
+        // Clone from the last ad's creative or fall back to the first creative
+        const lastAd = adsData[adsData.length - 1];
+        const creative = creativeData.creatives?.find(c => c.id === lastAd?.creativeId) || creativeData.creatives?.[0];
+        const isPerCreative = creativeData.creativeMode === 'per_creative';
+
         setAdsData(prev => [
             ...prev,
             {
                 id: `ad_${Date.now()}_${prev.length}`,
-                name: `Ad ${prev.length + 1}`,
-                useDefaultCreative: true
+                name: `${creative?.name || 'Ad'} ${prev.length + 1}`,
+                creativeId: creative?.id,
+                headlineIndex: 0,
+                bodyIndex: 0,
+                mediaType: creative?.mediaType || 'image',
+                useDefaultCreative: true,
+                ...(isPerCreative ? { perCreative: true } : {})
             }
         ]);
     };

--- a/frontend/src/components/BulkAdCreation.jsx
+++ b/frontend/src/components/BulkAdCreation.jsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { ChevronRight, Plus, Trash2, Loader, Film, Image } from 'lucide-react';
 import { useCampaign } from '../context/CampaignContext';
 import { createCompleteAd, createFacebookCampaign, createFacebookAdSet } from '../lib/facebookApi';
+import { getClickflareStatus, generateTrackingUrl } from '../api/clickflare';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api/v1';
 
@@ -183,6 +184,23 @@ const BulkAdCreation = ({ onNext, onBack }) => {
                 throw err; // Stop execution
             }
 
+            // Step 2.5: Generate Clickflare tracking URL if configured
+            let effectiveWebsiteUrl = creativeData.websiteUrl;
+            try {
+                const cfStatus = await getClickflareStatus();
+                if (cfStatus.enabled && creativeData.websiteUrl) {
+                    setProgress(prev => ({ ...prev, status: 'Generating Clickflare tracking URL...' }));
+                    const cfResult = await generateTrackingUrl(
+                        campaignData.name || 'Ad Campaign',
+                        creativeData.websiteUrl,
+                    );
+                    effectiveWebsiteUrl = cfResult.tracking_url;
+                    console.log('Clickflare tracking URL:', effectiveWebsiteUrl);
+                }
+            } catch (e) {
+                console.warn('Clickflare URL generation failed, using raw URL:', e);
+            }
+
             // Step 3: Create ads
             const createdAds = [];
             for (let i = 0; i < adsData.length; i++) {
@@ -218,6 +236,7 @@ const BulkAdCreation = ({ onNext, onBack }) => {
 
                     const adSpecificCreativeData = {
                         ...creativeData,
+                        websiteUrl: effectiveWebsiteUrl,
                         mediaType: isVideo ? 'video' : 'image',
                         imageUrl: !isVideo ? (specificCreative?.imageUrl || specificCreative?.previewUrl) : undefined,
                         videoUrl: isVideo ? (specificCreative?.videoUrl || specificCreative?.previewUrl) : undefined,
@@ -272,7 +291,7 @@ const BulkAdCreation = ({ onNext, onBack }) => {
                             headlines: adHeadlines,
                             description: adDescription,
                             cta: adCta,
-                            websiteUrl: creativeData.websiteUrl,
+                            websiteUrl: effectiveWebsiteUrl,
                             status: 'PAUSED',
                             fbAdId: result.adId,
                             fbCreativeId: result.creativeId

--- a/frontend/src/components/GenerateVideoModal.jsx
+++ b/frontend/src/components/GenerateVideoModal.jsx
@@ -1,0 +1,372 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { X, Video, Loader2, Check, AlertCircle, Download, ChevronDown } from 'lucide-react';
+import { getMotions, generateVideo, getJobStatus } from '../api/higgsfield';
+import { useToast } from '../context/ToastContext';
+
+// Ad-friendly motion categories
+const MOTION_CATEGORIES = {
+    'Zoom': ['zoom', 'crash zoom'],
+    'Dolly': ['dolly'],
+    'Pan': ['pan'],
+    'Orbit': ['orbit'],
+    'Tilt': ['tilt'],
+    'Push': ['push'],
+    'Pull': ['pull'],
+    'Other': [],
+};
+
+function categorizeMotions(motions) {
+    const categorized = {};
+    const used = new Set();
+
+    for (const [category, keywords] of Object.entries(MOTION_CATEGORIES)) {
+        if (category === 'Other') continue;
+        categorized[category] = motions.filter(m => {
+            const name = m.name?.toLowerCase() || '';
+            const match = keywords.some(k => name.includes(k));
+            if (match) used.add(m.id);
+            return match;
+        });
+    }
+
+    categorized['Other'] = motions.filter(m => !used.has(m.id));
+    // Remove empty categories
+    return Object.fromEntries(Object.entries(categorized).filter(([, v]) => v.length > 0));
+}
+
+export default function GenerateVideoModal({ imageUrl, onClose, onVideoReady }) {
+    const { showSuccess, showError } = useToast();
+    const [motions, setMotions] = useState(null);
+    const [categorizedMotions, setCategorizedMotions] = useState(null);
+    const [selectedMotion, setSelectedMotion] = useState(null);
+    const [expandedCategory, setExpandedCategory] = useState('Zoom');
+    const [prompt, setPrompt] = useState('');
+    const [model, setModel] = useState('dop-lite');
+    const [strength, setStrength] = useState(0.5);
+    const [loading, setLoading] = useState(false);
+    const [jobId, setJobId] = useState(null);
+    const [jobStatus, setJobStatus] = useState(null);
+    const [result, setResult] = useState(null);
+    const [error, setError] = useState(null);
+    const pollRef = useRef(null);
+
+    // Load motions on mount
+    useEffect(() => {
+        (async () => {
+            try {
+                const data = await getMotions();
+                setMotions(data);
+                setCategorizedMotions(categorizeMotions(data));
+                // Pre-select "Dolly In" or first motion
+                const dollyIn = data.find(m => m.name === 'Dolly In');
+                setSelectedMotion(dollyIn || data[0]);
+            } catch (err) {
+                setError('Failed to load motion presets');
+            }
+        })();
+    }, []);
+
+    // Poll job status
+    useEffect(() => {
+        if (!jobId) return;
+
+        const poll = async () => {
+            try {
+                const data = await getJobStatus(jobId);
+                const status = data.status?.toLowerCase?.() || data.status;
+                setJobStatus(status);
+
+                if (status === 'completed') {
+                    // Extract video URL from result
+                    const videoUrl = data.result?.video_url
+                        || data.result?.url
+                        || data.jobs?.[0]?.result?.video_url
+                        || data.jobs?.[0]?.result?.url
+                        || null;
+                    setResult({ ...data, videoUrl });
+                    setLoading(false);
+                    if (videoUrl) {
+                        showSuccess('Video generated successfully!');
+                    }
+                    clearInterval(pollRef.current);
+                } else if (status === 'failed') {
+                    setError(data.error || 'Video generation failed');
+                    setLoading(false);
+                    clearInterval(pollRef.current);
+                } else if (status === 'nsfw') {
+                    setError('Image was flagged as NSFW');
+                    setLoading(false);
+                    clearInterval(pollRef.current);
+                }
+            } catch {
+                // Keep polling on transient errors
+            }
+        };
+
+        pollRef.current = setInterval(poll, 5000);
+        poll(); // Initial check
+
+        return () => clearInterval(pollRef.current);
+    }, [jobId]);
+
+    const handleGenerate = async () => {
+        if (!selectedMotion) {
+            showError('Please select a motion preset');
+            return;
+        }
+        setLoading(true);
+        setError(null);
+        setResult(null);
+        setJobStatus('submitting');
+
+        try {
+            const data = await generateVideo({
+                image_url: imageUrl,
+                motion_id: selectedMotion.id,
+                prompt,
+                model,
+                strength,
+            });
+            const id = data.id || data.job_set_id;
+            setJobId(id);
+            setJobStatus('queued');
+        } catch (err) {
+            const detail = err.response?.data?.detail || err.message;
+            setError(detail);
+            setLoading(false);
+        }
+    };
+
+    const handleSaveToLibrary = () => {
+        if (result?.videoUrl && onVideoReady) {
+            onVideoReady(result.videoUrl);
+        }
+        onClose();
+    };
+
+    return (
+        <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4" onClick={onClose}>
+            <div className="bg-white rounded-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
+                {/* Header */}
+                <div className="flex items-center justify-between p-5 border-b border-gray-100">
+                    <div className="flex items-center gap-3">
+                        <div className="w-10 h-10 bg-purple-100 rounded-xl flex items-center justify-center">
+                            <Video size={20} className="text-purple-600" />
+                        </div>
+                        <div>
+                            <h2 className="text-lg font-semibold text-gray-900">Generate Video</h2>
+                            <p className="text-xs text-gray-500">Powered by Higgsfield AI</p>
+                        </div>
+                    </div>
+                    <button onClick={onClose} className="p-2 hover:bg-gray-100 rounded-lg">
+                        <X size={20} className="text-gray-400" />
+                    </button>
+                </div>
+
+                <div className="p-5 space-y-5">
+                    {/* Source image preview */}
+                    <div className="flex gap-4">
+                        <img
+                            src={imageUrl}
+                            alt="Source"
+                            className="w-32 h-24 object-cover rounded-lg border border-gray-200"
+                        />
+                        <div className="flex-1 text-sm text-gray-500">
+                            <p>This image will be animated into a short video using the motion preset you select below.</p>
+                        </div>
+                    </div>
+
+                    {/* Motion presets */}
+                    {!motions ? (
+                        <div className="flex items-center justify-center py-8 text-gray-400">
+                            <Loader2 size={20} className="animate-spin mr-2" />
+                            Loading motion presets...
+                        </div>
+                    ) : (
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 mb-2">
+                                Motion Preset
+                            </label>
+                            <div className="border border-gray-200 rounded-lg overflow-hidden max-h-48 overflow-y-auto">
+                                {categorizedMotions && Object.entries(categorizedMotions).map(([category, items]) => (
+                                    <div key={category}>
+                                        <button
+                                            onClick={() => setExpandedCategory(expandedCategory === category ? null : category)}
+                                            className="w-full flex items-center justify-between px-3 py-2 bg-gray-50 text-sm font-medium text-gray-700 hover:bg-gray-100"
+                                        >
+                                            {category} ({items.length})
+                                            <ChevronDown size={14} className={`transition-transform ${expandedCategory === category ? 'rotate-180' : ''}`} />
+                                        </button>
+                                        {expandedCategory === category && (
+                                            <div className="grid grid-cols-2 gap-1 p-2">
+                                                {items.map(m => (
+                                                    <button
+                                                        key={m.id}
+                                                        onClick={() => setSelectedMotion(m)}
+                                                        className={`text-left px-3 py-2 rounded-lg text-sm transition-colors ${
+                                                            selectedMotion?.id === m.id
+                                                                ? 'bg-purple-100 text-purple-700 font-medium'
+                                                                : 'hover:bg-gray-50 text-gray-600'
+                                                        }`}
+                                                    >
+                                                        {m.name}
+                                                    </button>
+                                                ))}
+                                            </div>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                            {selectedMotion && (
+                                <p className="mt-1 text-xs text-purple-600">
+                                    Selected: {selectedMotion.name}
+                                </p>
+                            )}
+                        </div>
+                    )}
+
+                    {/* Prompt */}
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">
+                            Prompt <span className="text-gray-400 font-normal">(optional)</span>
+                        </label>
+                        <input
+                            type="text"
+                            value={prompt}
+                            onChange={e => setPrompt(e.target.value)}
+                            placeholder="Describe the scene or leave blank for auto"
+                            className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                        />
+                    </div>
+
+                    {/* Model + Strength */}
+                    <div className="grid grid-cols-2 gap-4">
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 mb-1">Quality</label>
+                            <select
+                                value={model}
+                                onChange={e => setModel(e.target.value)}
+                                className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm"
+                            >
+                                <option value="dop-lite">Lite (fastest, cheapest)</option>
+                                <option value="dop-turbo">Turbo (balanced)</option>
+                                <option value="dop-preview">Preview (highest quality)</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 mb-1">
+                                Motion Strength: {Math.round(strength * 100)}%
+                            </label>
+                            <input
+                                type="range"
+                                min="0.1"
+                                max="1.0"
+                                step="0.1"
+                                value={strength}
+                                onChange={e => setStrength(parseFloat(e.target.value))}
+                                className="w-full mt-1"
+                            />
+                        </div>
+                    </div>
+
+                    {/* Error */}
+                    {error && (
+                        <div className="flex items-start gap-2 p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+                            <AlertCircle size={16} className="flex-shrink-0 mt-0.5" />
+                            <span>{error}</span>
+                        </div>
+                    )}
+
+                    {/* Job status */}
+                    {loading && jobStatus && (
+                        <div className="flex items-center gap-3 p-4 bg-purple-50 border border-purple-200 rounded-lg">
+                            <Loader2 size={20} className="animate-spin text-purple-600" />
+                            <div>
+                                <p className="text-sm font-medium text-purple-700">
+                                    {jobStatus === 'submitting' && 'Submitting job...'}
+                                    {jobStatus === 'queued' && 'Queued — waiting for GPU...'}
+                                    {jobStatus === 'in_progress' && 'Generating video...'}
+                                    {!['submitting', 'queued', 'in_progress'].includes(jobStatus) && `Status: ${jobStatus}`}
+                                </p>
+                                <p className="text-xs text-purple-500 mt-0.5">This usually takes 30-90 seconds</p>
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Result */}
+                    {result?.videoUrl && (
+                        <div className="space-y-3">
+                            <div className="flex items-center gap-2 text-green-700">
+                                <Check size={18} />
+                                <span className="text-sm font-medium">Video generated!</span>
+                            </div>
+                            <video
+                                src={result.videoUrl}
+                                controls
+                                autoPlay
+                                loop
+                                className="w-full rounded-lg border border-gray-200"
+                            />
+                            <div className="flex gap-2">
+                                <a
+                                    href={result.videoUrl}
+                                    download
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="flex items-center gap-2 px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg text-sm transition-colors"
+                                >
+                                    <Download size={16} />
+                                    Download
+                                </a>
+                                {onVideoReady && (
+                                    <button
+                                        onClick={handleSaveToLibrary}
+                                        className="flex-1 flex items-center justify-center gap-2 px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white rounded-lg text-sm transition-colors"
+                                    >
+                                        <Check size={16} />
+                                        Save to Ads Library
+                                    </button>
+                                )}
+                            </div>
+                        </div>
+                    )}
+
+                    {result && !result.videoUrl && (
+                        <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-lg text-sm text-yellow-700">
+                            Job completed but no video URL found. Check the Higgsfield dashboard.
+                        </div>
+                    )}
+                </div>
+
+                {/* Footer */}
+                {!result && (
+                    <div className="p-5 border-t border-gray-100 flex justify-end gap-3">
+                        <button
+                            onClick={onClose}
+                            className="px-4 py-2 text-gray-600 hover:bg-gray-100 rounded-lg text-sm"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            onClick={handleGenerate}
+                            disabled={loading || !selectedMotion}
+                            className="flex items-center gap-2 px-5 py-2 bg-purple-600 hover:bg-purple-700 disabled:bg-purple-300 text-white rounded-lg text-sm transition-colors"
+                        >
+                            {loading ? (
+                                <>
+                                    <Loader2 size={16} className="animate-spin" />
+                                    Generating...
+                                </>
+                            ) : (
+                                <>
+                                    <Video size={16} />
+                                    Generate Video
+                                </>
+                            )}
+                        </button>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useLocation, Outlet, useNavigate } from 'react-router-dom';
-import { LayoutDashboard, Package, Users, Video, Wand2, Settings, LogOut, Image, ShoppingBag, Target, ChevronLeft, ChevronRight, FileImage, Search, ChevronDown, UserCog, FolderOpen } from 'lucide-react';
+import { LayoutDashboard, Package, Users, Video, Wand2, Settings, LogOut, Image, ShoppingBag, Target, ChevronLeft, ChevronRight, FileImage, Search, ChevronDown, UserCog, FolderOpen, Type } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { useToast } from '../context/ToastContext';
 
@@ -40,6 +40,7 @@ export default function Layout() {
             ]
         },
         { icon: FolderOpen, label: 'Ads Library', path: '/ads-library' },
+        { icon: Type, label: 'Headlines', path: '/headlines' },
         { icon: Wand2, label: 'Build Creatives', path: '/build-creatives' },
         { icon: Image, label: 'Winning Ads', path: '/winning-ads' },
         { icon: FileImage, label: 'BreadWinner Ads', path: '/generated-ads' },

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useLocation, Outlet, useNavigate } from 'react-router-dom';
-import { LayoutDashboard, Package, Users, Video, Wand2, Settings, LogOut, Image, ShoppingBag, Target, ChevronLeft, ChevronRight, FileImage, Search, ChevronDown, UserCog } from 'lucide-react';
+import { LayoutDashboard, Package, Users, Video, Wand2, Settings, LogOut, Image, ShoppingBag, Target, ChevronLeft, ChevronRight, FileImage, Search, ChevronDown, UserCog, FolderOpen } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { useToast } from '../context/ToastContext';
 
@@ -41,7 +41,8 @@ export default function Layout() {
             ]
         },
         { icon: Image, label: 'Winning Ads', path: '/winning-ads' },
-        { icon: FileImage, label: 'Generated Ads', path: '/generated-ads' },
+        { icon: FileImage, label: 'BreadWinner Ads', path: '/generated-ads' },
+        { icon: FolderOpen, label: 'Ads Library', path: '/ads-library' },
         { icon: Target, label: 'Facebook Campaigns', path: '/facebook-campaigns' },
     ];
 

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -30,7 +30,6 @@ export default function Layout() {
                 { label: 'Settings', path: '/research/settings' }
             ]
         },
-        { icon: Wand2, label: 'Build Creatives', path: '/build-creatives' },
         {
             icon: ShoppingBag,
             label: 'Brands',
@@ -40,9 +39,10 @@ export default function Layout() {
                 { label: 'Customer Profiles', path: '/profiles' }
             ]
         },
+        { icon: FolderOpen, label: 'Ads Library', path: '/ads-library' },
+        { icon: Wand2, label: 'Build Creatives', path: '/build-creatives' },
         { icon: Image, label: 'Winning Ads', path: '/winning-ads' },
         { icon: FileImage, label: 'BreadWinner Ads', path: '/generated-ads' },
-        { icon: FolderOpen, label: 'Ads Library', path: '/ads-library' },
         { icon: Target, label: 'Facebook Campaigns', path: '/facebook-campaigns' },
     ];
 

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useLocation, Outlet, useNavigate } from 'react-router-dom';
-import { LayoutDashboard, Package, Users, Video, Wand2, Settings, LogOut, Image, ShoppingBag, Target, ChevronLeft, ChevronRight, FileImage, Search, ChevronDown, UserCog, FolderOpen, Type } from 'lucide-react';
+import { LayoutDashboard, Package, Users, Video, Wand2, Settings, LogOut, Image, ShoppingBag, Target, ChevronLeft, ChevronRight, FileImage, Search, ChevronDown, UserCog, FolderOpen, Type, BookOpen } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { useToast } from '../context/ToastContext';
 
@@ -45,6 +45,7 @@ export default function Layout() {
         { icon: Image, label: 'Winning Ads', path: '/winning-ads' },
         { icon: FileImage, label: 'BreadWinner Ads', path: '/generated-ads' },
         { icon: Target, label: 'Facebook Campaigns', path: '/facebook-campaigns' },
+        { icon: BookOpen, label: 'Prompts & Docs', path: '/prompts' },
     ];
 
     const toggleMenu = (label) => {

--- a/frontend/src/components/ProductForm.jsx
+++ b/frontend/src/components/ProductForm.jsx
@@ -50,11 +50,9 @@ const ProductForm = ({ onClose, onSave, initialData = null }) => {
         }
     };
 
-    const handleFileUpload = async (e) => {
-        const files = Array.from(e.target.files);
+    const uploadFiles = async (files) => {
         if (files.length === 0) return;
 
-        // Client-side validation
         for (const file of files) {
             if (!ALLOWED_TYPES.includes(file.type)) {
                 showError(`Invalid file type: ${file.name}. Allowed types: JPEG, PNG, GIF, WebP`);
@@ -100,6 +98,31 @@ const ProductForm = ({ onClose, onSave, initialData = null }) => {
             if (fileInputRef.current) fileInputRef.current.value = '';
         }
     };
+
+    const handleFileUpload = (e) => {
+        uploadFiles(Array.from(e.target.files));
+    };
+
+    // Paste from clipboard
+    React.useEffect(() => {
+        const handlePaste = (e) => {
+            const items = e.clipboardData?.items;
+            if (!items) return;
+            const imageFiles = [];
+            for (const item of items) {
+                if (item.type.startsWith('image/')) {
+                    const file = item.getAsFile();
+                    if (file) imageFiles.push(file);
+                }
+            }
+            if (imageFiles.length > 0) {
+                e.preventDefault();
+                uploadFiles(imageFiles);
+            }
+        };
+        document.addEventListener('paste', handlePaste);
+        return () => document.removeEventListener('paste', handlePaste);
+    }, [uploading]);
 
     const removeShot = (index) => {
         setFormData(prev => ({
@@ -198,7 +221,7 @@ const ProductForm = ({ onClose, onSave, initialData = null }) => {
                             onChange={handleFileUpload}
                             className="hidden"
                         />
-                        <p className="text-xs text-gray-500">Upload product images to use in ad generation.</p>
+                        <p className="text-xs text-gray-500">Upload or paste (Ctrl+V) product images to use in ad generation.</p>
                     </div>
 
                     <div className="flex justify-end gap-3 pt-4 border-t border-gray-100">

--- a/frontend/src/context/BrandContext.jsx
+++ b/frontend/src/context/BrandContext.jsx
@@ -79,11 +79,16 @@ export const BrandProvider = ({ children }) => {
                 id: crypto.randomUUID()
             };
 
-            await authFetch(`${API_URL}/brands`, {
+            const response = await authFetch(`${API_URL}/brands`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(newBrand)
             });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({}));
+                throw new Error(errorData.detail || `Failed to create brand (${response.status})`);
+            }
 
             await loadData();
         } catch (error) {
@@ -94,11 +99,16 @@ export const BrandProvider = ({ children }) => {
 
     const updateBrand = async (id, updatedBrand) => {
         try {
-            await authFetch(`${API_URL}/brands/${id}`, {
+            const response = await authFetch(`${API_URL}/brands/${id}`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(updatedBrand)
             });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({}));
+                throw new Error(errorData.detail || `Failed to update brand (${response.status})`);
+            }
 
             await loadData();
         } catch (error) {
@@ -180,11 +190,16 @@ export const BrandProvider = ({ children }) => {
                 id: crypto.randomUUID()
             };
 
-            await authFetch(`${API_URL}/profiles`, {
+            const response = await authFetch(`${API_URL}/profiles`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(newProfile)
             });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({}));
+                throw new Error(errorData.detail || `Failed to create profile (${response.status})`);
+            }
 
             await loadData();
             return newProfile;
@@ -196,11 +211,16 @@ export const BrandProvider = ({ children }) => {
 
     const updateProfile = async (id, updatedProfile) => {
         try {
-            await authFetch(`${API_URL}/profiles/${id}`, {
+            const response = await authFetch(`${API_URL}/profiles/${id}`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(updatedProfile)
             });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({}));
+                throw new Error(errorData.detail || `Failed to update profile (${response.status})`);
+            }
 
             await loadData();
         } catch (error) {

--- a/frontend/src/context/CampaignContext.jsx
+++ b/frontend/src/context/CampaignContext.jsx
@@ -68,7 +68,7 @@ export const CampaignProvider = ({ children }) => {
     });
 
     const [creativeData, setCreativeData] = useState({
-        creativeMode: 'standard', // 'standard' or 'per_creative'
+        creativeMode: 'per_creative', // 'standard' or 'per_creative'
         creativeName: '',
         creatives: [], // Array of { id, file, previewUrl, name, mediaType, headlines?, bodies?, description?, cta? }
         bodies: [''], // Start with 1 field (used in standard mode)

--- a/frontend/src/context/CampaignContext.jsx
+++ b/frontend/src/context/CampaignContext.jsx
@@ -68,10 +68,11 @@ export const CampaignProvider = ({ children }) => {
     });
 
     const [creativeData, setCreativeData] = useState({
+        creativeMode: 'standard', // 'standard' or 'per_creative'
         creativeName: '',
-        creatives: [], // Array of { id, file, previewUrl, name }
-        bodies: [''], // Start with 1 field
-        headlines: [''], // Start with 1 field
+        creatives: [], // Array of { id, file, previewUrl, name, mediaType, headlines?, bodies?, description?, cta? }
+        bodies: [''], // Start with 1 field (used in standard mode)
+        headlines: [''], // Start with 1 field (used in standard mode)
         description: '',
         cta: 'LEARN_MORE',
         websiteUrl: '',

--- a/frontend/src/context/CampaignContext.jsx
+++ b/frontend/src/context/CampaignContext.jsx
@@ -81,6 +81,7 @@ export const CampaignProvider = ({ children }) => {
     });
 
     const [adsData, setAdsData] = useState([]);
+    const [addingNewAd, setAddingNewAd] = useState(false);
 
     const [selectedAdAccount, setSelectedAdAccount] = useState(null);
 
@@ -153,6 +154,8 @@ export const CampaignProvider = ({ children }) => {
         setAdsData,
         selectedAdAccount,
         setSelectedAdAccount,
+        addingNewAd,
+        setAddingNewAd,
         resetWizard
     };
 

--- a/frontend/src/lib/facebookApi.js
+++ b/frontend/src/lib/facebookApi.js
@@ -140,6 +140,15 @@ export async function getPages(adAccountId) {
 }
 
 
+export async function getPageInfo(pageId) {
+    const response = await authFetch(`${API_BASE_URL}/pages/${pageId}`);
+    if (!response.ok) {
+        const error = await response.json().catch(() => ({}));
+        throw new Error(error.detail || 'Failed to fetch page info');
+    }
+    return response.json();
+}
+
 export const getAdSets = async (campaignId, adAccountId) => {
     try {
         let url = `${API_BASE_URL}/adsets?`;

--- a/frontend/src/pages/AdsLibrary.jsx
+++ b/frontend/src/pages/AdsLibrary.jsx
@@ -291,6 +291,7 @@ const AdsLibrary = () => {
                 funnel_stage: '',
                 ad_format: '',
                 status: 'draft',
+                folderId: (currentFolderId && currentFolderId !== '__none__') ? currentFolderId : null,
             });
         }
 
@@ -324,6 +325,7 @@ const AdsLibrary = () => {
                     funnel_stage: '',
                     ad_format: '',
                     status: 'draft',
+                    folderId: (currentFolderId && currentFolderId !== '__none__') ? currentFolderId : null,
                 });
             } catch (error) {
                 showError(`Failed to upload ${file.name}`);
@@ -371,9 +373,10 @@ const AdsLibrary = () => {
                     ad_format: item.ad_format || null,
                     status: item.status,
                 };
-                // Auto-set folder_id if inside a folder (Level 3)
-                if (currentFolderId && currentFolderId !== '__none__') {
-                    payload.folder_id = currentFolderId;
+                // Use folder_id stamped at upload time, fallback to current nav
+                const folderId = item.folderId || ((currentFolderId && currentFolderId !== '__none__') ? currentFolderId : null);
+                if (folderId) {
+                    payload.folder_id = folderId;
                 }
                 await createLibraryItem(payload);
                 saved++;
@@ -993,12 +996,6 @@ const AdsLibrary = () => {
 
         return (
             <div className="space-y-6">
-                {/* Upload area at folder level */}
-                {renderUploadArea()}
-
-                {/* Review queue */}
-                {renderReviewQueue()}
-
                 {/* Folder grid */}
                 <div>
                     <div className="flex items-center justify-between mb-4">

--- a/frontend/src/pages/AdsLibrary.jsx
+++ b/frontend/src/pages/AdsLibrary.jsx
@@ -868,23 +868,37 @@ const AdsLibrary = () => {
                             <X size={28} />
                         </button>
 
-                        {(() => {
-                            const isActualVideo = selectedItem.media_url?.match(/\.(mp4|webm|mov)(\?|$)/i);
-                            return isActualVideo ? (
+                        {selectedItem.media_type === 'video' ? (
+                            <div className="relative">
                                 <video
+                                    key={selectedItem.id}
                                     src={selectedItem.media_url}
                                     controls
                                     autoPlay
+                                    playsInline
+                                    poster={selectedItem.thumbnail_url || undefined}
                                     className="w-full rounded-lg max-h-[70vh] object-contain bg-black"
+                                    style={{ minHeight: '300px' }}
                                 />
-                            ) : (
-                                <img
-                                    src={selectedItem.media_url}
-                                    alt={selectedItem.name || 'Ad'}
-                                    className="w-full rounded-lg max-h-[70vh] object-contain bg-black"
-                                />
-                            );
-                        })()}
+                                <a
+                                    href={selectedItem.media_url}
+                                    download
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="absolute top-3 right-3 flex items-center gap-1 px-3 py-1.5 bg-white/90 text-gray-800 rounded-lg text-sm font-medium hover:bg-white transition-colors"
+                                    onClick={(e) => e.stopPropagation()}
+                                >
+                                    <Download size={14} />
+                                    Download
+                                </a>
+                            </div>
+                        ) : (
+                            <img
+                                src={selectedItem.media_url}
+                                alt={selectedItem.name || 'Ad'}
+                                className="w-full rounded-lg max-h-[70vh] object-contain bg-black"
+                            />
+                        )}
 
                         {/* Variant previews */}
                         {selectedItem.variants && Object.keys(selectedItem.variants).length > 1 && (

--- a/frontend/src/pages/AdsLibrary.jsx
+++ b/frontend/src/pages/AdsLibrary.jsx
@@ -102,65 +102,136 @@ const AdsLibrary = () => {
         setUploading(true);
         let uploaded = 0;
 
+        // Separate images and videos
+        const imageFiles = [];
+        const videoFiles = [];
         for (const file of files) {
-            const isImage = ALLOWED_IMAGE_TYPES.includes(file.type);
-            const isVideo = ALLOWED_VIDEO_TYPES.includes(file.type);
+            if (ALLOWED_IMAGE_TYPES.includes(file.type)) imageFiles.push(file);
+            else if (ALLOWED_VIDEO_TYPES.includes(file.type)) videoFiles.push(file);
+            else showError(`${file.name}: Unsupported file type`);
+        }
 
-            if (!isImage && !isVideo) {
-                showError(`${file.name}: Unsupported file type`);
-                continue;
-            }
-
+        // Phase 1: Upload all image files and detect ratios
+        const imageUploads = []; // { file, url, ratio }
+        for (const file of imageFiles) {
             try {
                 setUploadProgress(`Uploading ${file.name}...`);
-
-                // Upload file to R2
-                const { url, media_type } = await uploadFile(file);
-
-                let thumbnailUrl = null;
-                let variants = null;
-                let aiName = null;
-
-                if (isVideo) {
-                    // Extract video thumbnail
-                    try {
-                        setUploadProgress(`Extracting thumbnail from ${file.name}...`);
-                        const thumbBlob = await extractVideoThumbnail(file);
-                        const thumbFile = new File([thumbBlob], `thumb_${file.name.replace(/\.[^.]+$/, '.jpg')}`, { type: 'image/jpeg' });
-                        const thumbResult = await uploadFile(thumbFile);
-                        thumbnailUrl = thumbResult.url;
-                    } catch (e) {
-                        console.warn('Thumbnail extraction failed:', e);
-                    }
-                }
-
-                if (isImage) {
-                    // Detect aspect ratio and store in variants
-                    try {
-                        const ratio = await detectAspectRatio(file);
-                        variants = { [ratio]: url };
-                    } catch (e) {
-                        console.warn('Aspect ratio detection failed:', e);
-                    }
-                }
-
-                // AI-generated name
+                const { url } = await uploadFile(file);
+                let ratio = 'unknown';
                 try {
-                    setUploadProgress(`Naming ${file.name} with AI...`);
-                    const { name } = await getAiName(url);
+                    ratio = await detectAspectRatio(file);
+                } catch (e) {
+                    console.warn('Aspect ratio detection failed:', e);
+                }
+                imageUploads.push({ file, url, ratio, size: file.size });
+            } catch (error) {
+                showError(`Failed to upload ${file.name}`);
+            }
+        }
+
+        // Phase 2: Group images by ratio pairs (e.g., 1:1 + 9:16 → one entry)
+        const groups = []; // each group = array of { url, ratio, size }
+        const used = new Set();
+
+        // Try to pair images with different ratios
+        for (let i = 0; i < imageUploads.length; i++) {
+            if (used.has(i)) continue;
+            const a = imageUploads[i];
+            let paired = false;
+
+            // Look for a partner with a different ratio
+            for (let j = i + 1; j < imageUploads.length; j++) {
+                if (used.has(j)) continue;
+                const b = imageUploads[j];
+                if (a.ratio !== b.ratio && a.ratio !== 'unknown' && b.ratio !== 'unknown') {
+                    // Pair them
+                    groups.push([a, b]);
+                    used.add(i);
+                    used.add(j);
+                    paired = true;
+                    break;
+                }
+            }
+            if (!paired) {
+                groups.push([a]);
+                used.add(i);
+            }
+        }
+
+        // Phase 3: Create library items for each group
+        for (const group of groups) {
+            try {
+                const primary = group[0];
+                const variants = {};
+                let totalSize = 0;
+                for (const item of group) {
+                    variants[item.ratio] = item.url;
+                    totalSize += item.size;
+                }
+
+                // AI name from primary image
+                let aiName = null;
+                try {
+                    setUploadProgress(`Naming with AI...`);
+                    const { name } = await getAiName(primary.url);
                     aiName = name;
                 } catch (e) {
                     console.warn('AI naming failed:', e);
                 }
 
-                // Create library item
+                const ratioLabel = group.length > 1
+                    ? ` (${group.map(g => g.ratio).join(' + ')})`
+                    : '';
+
+                await createLibraryItem({
+                    brand_id: uploadBrand,
+                    name: aiName || primary.file.name.replace(/\.[^.]+$/, '') + ratioLabel,
+                    media_type: 'image',
+                    media_url: primary.url,
+                    variants,
+                    file_size: totalSize,
+                    status: 'draft',
+                });
+                uploaded++;
+            } catch (error) {
+                showError('Failed to create library item');
+            }
+        }
+
+        // Phase 4: Handle video files
+        for (const file of videoFiles) {
+            try {
+                setUploadProgress(`Uploading ${file.name}...`);
+                const { url } = await uploadFile(file);
+
+                let thumbnailUrl = null;
+                try {
+                    setUploadProgress(`Extracting thumbnail...`);
+                    const thumbBlob = await extractVideoThumbnail(file);
+                    const thumbFile = new File([thumbBlob], `thumb_${file.name.replace(/\.[^.]+$/, '.jpg')}`, { type: 'image/jpeg' });
+                    const thumbResult = await uploadFile(thumbFile);
+                    thumbnailUrl = thumbResult.url;
+                } catch (e) {
+                    console.warn('Thumbnail extraction failed:', e);
+                }
+
+                let aiName = null;
+                if (thumbnailUrl) {
+                    try {
+                        setUploadProgress(`Naming with AI...`);
+                        const { name } = await getAiName(thumbnailUrl);
+                        aiName = name;
+                    } catch (e) {
+                        console.warn('AI naming failed:', e);
+                    }
+                }
+
                 await createLibraryItem({
                     brand_id: uploadBrand,
                     name: aiName || file.name.replace(/\.[^.]+$/, ''),
-                    media_type: media_type,
+                    media_type: 'video',
                     media_url: url,
                     thumbnail_url: thumbnailUrl,
-                    variants: variants,
                     file_size: file.size,
                     status: 'draft',
                 });
@@ -171,7 +242,7 @@ const AdsLibrary = () => {
         }
 
         if (uploaded > 0) {
-            showSuccess(`Uploaded ${uploaded} file${uploaded > 1 ? 's' : ''}`);
+            showSuccess(`Uploaded ${uploaded} item${uploaded > 1 ? 's' : ''}`);
             fetchItems();
         }
         setUploading(false);

--- a/frontend/src/pages/AdsLibrary.jsx
+++ b/frontend/src/pages/AdsLibrary.jsx
@@ -212,7 +212,8 @@ const AdsLibrary = () => {
                     const thumbResult = await uploadFile(thumbFile);
                     thumbnailUrl = thumbResult.url;
                 } catch (e) {
-                    console.warn('Thumbnail extraction failed:', e);
+                    console.warn('Thumbnail extraction failed:', e?.message || e);
+                    setUploadProgress('Thumbnail extraction failed, continuing...');
                 }
 
                 let aiName = null;

--- a/frontend/src/pages/AdsLibrary.jsx
+++ b/frontend/src/pages/AdsLibrary.jsx
@@ -78,6 +78,7 @@ const AdsLibrary = () => {
     // ── Upload ──
     const [uploading, setUploading] = useState(false);
     const [uploadProgress, setUploadProgress] = useState('');
+    const [uploadFiles, setUploadFiles] = useState([]); // [{id, name, progress, status}]
     const [dragActive, setDragActive] = useState(false);
     const fileInputRef = useRef(null);
 
@@ -196,9 +197,21 @@ const AdsLibrary = () => {
     const STANDARD_RATIOS = ['1:1', '9:16', '4:5'];
 
     // ── Upload handlers — now populates review queue instead of creating items immediately ──
-    const handleFiles = async (files) => {
-        setUploading(true);
+    // Concurrency-limited parallel executor
+    const runParallel = async (tasks, concurrency = 3) => {
+        const results = [];
+        let idx = 0;
+        const run = async () => {
+            while (idx < tasks.length) {
+                const i = idx++;
+                results[i] = await tasks[i]();
+            }
+        };
+        await Promise.all(Array.from({ length: Math.min(concurrency, tasks.length) }, run));
+        return results;
+    };
 
+    const handleFiles = async (files) => {
         // Separate images and videos
         const imageFiles = [];
         const videoFiles = [];
@@ -219,23 +232,45 @@ const AdsLibrary = () => {
             showError('Only image files are accepted in the Images section');
         }
 
-        // Phase 1: Upload all image files and detect ratios
+        const allFiles = [...relevantImages, ...relevantVideos];
+        if (allFiles.length === 0) return;
+
+        // Build per-file tracker
+        const fileTrackers = allFiles.map((file, i) => ({
+            id: `upload_${Date.now()}_${i}`,
+            name: file.name,
+            progress: 0,
+            status: 'pending', // pending | uploading | processing | done | error
+        }));
+        setUploadFiles(fileTrackers);
+        setUploading(true);
+
+        const updateTracker = (id, updates) => {
+            setUploadFiles(prev => prev.map(f => f.id === id ? { ...f, ...updates } : f));
+        };
+
+        const capturedFolderId = (currentFolderId && currentFolderId !== '__none__') ? currentFolderId : null;
+
+        // Phase 1: Upload all images in parallel (max 3 concurrent)
         const imageUploads = [];
-        for (const file of relevantImages) {
+        const imageTasks = relevantImages.map((file, i) => () => (async () => {
+            const tracker = fileTrackers[i];
+            updateTracker(tracker.id, { status: 'uploading', progress: 0 });
             try {
-                setUploadProgress(`Uploading ${file.name}...`);
-                const { url } = await uploadFile(file);
+                const { url } = await uploadFile(file, (pct) => {
+                    updateTracker(tracker.id, { progress: pct });
+                });
+                updateTracker(tracker.id, { status: 'processing', progress: 100 });
                 let ratio = 'unknown';
-                try {
-                    ratio = await detectAspectRatio(file);
-                } catch (e) {
-                    console.warn('Aspect ratio detection failed:', e);
-                }
+                try { ratio = await detectAspectRatio(file); } catch {}
+                updateTracker(tracker.id, { status: 'done' });
                 imageUploads.push({ file, url, ratio, size: file.size });
-            } catch (error) {
+            } catch {
+                updateTracker(tracker.id, { status: 'error' });
                 showError(`Failed to upload ${file.name}`);
             }
-        }
+        })());
+        await runParallel(imageTasks, 3);
 
         // Phase 2: Group images by ratio pairs
         const groups = [];
@@ -261,9 +296,7 @@ const AdsLibrary = () => {
             }
         }
 
-        // Phase 3: Build review queue items for images
-        const newQueueItems = [];
-
+        // Phase 3: Add image items to review queue immediately
         for (const group of groups) {
             const tempId = `review_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
             const primary = group[0];
@@ -273,11 +306,10 @@ const AdsLibrary = () => {
                 variants[item.ratio] = item.url;
                 totalSize += item.size;
             }
-
             const uploadedRatios = Object.keys(variants);
             const missingRatios = STANDARD_RATIOS.filter(r => !uploadedRatios.includes(r));
 
-            newQueueItems.push({
+            const queueItem = {
                 id: tempId,
                 mediaType: 'image',
                 primaryUrl: primary.url,
@@ -291,31 +323,42 @@ const AdsLibrary = () => {
                 funnel_stage: '',
                 ad_format: '',
                 status: 'draft',
-                folderId: (currentFolderId && currentFolderId !== '__none__') ? currentFolderId : null,
-            });
+                folderId: capturedFolderId,
+            };
+            setReviewQueue(prev => [...prev, queueItem]);
+
+            // AI naming in background
+            getAiName(queueItem.primaryUrl)
+                .then(({ name }) => {
+                    setReviewQueue(prev => prev.map(q =>
+                        q.id === tempId ? { ...q, name, nameLoading: false } : q
+                    ));
+                })
+                .catch(() => {
+                    setReviewQueue(prev => prev.map(q =>
+                        q.id === tempId ? { ...q, nameLoading: false } : q
+                    ));
+                });
         }
 
-        // Phase 4: Handle video files — upload + extract thumbnail, add to queue
-        for (const file of relevantVideos) {
+        // Phase 4: Upload videos in parallel (max 3), stream each to queue as it finishes
+        const videoTasks = relevantVideos.map((file, vi) => () => (async () => {
+            const tracker = fileTrackers[relevantImages.length + vi];
+            updateTracker(tracker.id, { status: 'uploading', progress: 0 });
             try {
-                setUploadProgress(`Uploading ${file.name}...`);
-                const { url } = await uploadFile(file);
+                const { url } = await uploadFile(file, (pct) => {
+                    updateTracker(tracker.id, { progress: pct });
+                });
+                updateTracker(tracker.id, { status: 'processing', progress: 100 });
 
-                let thumbnailUrl = null;
-                try {
-                    setUploadProgress(`Extracting thumbnail...`);
-                    const { thumbnail_url } = await getVideoThumbnail(url);
-                    thumbnailUrl = thumbnail_url;
-                } catch (e) {
-                    console.warn('Server thumbnail extraction failed:', e?.message || e);
-                }
-
+                // Add to review queue immediately (thumbnail will fill in later)
                 const tempId = `review_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-                newQueueItems.push({
+                const queueItem = {
                     id: tempId,
                     mediaType: 'video',
                     primaryUrl: url,
-                    thumbnailUrl,
+                    thumbnailUrl: null,
+                    thumbnailLoading: true,
                     variants: {},
                     totalSize: file.size,
                     name: file.name.replace(/\.[^.]+$/, ''),
@@ -325,31 +368,35 @@ const AdsLibrary = () => {
                     funnel_stage: '',
                     ad_format: '',
                     status: 'draft',
-                    folderId: (currentFolderId && currentFolderId !== '__none__') ? currentFolderId : null,
-                });
-            } catch (error) {
+                    folderId: capturedFolderId,
+                };
+                setReviewQueue(prev => [...prev, queueItem]);
+
+                // Extract thumbnail in background — fills in when ready
+                getVideoThumbnail(url)
+                    .then(({ thumbnail_url }) => {
+                        setReviewQueue(prev => prev.map(q =>
+                            q.id === tempId ? { ...q, thumbnailUrl: thumbnail_url, thumbnailLoading: false } : q
+                        ));
+                    })
+                    .catch(() => {
+                        setReviewQueue(prev => prev.map(q =>
+                            q.id === tempId ? { ...q, thumbnailLoading: false } : q
+                        ));
+                    });
+
+                updateTracker(tracker.id, { status: 'done' });
+            } catch {
+                updateTracker(tracker.id, { status: 'error' });
                 showError(`Failed to upload ${file.name}`);
             }
-        }
+        })());
+        await runParallel(videoTasks, 3);
 
-        setReviewQueue(prev => [...prev, ...newQueueItems]);
         setUploading(false);
         setUploadProgress('');
-
-        // Kick off AI naming in parallel for image items
-        for (const item of newQueueItems.filter(i => i.mediaType === 'image')) {
-            getAiName(item.primaryUrl)
-                .then(({ name }) => {
-                    setReviewQueue(prev => prev.map(q =>
-                        q.id === item.id ? { ...q, name, nameLoading: false } : q
-                    ));
-                })
-                .catch(() => {
-                    setReviewQueue(prev => prev.map(q =>
-                        q.id === item.id ? { ...q, nameLoading: false } : q
-                    ));
-                });
-        }
+        // Clear file trackers after a short delay so user sees final state
+        setTimeout(() => setUploadFiles([]), 2000);
     };
 
     // Save all review queue items to the library
@@ -709,18 +756,41 @@ const AdsLibrary = () => {
                 </h2>
 
                 <div
-                    className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer ${
-                        dragActive ? 'border-amber-500 bg-amber-50' : 'border-gray-300 hover:border-amber-400'
-                    }`}
-                    onDrop={handleDrop}
-                    onDragOver={handleDragOver}
-                    onDragLeave={handleDragLeave}
-                    onClick={() => fileInputRef.current?.click()}
+                    className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors ${
+                        uploading ? '' : 'cursor-pointer'
+                    } ${dragActive ? 'border-amber-500 bg-amber-50' : 'border-gray-300 hover:border-amber-400'}`}
+                    onDrop={!uploading ? handleDrop : undefined}
+                    onDragOver={!uploading ? handleDragOver : undefined}
+                    onDragLeave={!uploading ? handleDragLeave : undefined}
+                    onClick={!uploading ? () => fileInputRef.current?.click() : undefined}
                 >
-                    {uploading ? (
-                        <div className="flex flex-col items-center gap-2 text-amber-600">
-                            <Loader2 size={24} className="animate-spin" />
-                            <span>{uploadProgress || 'Uploading...'}</span>
+                    {uploadFiles.length > 0 ? (
+                        <div className="space-y-2 text-left max-w-md mx-auto">
+                            {uploadFiles.map(f => (
+                                <div key={f.id} className="flex items-center gap-3">
+                                    <div className="flex-1 min-w-0">
+                                        <p className="text-sm text-gray-700 truncate">{f.name}</p>
+                                        <div className="w-full bg-gray-200 rounded-full h-2 mt-1">
+                                            <div
+                                                className={`h-2 rounded-full transition-all duration-300 ${
+                                                    f.status === 'error' ? 'bg-red-500' :
+                                                    f.status === 'done' ? 'bg-green-500' :
+                                                    f.status === 'processing' ? 'bg-blue-500' :
+                                                    'bg-amber-500'
+                                                }`}
+                                                style={{ width: `${f.progress}%` }}
+                                            />
+                                        </div>
+                                    </div>
+                                    <span className="text-xs text-gray-500 flex-shrink-0 w-20 text-right">
+                                        {f.status === 'error' ? 'Failed' :
+                                         f.status === 'done' ? 'Done' :
+                                         f.status === 'processing' ? 'Processing' :
+                                         f.status === 'uploading' ? `${f.progress}%` :
+                                         'Waiting'}
+                                    </span>
+                                </div>
+                            ))}
                         </div>
                     ) : (
                         <>
@@ -783,7 +853,11 @@ const AdsLibrary = () => {
                                         <img src={qItem.thumbnailUrl} alt="" className="w-full h-full object-cover" />
                                     ) : (
                                         <div className="w-full h-full flex items-center justify-center bg-gray-800">
-                                            <Video size={24} className="text-gray-500" />
+                                            {qItem.thumbnailLoading ? (
+                                                <Loader2 size={20} className="text-gray-400 animate-spin" />
+                                            ) : (
+                                                <Video size={24} className="text-gray-500" />
+                                            )}
                                         </div>
                                     )
                                 ) : (

--- a/frontend/src/pages/AdsLibrary.jsx
+++ b/frontend/src/pages/AdsLibrary.jsx
@@ -1,0 +1,712 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { useToast } from '../context/ToastContext';
+import { useBrands } from '../context/BrandContext';
+import { getLibraryItems, createLibraryItem, updateLibraryItem, deleteLibraryItem, uploadFile } from '../api/adsLibrary';
+import { Upload, Image, Video, Trash2, Pencil, X, Download, ChevronLeft, ChevronRight, Play, FolderOpen, Loader2, Plus, ExternalLink, Filter, Wand2 } from 'lucide-react';
+import GenerateVideoModal from '../components/GenerateVideoModal';
+
+const FUNNEL_STAGES = [
+    { value: '', label: 'All Stages' },
+    { value: 'tofu', label: 'TOFU (Awareness)' },
+    { value: 'mofu', label: 'MOFU (Consideration)' },
+    { value: 'bofu', label: 'BOFU (Conversion)' },
+];
+
+const AD_FORMATS = [
+    { value: '', label: 'Select Format' },
+    { value: 'single_image', label: 'Single Image' },
+    { value: 'carousel', label: 'Carousel' },
+    { value: 'story', label: 'Story' },
+    { value: 'reel', label: 'Reel' },
+    { value: 'ugc', label: 'UGC' },
+    { value: 'testimonial', label: 'Testimonial' },
+];
+
+const STATUSES = [
+    { value: '', label: 'All Statuses' },
+    { value: 'draft', label: 'Draft' },
+    { value: 'ready', label: 'Ready' },
+    { value: 'active', label: 'Active' },
+    { value: 'archived', label: 'Archived' },
+];
+
+const STATUS_COLORS = {
+    draft: 'bg-gray-100 text-gray-700',
+    ready: 'bg-green-100 text-green-700',
+    active: 'bg-blue-100 text-blue-700',
+    archived: 'bg-amber-100 text-amber-700',
+};
+
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
+const ALLOWED_VIDEO_TYPES = ['video/mp4', 'video/quicktime', 'video/x-msvideo', 'video/webm'];
+
+const AdsLibrary = () => {
+    const { showSuccess, showError } = useToast();
+    const { brands } = useBrands();
+
+    // Data
+    const [items, setItems] = useState([]);
+    const [loading, setLoading] = useState(true);
+
+    // Filters
+    const [filterBrand, setFilterBrand] = useState('');
+    const [filterMediaType, setFilterMediaType] = useState('');
+    const [filterFunnel, setFilterFunnel] = useState('');
+    const [filterStatus, setFilterStatus] = useState('');
+
+    // Upload
+    const [uploading, setUploading] = useState(false);
+    const [uploadBrand, setUploadBrand] = useState('');
+    const [dragActive, setDragActive] = useState(false);
+    const fileInputRef = useRef(null);
+
+    // Modals
+    const [selectedItem, setSelectedItem] = useState(null);
+    const [editItem, setEditItem] = useState(null);
+    const [deleteTarget, setDeleteTarget] = useState(null);
+    const [videoGenImage, setVideoGenImage] = useState(null);
+
+    const fetchItems = useCallback(async () => {
+        try {
+            setLoading(true);
+            const filters = {};
+            if (filterBrand) filters.brand_id = filterBrand;
+            if (filterMediaType) filters.media_type = filterMediaType;
+            if (filterFunnel) filters.funnel_stage = filterFunnel;
+            if (filterStatus) filters.status = filterStatus;
+            const data = await getLibraryItems(filters);
+            setItems(data);
+        } catch (error) {
+            showError('Failed to load ads library');
+        } finally {
+            setLoading(false);
+        }
+    }, [filterBrand, filterMediaType, filterFunnel, filterStatus]);
+
+    useEffect(() => {
+        fetchItems();
+    }, [fetchItems]);
+
+    // Upload handlers
+    const handleFiles = async (files) => {
+        if (!uploadBrand) {
+            showError('Please select a brand first');
+            return;
+        }
+
+        setUploading(true);
+        let uploaded = 0;
+
+        for (const file of files) {
+            const isImage = ALLOWED_IMAGE_TYPES.includes(file.type);
+            const isVideo = ALLOWED_VIDEO_TYPES.includes(file.type);
+
+            if (!isImage && !isVideo) {
+                showError(`${file.name}: Unsupported file type`);
+                continue;
+            }
+
+            try {
+                // Upload file to R2
+                const { url, media_type } = await uploadFile(file);
+
+                // Create library item
+                await createLibraryItem({
+                    brand_id: uploadBrand,
+                    name: file.name.replace(/\.[^.]+$/, ''),
+                    media_type: media_type,
+                    media_url: url,
+                    file_size: file.size,
+                    status: 'draft',
+                });
+                uploaded++;
+            } catch (error) {
+                showError(`Failed to upload ${file.name}`);
+            }
+        }
+
+        if (uploaded > 0) {
+            showSuccess(`Uploaded ${uploaded} file${uploaded > 1 ? 's' : ''}`);
+            fetchItems();
+        }
+        setUploading(false);
+    };
+
+    const handleDrop = (e) => {
+        e.preventDefault();
+        setDragActive(false);
+        handleFiles(Array.from(e.dataTransfer.files));
+    };
+
+    const handleDragOver = (e) => {
+        e.preventDefault();
+        setDragActive(true);
+    };
+
+    const handleDragLeave = () => setDragActive(false);
+
+    // Edit handlers
+    const handleSaveEdit = async () => {
+        if (!editItem) return;
+        try {
+            await updateLibraryItem(editItem.id, {
+                name: editItem.name,
+                headline: editItem.headline,
+                body: editItem.body,
+                cta: editItem.cta,
+                tags: editItem.tags,
+                funnel_stage: editItem.funnel_stage,
+                ad_format: editItem.ad_format,
+                status: editItem.status,
+                brand_id: editItem.brand_id,
+            });
+            showSuccess('Ad updated');
+            setEditItem(null);
+            fetchItems();
+        } catch (error) {
+            showError('Failed to update ad');
+        }
+    };
+
+    // Delete
+    const handleDelete = async () => {
+        if (!deleteTarget) return;
+        try {
+            await deleteLibraryItem(deleteTarget.id);
+            showSuccess('Ad deleted');
+            setDeleteTarget(null);
+            if (selectedItem?.id === deleteTarget.id) setSelectedItem(null);
+            fetchItems();
+        } catch (error) {
+            showError('Failed to delete ad');
+        }
+    };
+
+    const formatSize = (bytes) => {
+        if (!bytes) return '';
+        if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+        return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    };
+
+    return (
+        <div className="space-y-6">
+            {/* Header */}
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold text-amber-900 flex items-center gap-2">
+                        <FolderOpen size={28} />
+                        Ads Library
+                    </h1>
+                    <p className="text-amber-600 text-sm">Upload and organize your ad creatives by brand</p>
+                </div>
+                <div className="text-sm text-gray-500">
+                    {items.length} ad{items.length !== 1 ? 's' : ''}
+                </div>
+            </div>
+
+            {/* Upload Area */}
+            <div className="bg-white rounded-xl border border-amber-200 p-6">
+                <h2 className="text-lg font-semibold text-amber-900 mb-4">Upload Ads</h2>
+                <div className="flex gap-4 mb-4">
+                    <select
+                        value={uploadBrand}
+                        onChange={(e) => setUploadBrand(e.target.value)}
+                        className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+                    >
+                        <option value="">Select Brand *</option>
+                        {brands.map((b) => (
+                            <option key={b.id} value={b.id}>{b.name}</option>
+                        ))}
+                    </select>
+                </div>
+
+                <div
+                    className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer ${
+                        dragActive ? 'border-amber-500 bg-amber-50' : 'border-gray-300 hover:border-amber-400'
+                    }`}
+                    onDrop={handleDrop}
+                    onDragOver={handleDragOver}
+                    onDragLeave={handleDragLeave}
+                    onClick={() => fileInputRef.current?.click()}
+                >
+                    {uploading ? (
+                        <div className="flex items-center justify-center gap-2 text-amber-600">
+                            <Loader2 size={24} className="animate-spin" />
+                            Uploading...
+                        </div>
+                    ) : (
+                        <>
+                            <Upload size={32} className="mx-auto text-gray-400 mb-2" />
+                            <p className="text-gray-600">Drag & drop images or videos here</p>
+                            <p className="text-gray-400 text-sm mt-1">or click to browse (JPG, PNG, WEBP, GIF, MP4, MOV, WEBM)</p>
+                        </>
+                    )}
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept="image/*,video/*"
+                        multiple
+                        className="hidden"
+                        onChange={(e) => handleFiles(Array.from(e.target.files))}
+                    />
+                </div>
+            </div>
+
+            {/* Filters */}
+            <div className="bg-white rounded-xl border border-amber-200 p-4">
+                <div className="flex flex-wrap gap-3 items-center">
+                    <Filter size={16} className="text-gray-400" />
+                    <select
+                        value={filterBrand}
+                        onChange={(e) => setFilterBrand(e.target.value)}
+                        className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+                    >
+                        <option value="">All Brands</option>
+                        {brands.map((b) => (
+                            <option key={b.id} value={b.id}>{b.name}</option>
+                        ))}
+                    </select>
+
+                    <div className="flex rounded-lg border border-gray-300 overflow-hidden">
+                        {['', 'image', 'video'].map((type) => (
+                            <button
+                                key={type}
+                                onClick={() => setFilterMediaType(type)}
+                                className={`px-3 py-1.5 text-sm ${
+                                    filterMediaType === type
+                                        ? 'bg-amber-600 text-white'
+                                        : 'bg-white text-gray-600 hover:bg-gray-50'
+                                }`}
+                            >
+                                {type === '' ? 'All' : type === 'image' ? 'Images' : 'Videos'}
+                            </button>
+                        ))}
+                    </div>
+
+                    <select
+                        value={filterFunnel}
+                        onChange={(e) => setFilterFunnel(e.target.value)}
+                        className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+                    >
+                        {FUNNEL_STAGES.map((s) => (
+                            <option key={s.value} value={s.value}>{s.label}</option>
+                        ))}
+                    </select>
+
+                    <select
+                        value={filterStatus}
+                        onChange={(e) => setFilterStatus(e.target.value)}
+                        className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+                    >
+                        {STATUSES.map((s) => (
+                            <option key={s.value} value={s.value}>{s.label}</option>
+                        ))}
+                    </select>
+                </div>
+            </div>
+
+            {/* Grid */}
+            {loading ? (
+                <div className="flex items-center justify-center py-12 text-amber-600">
+                    <Loader2 size={24} className="animate-spin mr-2" />
+                    Loading...
+                </div>
+            ) : items.length === 0 ? (
+                <div className="bg-white rounded-xl border border-amber-200 p-12 text-center">
+                    <FolderOpen size={48} className="mx-auto text-gray-300 mb-4" />
+                    <p className="text-gray-500 text-lg">No ads yet</p>
+                    <p className="text-gray-400 text-sm mt-1">Upload your first ad above!</p>
+                </div>
+            ) : (
+                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                    {items.map((item) => (
+                        <div
+                            key={item.id}
+                            className="bg-white rounded-lg border border-amber-200 overflow-hidden group"
+                        >
+                            {/* Thumbnail */}
+                            <div
+                                className="aspect-video bg-gray-100 relative cursor-pointer"
+                                onClick={() => setSelectedItem(item)}
+                            >
+                                {item.media_type === 'video' ? (
+                                    <>
+                                        <img
+                                            src={item.thumbnail_url || item.media_url}
+                                            alt={item.name || 'Ad'}
+                                            className="w-full h-full object-cover"
+                                            onError={(e) => { e.target.style.display = 'none'; }}
+                                        />
+                                        <div className="absolute inset-0 flex items-center justify-center">
+                                            <div className="w-10 h-10 bg-black/60 rounded-full flex items-center justify-center group-hover:bg-black/80 transition-colors">
+                                                <Play size={20} className="text-white ml-0.5" fill="white" />
+                                            </div>
+                                        </div>
+                                    </>
+                                ) : (
+                                    <img
+                                        src={item.media_url}
+                                        alt={item.name || 'Ad'}
+                                        className="w-full h-full object-cover"
+                                    />
+                                )}
+
+                                {/* Media type badge */}
+                                <span className="absolute top-2 left-2 px-2 py-0.5 bg-black/60 text-white text-xs rounded flex items-center gap-1">
+                                    {item.media_type === 'video' ? <Video size={10} /> : <Image size={10} />}
+                                    {item.media_type}
+                                </span>
+
+                                {/* Status badge */}
+                                <span className={`absolute top-2 right-2 px-2 py-0.5 text-xs rounded ${STATUS_COLORS[item.status] || 'bg-gray-100 text-gray-700'}`}>
+                                    {item.status}
+                                </span>
+
+                                {/* Hover actions */}
+                                <div className="absolute bottom-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                                    {item.media_type === 'image' && (
+                                        <button
+                                            onClick={(e) => { e.stopPropagation(); setVideoGenImage(item.media_url); }}
+                                            className="w-8 h-8 bg-purple-500/90 hover:bg-purple-600 rounded-full flex items-center justify-center text-white"
+                                            title="Generate Video"
+                                        >
+                                            <Wand2 size={14} />
+                                        </button>
+                                    )}
+                                    <button
+                                        onClick={(e) => { e.stopPropagation(); setEditItem({ ...item }); }}
+                                        className="w-8 h-8 bg-white/90 hover:bg-white rounded-full flex items-center justify-center text-gray-700"
+                                        title="Edit"
+                                    >
+                                        <Pencil size={14} />
+                                    </button>
+                                    <button
+                                        onClick={(e) => { e.stopPropagation(); setDeleteTarget(item); }}
+                                        className="w-8 h-8 bg-white/90 hover:bg-white rounded-full flex items-center justify-center text-red-600"
+                                        title="Delete"
+                                    >
+                                        <Trash2 size={14} />
+                                    </button>
+                                </div>
+                            </div>
+
+                            {/* Info */}
+                            <div className="p-3">
+                                <p className="text-sm font-medium text-gray-900 truncate">
+                                    {item.name || 'Untitled'}
+                                </p>
+                                <p className="text-xs text-amber-600 truncate">
+                                    {item.brand_name || 'No brand'}
+                                </p>
+                                <div className="flex items-center gap-2 mt-1 flex-wrap">
+                                    {item.funnel_stage && (
+                                        <span className="px-1.5 py-0.5 text-[10px] bg-purple-100 text-purple-700 rounded">
+                                            {item.funnel_stage.toUpperCase()}
+                                        </span>
+                                    )}
+                                    {item.ad_format && (
+                                        <span className="px-1.5 py-0.5 text-[10px] bg-blue-100 text-blue-700 rounded">
+                                            {item.ad_format.replace('_', ' ')}
+                                        </span>
+                                    )}
+                                    {item.tags && item.tags.map((tag, i) => (
+                                        <span key={i} className="px-1.5 py-0.5 text-[10px] bg-gray-100 text-gray-600 rounded">
+                                            {tag}
+                                        </span>
+                                    ))}
+                                </div>
+                                {item.file_size && (
+                                    <p className="text-[10px] text-gray-400 mt-1">{formatSize(item.file_size)}</p>
+                                )}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {/* View Modal */}
+            {selectedItem && (
+                <div
+                    className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4"
+                    onClick={() => setSelectedItem(null)}
+                >
+                    <div className="relative w-full max-w-4xl" onClick={(e) => e.stopPropagation()}>
+                        <button
+                            onClick={() => setSelectedItem(null)}
+                            className="absolute -top-10 right-0 text-white hover:text-gray-300 transition-colors z-10"
+                        >
+                            <X size={28} />
+                        </button>
+
+                        {(() => {
+                            const isActualVideo = selectedItem.media_url?.match(/\.(mp4|webm|mov)(\?|$)/i);
+                            return isActualVideo ? (
+                                <video
+                                    src={selectedItem.media_url}
+                                    controls
+                                    autoPlay
+                                    className="w-full rounded-lg max-h-[70vh] object-contain bg-black"
+                                />
+                            ) : (
+                                <img
+                                    src={selectedItem.media_url}
+                                    alt={selectedItem.name || 'Ad'}
+                                    className="w-full rounded-lg max-h-[70vh] object-contain bg-black"
+                                />
+                            );
+                        })()}
+
+                        <div className="mt-4 bg-white/10 backdrop-blur rounded-lg p-4">
+                            <div className="flex items-start justify-between gap-4">
+                                <div className="flex-1 min-w-0">
+                                    {selectedItem.brand_name && (
+                                        <p className="text-amber-400 text-sm font-medium">{selectedItem.brand_name}</p>
+                                    )}
+                                    <p className="text-white font-medium mt-1">{selectedItem.name || 'Untitled'}</p>
+                                    {selectedItem.headline && (
+                                        <p className="text-white/80 text-sm mt-1">{selectedItem.headline}</p>
+                                    )}
+                                    {selectedItem.body && (
+                                        <p className="text-white/60 text-sm mt-1">{selectedItem.body}</p>
+                                    )}
+                                    <div className="flex items-center gap-2 mt-2 flex-wrap">
+                                        {selectedItem.cta && (
+                                            <span className="px-2 py-0.5 text-xs bg-amber-500/20 text-amber-300 rounded">{selectedItem.cta}</span>
+                                        )}
+                                        {selectedItem.funnel_stage && (
+                                            <span className="px-2 py-0.5 text-xs bg-purple-500/20 text-purple-300 rounded">{selectedItem.funnel_stage.toUpperCase()}</span>
+                                        )}
+                                        {selectedItem.ad_format && (
+                                            <span className="px-2 py-0.5 text-xs bg-blue-500/20 text-blue-300 rounded">{selectedItem.ad_format.replace('_', ' ')}</span>
+                                        )}
+                                        <span className={`px-2 py-0.5 text-xs rounded ${STATUS_COLORS[selectedItem.status] || ''}`}>{selectedItem.status}</span>
+                                    </div>
+                                </div>
+                                <div className="flex items-center gap-2 flex-shrink-0">
+                                    {selectedItem.media_type === 'image' && (
+                                        <button
+                                            onClick={() => {
+                                                setVideoGenImage(selectedItem.media_url);
+                                                setSelectedItem(null);
+                                            }}
+                                            className="flex items-center gap-2 px-4 py-2 bg-purple-600 hover:bg-purple-700 text-white rounded-lg transition-colors"
+                                        >
+                                            <Wand2 size={16} />
+                                            Generate Video
+                                        </button>
+                                    )}
+                                    <button
+                                        onClick={async () => {
+                                            try {
+                                                const resp = await fetch(selectedItem.media_url);
+                                                const blob = await resp.blob();
+                                                const url = URL.createObjectURL(blob);
+                                                const a = document.createElement('a');
+                                                a.href = url;
+                                                a.download = selectedItem.media_url.split('/').pop() || 'download';
+                                                document.body.appendChild(a);
+                                                a.click();
+                                                document.body.removeChild(a);
+                                                URL.revokeObjectURL(url);
+                                            } catch { window.open(selectedItem.media_url, '_blank'); }
+                                        }}
+                                        className="flex items-center gap-2 px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white rounded-lg transition-colors"
+                                    >
+                                        <Download size={16} />
+                                        Download
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Edit Modal */}
+            {editItem && (
+                <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4" onClick={() => setEditItem(null)}>
+                    <div className="bg-white rounded-xl p-6 max-w-lg w-full max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+                        <div className="flex items-center justify-between mb-4">
+                            <h3 className="text-lg font-semibold text-gray-900">Edit Ad</h3>
+                            <button onClick={() => setEditItem(null)} className="text-gray-400 hover:text-gray-600">
+                                <X size={20} />
+                            </button>
+                        </div>
+
+                        <div className="space-y-4">
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
+                                <input
+                                    type="text"
+                                    value={editItem.name || ''}
+                                    onChange={(e) => setEditItem({ ...editItem, name: e.target.value })}
+                                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+                                    placeholder="Ad name"
+                                />
+                            </div>
+
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Brand</label>
+                                <select
+                                    value={editItem.brand_id || ''}
+                                    onChange={(e) => setEditItem({ ...editItem, brand_id: e.target.value || null })}
+                                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+                                >
+                                    <option value="">No Brand</option>
+                                    {brands.map((b) => (
+                                        <option key={b.id} value={b.id}>{b.name}</option>
+                                    ))}
+                                </select>
+                            </div>
+
+                            <div className="grid grid-cols-2 gap-4">
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-1">Funnel Stage</label>
+                                    <select
+                                        value={editItem.funnel_stage || ''}
+                                        onChange={(e) => setEditItem({ ...editItem, funnel_stage: e.target.value || null })}
+                                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+                                    >
+                                        <option value="">None</option>
+                                        <option value="tofu">TOFU (Awareness)</option>
+                                        <option value="mofu">MOFU (Consideration)</option>
+                                        <option value="bofu">BOFU (Conversion)</option>
+                                    </select>
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-1">Ad Format</label>
+                                    <select
+                                        value={editItem.ad_format || ''}
+                                        onChange={(e) => setEditItem({ ...editItem, ad_format: e.target.value || null })}
+                                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+                                    >
+                                        {AD_FORMATS.map((f) => (
+                                            <option key={f.value} value={f.value}>{f.label}</option>
+                                        ))}
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
+                                <select
+                                    value={editItem.status || 'draft'}
+                                    onChange={(e) => setEditItem({ ...editItem, status: e.target.value })}
+                                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+                                >
+                                    <option value="draft">Draft</option>
+                                    <option value="ready">Ready</option>
+                                    <option value="active">Active</option>
+                                    <option value="archived">Archived</option>
+                                </select>
+                            </div>
+
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Headline</label>
+                                <input
+                                    type="text"
+                                    value={editItem.headline || ''}
+                                    onChange={(e) => setEditItem({ ...editItem, headline: e.target.value })}
+                                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+                                    placeholder="Ad headline"
+                                />
+                            </div>
+
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Body</label>
+                                <textarea
+                                    value={editItem.body || ''}
+                                    onChange={(e) => setEditItem({ ...editItem, body: e.target.value })}
+                                    rows={3}
+                                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+                                    placeholder="Ad body text"
+                                />
+                            </div>
+
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">CTA</label>
+                                <input
+                                    type="text"
+                                    value={editItem.cta || ''}
+                                    onChange={(e) => setEditItem({ ...editItem, cta: e.target.value })}
+                                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+                                    placeholder="Call to action"
+                                />
+                            </div>
+
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Tags (comma-separated)</label>
+                                <input
+                                    type="text"
+                                    value={(editItem.tags || []).join(', ')}
+                                    onChange={(e) => setEditItem({
+                                        ...editItem,
+                                        tags: e.target.value ? e.target.value.split(',').map(t => t.trim()).filter(Boolean) : []
+                                    })}
+                                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+                                    placeholder="e.g., testimonial, Q1, promo"
+                                />
+                            </div>
+                        </div>
+
+                        <div className="flex gap-3 justify-end mt-6">
+                            <button
+                                onClick={() => setEditItem(null)}
+                                className="px-4 py-2 text-gray-600 hover:bg-gray-100 rounded-lg"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                onClick={handleSaveEdit}
+                                className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700"
+                            >
+                                Save Changes
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Delete Modal */}
+            {deleteTarget && (
+                <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+                    <div className="bg-white rounded-xl p-6 max-w-md w-full mx-4">
+                        <h3 className="text-lg font-semibold text-gray-900 mb-2">Delete Ad?</h3>
+                        <p className="text-gray-600 mb-4">
+                            This will permanently delete "{deleteTarget.name || 'Untitled'}" and its media file. This action cannot be undone.
+                        </p>
+                        <div className="flex gap-3 justify-end">
+                            <button
+                                onClick={() => setDeleteTarget(null)}
+                                className="px-4 py-2 text-gray-600 hover:bg-gray-100 rounded-lg"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                onClick={handleDelete}
+                                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
+                            >
+                                Delete
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Generate Video Modal */}
+            {videoGenImage && (
+                <GenerateVideoModal
+                    imageUrl={videoGenImage}
+                    onClose={() => setVideoGenImage(null)}
+                    onVideoReady={(videoUrl) => {
+                        showSuccess('Video generated! Refresh to see it in your library.');
+                        setVideoGenImage(null);
+                        fetchItems();
+                    }}
+                />
+            )}
+        </div>
+    );
+};
+
+export default AdsLibrary;

--- a/frontend/src/pages/AdsLibrary.jsx
+++ b/frontend/src/pages/AdsLibrary.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useToast } from '../context/ToastContext';
 import { useBrands } from '../context/BrandContext';
-import { getLibraryItems, createLibraryItem, updateLibraryItem, deleteLibraryItem, uploadFile } from '../api/adsLibrary';
-import { Upload, Image, Video, Trash2, Pencil, X, Download, ChevronLeft, ChevronRight, Play, FolderOpen, Loader2, Plus, ExternalLink, Filter, Wand2 } from 'lucide-react';
+import { getLibraryItems, createLibraryItem, updateLibraryItem, deleteLibraryItem, uploadFile, getAiName, extractVideoThumbnail, detectAspectRatio } from '../api/adsLibrary';
+import { Upload, Image, Video, Trash2, Pencil, X, Download, Play, FolderOpen, Loader2, Wand2, Layers, Plus, Filter, Sparkles } from 'lucide-react';
 import GenerateVideoModal from '../components/GenerateVideoModal';
 
 const FUNNEL_STAGES = [
@@ -56,9 +56,14 @@ const AdsLibrary = () => {
 
     // Upload
     const [uploading, setUploading] = useState(false);
+    const [uploadProgress, setUploadProgress] = useState('');
     const [uploadBrand, setUploadBrand] = useState('');
     const [dragActive, setDragActive] = useState(false);
     const fileInputRef = useRef(null);
+
+    // Add variant
+    const [addVariantTarget, setAddVariantTarget] = useState(null);
+    const variantInputRef = useRef(null);
 
     // Modals
     const [selectedItem, setSelectedItem] = useState(null);
@@ -107,15 +112,55 @@ const AdsLibrary = () => {
             }
 
             try {
+                setUploadProgress(`Uploading ${file.name}...`);
+
                 // Upload file to R2
                 const { url, media_type } = await uploadFile(file);
+
+                let thumbnailUrl = null;
+                let variants = null;
+                let aiName = null;
+
+                if (isVideo) {
+                    // Extract video thumbnail
+                    try {
+                        setUploadProgress(`Extracting thumbnail from ${file.name}...`);
+                        const thumbBlob = await extractVideoThumbnail(file);
+                        const thumbFile = new File([thumbBlob], `thumb_${file.name.replace(/\.[^.]+$/, '.jpg')}`, { type: 'image/jpeg' });
+                        const thumbResult = await uploadFile(thumbFile);
+                        thumbnailUrl = thumbResult.url;
+                    } catch (e) {
+                        console.warn('Thumbnail extraction failed:', e);
+                    }
+                }
+
+                if (isImage) {
+                    // Detect aspect ratio and store in variants
+                    try {
+                        const ratio = await detectAspectRatio(file);
+                        variants = { [ratio]: url };
+                    } catch (e) {
+                        console.warn('Aspect ratio detection failed:', e);
+                    }
+                }
+
+                // AI-generated name
+                try {
+                    setUploadProgress(`Naming ${file.name} with AI...`);
+                    const { name } = await getAiName(url);
+                    aiName = name;
+                } catch (e) {
+                    console.warn('AI naming failed:', e);
+                }
 
                 // Create library item
                 await createLibraryItem({
                     brand_id: uploadBrand,
-                    name: file.name.replace(/\.[^.]+$/, ''),
+                    name: aiName || file.name.replace(/\.[^.]+$/, ''),
                     media_type: media_type,
                     media_url: url,
+                    thumbnail_url: thumbnailUrl,
+                    variants: variants,
                     file_size: file.size,
                     status: 'draft',
                 });
@@ -130,6 +175,35 @@ const AdsLibrary = () => {
             fetchItems();
         }
         setUploading(false);
+        setUploadProgress('');
+    };
+
+    const handleAddVariant = async (files) => {
+        if (!addVariantTarget || !files.length) return;
+        const file = files[0];
+        if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+            showError('Only images can be added as size variants');
+            return;
+        }
+
+        setUploading(true);
+        try {
+            setUploadProgress(`Uploading variant for ${addVariantTarget.name}...`);
+            const { url } = await uploadFile(file);
+            const ratio = await detectAspectRatio(file);
+            const existingVariants = addVariantTarget.variants || {};
+            const newVariants = { ...existingVariants, [ratio]: url };
+
+            await updateLibraryItem(addVariantTarget.id, { variants: newVariants });
+            showSuccess(`Added ${ratio} variant`);
+            setAddVariantTarget(null);
+            fetchItems();
+        } catch (error) {
+            showError('Failed to add variant');
+        } finally {
+            setUploading(false);
+            setUploadProgress('');
+        }
     };
 
     const handleDrop = (e) => {
@@ -188,6 +262,28 @@ const AdsLibrary = () => {
         return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
     };
 
+    const variantCount = (item) => {
+        if (!item.variants) return 0;
+        return Object.keys(item.variants).length;
+    };
+
+    const handleDownload = async (url) => {
+        try {
+            const resp = await fetch(url);
+            const blob = await resp.blob();
+            const blobUrl = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = blobUrl;
+            a.download = url.split('/').pop() || 'download';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(blobUrl);
+        } catch {
+            window.open(url, '_blank');
+        }
+    };
+
     return (
         <div className="space-y-6">
             {/* Header */}
@@ -230,15 +326,15 @@ const AdsLibrary = () => {
                     onClick={() => fileInputRef.current?.click()}
                 >
                     {uploading ? (
-                        <div className="flex items-center justify-center gap-2 text-amber-600">
+                        <div className="flex flex-col items-center gap-2 text-amber-600">
                             <Loader2 size={24} className="animate-spin" />
-                            Uploading...
+                            <span>{uploadProgress || 'Uploading...'}</span>
                         </div>
                     ) : (
                         <>
                             <Upload size={32} className="mx-auto text-gray-400 mb-2" />
                             <p className="text-gray-600">Drag & drop images or videos here</p>
-                            <p className="text-gray-400 text-sm mt-1">or click to browse (JPG, PNG, WEBP, GIF, MP4, MOV, WEBM)</p>
+                            <p className="text-gray-400 text-sm mt-1">JPG, PNG, WEBP, GIF, MP4, MOV, WEBM &mdash; AI auto-names your ads</p>
                         </>
                     )}
                     <input
@@ -331,12 +427,17 @@ const AdsLibrary = () => {
                             >
                                 {item.media_type === 'video' ? (
                                     <>
-                                        <img
-                                            src={item.thumbnail_url || item.media_url}
-                                            alt={item.name || 'Ad'}
-                                            className="w-full h-full object-cover"
-                                            onError={(e) => { e.target.style.display = 'none'; }}
-                                        />
+                                        {item.thumbnail_url ? (
+                                            <img
+                                                src={item.thumbnail_url}
+                                                alt={item.name || 'Video'}
+                                                className="w-full h-full object-cover"
+                                            />
+                                        ) : (
+                                            <div className="w-full h-full flex items-center justify-center bg-gray-800">
+                                                <Video size={32} className="text-gray-500" />
+                                            </div>
+                                        )}
                                         <div className="absolute inset-0 flex items-center justify-center">
                                             <div className="w-10 h-10 bg-black/60 rounded-full flex items-center justify-center group-hover:bg-black/80 transition-colors">
                                                 <Play size={20} className="text-white ml-0.5" fill="white" />
@@ -357,6 +458,14 @@ const AdsLibrary = () => {
                                     {item.media_type}
                                 </span>
 
+                                {/* Variants badge */}
+                                {variantCount(item) > 1 && (
+                                    <span className="absolute bottom-2 left-2 px-2 py-0.5 bg-purple-600/90 text-white text-xs rounded flex items-center gap-1">
+                                        <Layers size={10} />
+                                        {variantCount(item)} sizes
+                                    </span>
+                                )}
+
                                 {/* Status badge */}
                                 <span className={`absolute top-2 right-2 px-2 py-0.5 text-xs rounded ${STATUS_COLORS[item.status] || 'bg-gray-100 text-gray-700'}`}>
                                     {item.status}
@@ -365,13 +474,26 @@ const AdsLibrary = () => {
                                 {/* Hover actions */}
                                 <div className="absolute bottom-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
                                     {item.media_type === 'image' && (
-                                        <button
-                                            onClick={(e) => { e.stopPropagation(); setVideoGenImage(item.media_url); }}
-                                            className="w-8 h-8 bg-purple-500/90 hover:bg-purple-600 rounded-full flex items-center justify-center text-white"
-                                            title="Generate Video"
-                                        >
-                                            <Wand2 size={14} />
-                                        </button>
+                                        <>
+                                            <button
+                                                onClick={(e) => { e.stopPropagation(); setVideoGenImage(item.media_url); }}
+                                                className="w-8 h-8 bg-purple-500/90 hover:bg-purple-600 rounded-full flex items-center justify-center text-white"
+                                                title="Generate Video"
+                                            >
+                                                <Wand2 size={14} />
+                                            </button>
+                                            <button
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    setAddVariantTarget(item);
+                                                    setTimeout(() => variantInputRef.current?.click(), 100);
+                                                }}
+                                                className="w-8 h-8 bg-indigo-500/90 hover:bg-indigo-600 rounded-full flex items-center justify-center text-white"
+                                                title="Add size variant"
+                                            >
+                                                <Plus size={14} />
+                                            </button>
+                                        </>
                                     )}
                                     <button
                                         onClick={(e) => { e.stopPropagation(); setEditItem({ ...item }); }}
@@ -399,6 +521,13 @@ const AdsLibrary = () => {
                                     {item.brand_name || 'No brand'}
                                 </p>
                                 <div className="flex items-center gap-2 mt-1 flex-wrap">
+                                    {item.variants && Object.keys(item.variants).length > 0 && (
+                                        Object.keys(item.variants).map((ratio) => (
+                                            <span key={ratio} className="px-1.5 py-0.5 text-[10px] bg-indigo-100 text-indigo-700 rounded">
+                                                {ratio}
+                                            </span>
+                                        ))
+                                    )}
                                     {item.funnel_stage && (
                                         <span className="px-1.5 py-0.5 text-[10px] bg-purple-100 text-purple-700 rounded">
                                             {item.funnel_stage.toUpperCase()}
@@ -423,6 +552,18 @@ const AdsLibrary = () => {
                     ))}
                 </div>
             )}
+
+            {/* Hidden input for adding variant */}
+            <input
+                ref={variantInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={(e) => {
+                    handleAddVariant(Array.from(e.target.files));
+                    e.target.value = '';
+                }}
+            />
 
             {/* View Modal */}
             {selectedItem && (
@@ -455,6 +596,28 @@ const AdsLibrary = () => {
                                 />
                             );
                         })()}
+
+                        {/* Variant previews */}
+                        {selectedItem.variants && Object.keys(selectedItem.variants).length > 1 && (
+                            <div className="mt-3">
+                                <p className="text-white/60 text-xs mb-2">Size Variants:</p>
+                                <div className="flex gap-3">
+                                    {Object.entries(selectedItem.variants).map(([ratio, url]) => (
+                                        <div key={ratio} className="text-center">
+                                            <img
+                                                src={url}
+                                                alt={ratio}
+                                                className={`rounded border-2 transition-colors cursor-pointer ${
+                                                    selectedItem.media_url === url ? 'border-amber-500' : 'border-transparent hover:border-white/50'
+                                                } ${ratio === '9:16' || ratio === '4:5' ? 'h-24 w-auto' : 'h-16 w-auto'}`}
+                                                onClick={() => setSelectedItem({ ...selectedItem, media_url: url })}
+                                            />
+                                            <span className="text-white/70 text-xs mt-1 block">{ratio}</span>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
 
                         <div className="mt-4 bg-white/10 backdrop-blur rounded-lg p-4">
                             <div className="flex items-start justify-between gap-4">
@@ -496,20 +659,7 @@ const AdsLibrary = () => {
                                         </button>
                                     )}
                                     <button
-                                        onClick={async () => {
-                                            try {
-                                                const resp = await fetch(selectedItem.media_url);
-                                                const blob = await resp.blob();
-                                                const url = URL.createObjectURL(blob);
-                                                const a = document.createElement('a');
-                                                a.href = url;
-                                                a.download = selectedItem.media_url.split('/').pop() || 'download';
-                                                document.body.appendChild(a);
-                                                a.click();
-                                                document.body.removeChild(a);
-                                                URL.revokeObjectURL(url);
-                                            } catch { window.open(selectedItem.media_url, '_blank'); }
-                                        }}
+                                        onClick={() => handleDownload(selectedItem.media_url)}
                                         className="flex items-center gap-2 px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white rounded-lg transition-colors"
                                     >
                                         <Download size={16} />
@@ -536,13 +686,30 @@ const AdsLibrary = () => {
                         <div className="space-y-4">
                             <div>
                                 <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
-                                <input
-                                    type="text"
-                                    value={editItem.name || ''}
-                                    onChange={(e) => setEditItem({ ...editItem, name: e.target.value })}
-                                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
-                                    placeholder="Ad name"
-                                />
+                                <div className="flex gap-2">
+                                    <input
+                                        type="text"
+                                        value={editItem.name || ''}
+                                        onChange={(e) => setEditItem({ ...editItem, name: e.target.value })}
+                                        className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+                                        placeholder="Ad name"
+                                    />
+                                    <button
+                                        onClick={async () => {
+                                            try {
+                                                const { name } = await getAiName(editItem.media_url);
+                                                setEditItem({ ...editItem, name });
+                                            } catch {
+                                                showError('AI naming failed');
+                                            }
+                                        }}
+                                        className="px-3 py-2 bg-purple-100 hover:bg-purple-200 text-purple-700 rounded-lg text-sm flex items-center gap-1"
+                                        title="Generate name with AI"
+                                    >
+                                        <Sparkles size={14} />
+                                        AI
+                                    </button>
+                                </div>
                             </div>
 
                             <div>

--- a/frontend/src/pages/AdsLibrary.jsx
+++ b/frontend/src/pages/AdsLibrary.jsx
@@ -65,6 +65,9 @@ const AdsLibrary = () => {
     const [addVariantTarget, setAddVariantTarget] = useState(null);
     const variantInputRef = useRef(null);
 
+    // Review queue (items pending review before saving)
+    const [reviewQueue, setReviewQueue] = useState([]);
+
     // Modals
     const [selectedItem, setSelectedItem] = useState(null);
     const [editItem, setEditItem] = useState(null);
@@ -92,7 +95,10 @@ const AdsLibrary = () => {
         fetchItems();
     }, [fetchItems]);
 
-    // Upload handlers
+    // Standard ratios for FB ads
+    const STANDARD_RATIOS = ['1:1', '9:16', '4:5'];
+
+    // Upload handlers — now populates review queue instead of creating items immediately
     const handleFiles = async (files) => {
         if (!uploadBrand) {
             showError('Please select a brand first');
@@ -100,7 +106,6 @@ const AdsLibrary = () => {
         }
 
         setUploading(true);
-        let uploaded = 0;
 
         // Separate images and videos
         const imageFiles = [];
@@ -112,7 +117,7 @@ const AdsLibrary = () => {
         }
 
         // Phase 1: Upload all image files and detect ratios
-        const imageUploads = []; // { file, url, ratio }
+        const imageUploads = [];
         for (const file of imageFiles) {
             try {
                 setUploadProgress(`Uploading ${file.name}...`);
@@ -129,22 +134,17 @@ const AdsLibrary = () => {
             }
         }
 
-        // Phase 2: Group images by ratio pairs (e.g., 1:1 + 9:16 → one entry)
-        const groups = []; // each group = array of { url, ratio, size }
+        // Phase 2: Group images by ratio pairs
+        const groups = [];
         const used = new Set();
-
-        // Try to pair images with different ratios
         for (let i = 0; i < imageUploads.length; i++) {
             if (used.has(i)) continue;
             const a = imageUploads[i];
             let paired = false;
-
-            // Look for a partner with a different ratio
             for (let j = i + 1; j < imageUploads.length; j++) {
                 if (used.has(j)) continue;
                 const b = imageUploads[j];
                 if (a.ratio !== b.ratio && a.ratio !== 'unknown' && b.ratio !== 'unknown') {
-                    // Pair them
                     groups.push([a, b]);
                     used.add(i);
                     used.add(j);
@@ -158,86 +158,170 @@ const AdsLibrary = () => {
             }
         }
 
-        // Phase 3: Create library items for each group
+        // Phase 3: Build review queue items for images
+        const newQueueItems = [];
+
         for (const group of groups) {
-            try {
-                const primary = group[0];
-                const variants = {};
-                let totalSize = 0;
-                for (const item of group) {
-                    variants[item.ratio] = item.url;
-                    totalSize += item.size;
-                }
-
-                // AI name from primary image
-                let aiName = null;
-                try {
-                    setUploadProgress(`Naming with AI...`);
-                    const { name } = await getAiName(primary.url);
-                    aiName = name;
-                } catch (e) {
-                    console.warn('AI naming failed:', e);
-                }
-
-                const ratioLabel = group.length > 1
-                    ? ` (${group.map(g => g.ratio).join(' + ')})`
-                    : '';
-
-                await createLibraryItem({
-                    brand_id: uploadBrand,
-                    name: aiName || primary.file.name.replace(/\.[^.]+$/, '') + ratioLabel,
-                    media_type: 'image',
-                    media_url: primary.url,
-                    variants,
-                    file_size: totalSize,
-                    status: 'draft',
-                });
-                uploaded++;
-            } catch (error) {
-                showError('Failed to create library item');
+            const tempId = `review_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+            const primary = group[0];
+            const variants = {};
+            let totalSize = 0;
+            for (const item of group) {
+                variants[item.ratio] = item.url;
+                totalSize += item.size;
             }
+
+            const uploadedRatios = Object.keys(variants);
+            const missingRatios = STANDARD_RATIOS.filter(r => !uploadedRatios.includes(r));
+
+            newQueueItems.push({
+                id: tempId,
+                mediaType: 'image',
+                primaryUrl: primary.url,
+                thumbnailUrl: null,
+                variants,
+                totalSize,
+                name: primary.file.name.replace(/\.[^.]+$/, ''),
+                nameLoading: true,
+                missingRatios,
+                tags: [],
+                funnel_stage: '',
+                ad_format: '',
+                status: 'draft',
+            });
         }
 
-        // Phase 4: Handle video files
+        // Phase 4: Handle video files — upload + extract thumbnail, add to queue
         for (const file of videoFiles) {
             try {
                 setUploadProgress(`Uploading ${file.name}...`);
                 const { url } = await uploadFile(file);
 
-                // Server-side thumbnail extraction via ffmpeg
                 let thumbnailUrl = null;
                 try {
-                    setUploadProgress(`Extracting thumbnail (server)...`);
+                    setUploadProgress(`Extracting thumbnail...`);
                     const { thumbnail_url } = await getVideoThumbnail(url);
                     thumbnailUrl = thumbnail_url;
                 } catch (e) {
                     console.warn('Server thumbnail extraction failed:', e?.message || e);
                 }
 
-                // Videos just use filename, no AI naming
-                const videoName = file.name.replace(/\.[^.]+$/, '');
-
-                await createLibraryItem({
-                    brand_id: uploadBrand,
-                    name: videoName,
-                    media_type: 'video',
-                    media_url: url,
-                    thumbnail_url: thumbnailUrl,
-                    file_size: file.size,
+                const tempId = `review_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+                newQueueItems.push({
+                    id: tempId,
+                    mediaType: 'video',
+                    primaryUrl: url,
+                    thumbnailUrl,
+                    variants: {},
+                    totalSize: file.size,
+                    name: file.name.replace(/\.[^.]+$/, ''),
+                    nameLoading: false,
+                    missingRatios: [],
+                    tags: [],
+                    funnel_stage: '',
+                    ad_format: '',
                     status: 'draft',
                 });
-                uploaded++;
             } catch (error) {
                 showError(`Failed to upload ${file.name}`);
             }
         }
 
-        if (uploaded > 0) {
-            showSuccess(`Uploaded ${uploaded} item${uploaded > 1 ? 's' : ''}`);
+        setReviewQueue(prev => [...prev, ...newQueueItems]);
+        setUploading(false);
+        setUploadProgress('');
+
+        // Kick off AI naming in parallel for image items
+        for (const item of newQueueItems.filter(i => i.mediaType === 'image')) {
+            getAiName(item.primaryUrl)
+                .then(({ name }) => {
+                    setReviewQueue(prev => prev.map(q =>
+                        q.id === item.id ? { ...q, name, nameLoading: false } : q
+                    ));
+                })
+                .catch(() => {
+                    setReviewQueue(prev => prev.map(q =>
+                        q.id === item.id ? { ...q, nameLoading: false } : q
+                    ));
+                });
+        }
+    };
+
+    // Save all review queue items to the library
+    const handleSaveAll = async () => {
+        setUploading(true);
+        let saved = 0;
+
+        for (const item of reviewQueue) {
+            try {
+                setUploadProgress(`Saving "${item.name}"...`);
+                await createLibraryItem({
+                    brand_id: uploadBrand,
+                    name: item.name,
+                    media_type: item.mediaType,
+                    media_url: item.primaryUrl,
+                    thumbnail_url: item.thumbnailUrl || null,
+                    variants: Object.keys(item.variants).length > 0 ? item.variants : null,
+                    file_size: item.totalSize,
+                    tags: item.tags.length > 0 ? item.tags : null,
+                    funnel_stage: item.funnel_stage || null,
+                    ad_format: item.ad_format || null,
+                    status: item.status,
+                });
+                saved++;
+            } catch (error) {
+                showError(`Failed to save "${item.name}"`);
+            }
+        }
+
+        if (saved > 0) {
+            showSuccess(`Saved ${saved} item${saved > 1 ? 's' : ''}`);
+            setReviewQueue([]);
             fetchItems();
         }
         setUploading(false);
         setUploadProgress('');
+    };
+
+    // Update a field on a review queue item
+    const updateQueueItem = (itemId, updates) => {
+        setReviewQueue(prev => prev.map(q =>
+            q.id === itemId ? { ...q, ...updates } : q
+        ));
+    };
+
+    // Remove an item from the review queue
+    const removeFromQueue = (itemId) => {
+        setReviewQueue(prev => prev.filter(q => q.id !== itemId));
+    };
+
+    // Drop a file onto a missing ratio slot
+    const handleDropOnMissingRatio = async (queueItemId, files) => {
+        const file = files[0];
+        if (!file || !ALLOWED_IMAGE_TYPES.includes(file.type)) {
+            showError('Only images can be added as size variants');
+            return;
+        }
+
+        setUploading(true);
+        setUploadProgress(`Uploading variant...`);
+        try {
+            const { url } = await uploadFile(file);
+            const detectedRatio = await detectAspectRatio(file);
+
+            setReviewQueue(prev => prev.map(q => {
+                if (q.id !== queueItemId) return q;
+                const newVariants = { ...q.variants, [detectedRatio]: url };
+                const newMissing = q.missingRatios.filter(r => r !== detectedRatio);
+                return { ...q, variants: newVariants, missingRatios: newMissing, totalSize: q.totalSize + file.size };
+            }));
+            showSuccess(`Added ${detectedRatio} variant`);
+        } catch (error) {
+            showError('Failed to upload variant');
+        } finally {
+            setUploading(false);
+            setUploadProgress('');
+        }
     };
 
     const handleAddVariant = async (files) => {
@@ -409,6 +493,149 @@ const AdsLibrary = () => {
                     />
                 </div>
             </div>
+
+            {/* Review Queue */}
+            {reviewQueue.length > 0 && (
+                <div className="bg-white rounded-xl border border-indigo-200 p-6">
+                    <div className="flex items-center justify-between mb-4">
+                        <h2 className="text-lg font-semibold text-gray-900">
+                            Review Uploads ({reviewQueue.length} item{reviewQueue.length !== 1 ? 's' : ''})
+                        </h2>
+                        <div className="flex gap-3">
+                            <button onClick={() => setReviewQueue([])} className="px-4 py-2 text-gray-600 hover:bg-gray-100 rounded-lg text-sm">
+                                Discard All
+                            </button>
+                            <button
+                                onClick={handleSaveAll}
+                                disabled={uploading}
+                                className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 text-sm font-medium disabled:opacity-50"
+                            >
+                                Save All
+                            </button>
+                        </div>
+                    </div>
+
+                    <div className="space-y-4">
+                        {reviewQueue.map((qItem) => (
+                            <div key={qItem.id} className="flex gap-4 p-4 border border-gray-200 rounded-lg bg-gray-50">
+                                {/* Thumbnail */}
+                                <div className="w-32 h-32 flex-shrink-0 rounded-lg overflow-hidden bg-gray-200">
+                                    {qItem.mediaType === 'video' ? (
+                                        qItem.thumbnailUrl ? (
+                                            <img src={qItem.thumbnailUrl} alt="" className="w-full h-full object-cover" />
+                                        ) : (
+                                            <div className="w-full h-full flex items-center justify-center bg-gray-800">
+                                                <Video size={24} className="text-gray-500" />
+                                            </div>
+                                        )
+                                    ) : (
+                                        <img src={qItem.primaryUrl} alt="" className="w-full h-full object-cover" />
+                                    )}
+                                </div>
+
+                                {/* Fields */}
+                                <div className="flex-1 space-y-3">
+                                    {/* Name */}
+                                    <div className="flex items-center gap-2">
+                                        {qItem.nameLoading ? (
+                                            <div className="flex items-center gap-2 text-sm text-gray-500">
+                                                <Loader2 size={14} className="animate-spin" />
+                                                AI naming...
+                                            </div>
+                                        ) : null}
+                                        <input
+                                            type="text"
+                                            value={qItem.name}
+                                            onChange={(e) => updateQueueItem(qItem.id, { name: e.target.value })}
+                                            placeholder="Ad name"
+                                            className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+                                        />
+                                    </div>
+
+                                    {/* Ratio badges (images only) */}
+                                    {qItem.mediaType === 'image' && (
+                                        <div className="flex flex-wrap gap-2">
+                                            {/* Uploaded ratios */}
+                                            {Object.keys(qItem.variants).map((ratio) => (
+                                                <span key={ratio} className="inline-flex items-center gap-1 px-2 py-1 bg-green-100 text-green-700 text-xs rounded-md font-medium">
+                                                    <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+                                                    {ratio}
+                                                </span>
+                                            ))}
+                                            {/* Missing ratios as drop zones */}
+                                            {qItem.missingRatios.map((ratio) => (
+                                                <label
+                                                    key={ratio}
+                                                    className="inline-flex items-center gap-1 px-2 py-1 border border-dashed border-gray-400 text-gray-500 text-xs rounded-md cursor-pointer hover:border-amber-500 hover:text-amber-600 transition-colors"
+                                                    onDragOver={(e) => e.preventDefault()}
+                                                    onDrop={(e) => {
+                                                        e.preventDefault();
+                                                        handleDropOnMissingRatio(qItem.id, Array.from(e.dataTransfer.files));
+                                                    }}
+                                                >
+                                                    <Plus size={12} />
+                                                    {ratio}
+                                                    <input
+                                                        type="file"
+                                                        accept="image/*"
+                                                        className="hidden"
+                                                        onChange={(e) => handleDropOnMissingRatio(qItem.id, Array.from(e.target.files))}
+                                                    />
+                                                </label>
+                                            ))}
+                                        </div>
+                                    )}
+
+                                    {qItem.mediaType === 'video' && (
+                                        <span className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-700 text-xs rounded-md font-medium">
+                                            <Video size={12} /> Video
+                                        </span>
+                                    )}
+
+                                    {/* Metadata row */}
+                                    <div className="flex flex-wrap gap-2">
+                                        <select
+                                            value={qItem.funnel_stage}
+                                            onChange={(e) => updateQueueItem(qItem.id, { funnel_stage: e.target.value })}
+                                            className="px-2 py-1 text-xs border border-gray-300 rounded-lg"
+                                        >
+                                            <option value="">Funnel Stage</option>
+                                            <option value="tofu">TOFU</option>
+                                            <option value="mofu">MOFU</option>
+                                            <option value="bofu">BOFU</option>
+                                        </select>
+                                        <select
+                                            value={qItem.ad_format}
+                                            onChange={(e) => updateQueueItem(qItem.id, { ad_format: e.target.value })}
+                                            className="px-2 py-1 text-xs border border-gray-300 rounded-lg"
+                                        >
+                                            {AD_FORMATS.map((f) => (
+                                                <option key={f.value} value={f.value}>{f.label}</option>
+                                            ))}
+                                        </select>
+                                        <input
+                                            type="text"
+                                            value={qItem.tags.join(', ')}
+                                            onChange={(e) => updateQueueItem(qItem.id, {
+                                                tags: e.target.value.split(',').map(t => t.trim()).filter(Boolean)
+                                            })}
+                                            placeholder="Tags (comma-separated)"
+                                            className="flex-1 min-w-[120px] px-2 py-1 text-xs border border-gray-300 rounded-lg"
+                                        />
+                                        <button
+                                            onClick={() => removeFromQueue(qItem.id)}
+                                            className="px-2 py-1 text-red-500 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors"
+                                            title="Remove"
+                                        >
+                                            <Trash2 size={14} />
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
 
             {/* Filters */}
             <div className="bg-white rounded-xl border border-amber-200 p-4">

--- a/frontend/src/pages/AdsLibrary.jsx
+++ b/frontend/src/pages/AdsLibrary.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useToast } from '../context/ToastContext';
 import { useBrands } from '../context/BrandContext';
-import { getLibraryItems, createLibraryItem, updateLibraryItem, deleteLibraryItem, uploadFile, getAiName, extractVideoThumbnail, detectAspectRatio } from '../api/adsLibrary';
+import { getLibraryItems, createLibraryItem, updateLibraryItem, deleteLibraryItem, uploadFile, getAiName, getVideoThumbnail, detectAspectRatio } from '../api/adsLibrary';
 import { Upload, Image, Video, Trash2, Pencil, X, Download, Play, FolderOpen, Loader2, Wand2, Layers, Plus, Filter, Sparkles } from 'lucide-react';
 import GenerateVideoModal from '../components/GenerateVideoModal';
 
@@ -204,32 +204,22 @@ const AdsLibrary = () => {
                 setUploadProgress(`Uploading ${file.name}...`);
                 const { url } = await uploadFile(file);
 
+                // Server-side thumbnail extraction via ffmpeg
                 let thumbnailUrl = null;
                 try {
-                    setUploadProgress(`Extracting thumbnail...`);
-                    const thumbBlob = await extractVideoThumbnail(file);
-                    const thumbFile = new File([thumbBlob], `thumb_${file.name.replace(/\.[^.]+$/, '.jpg')}`, { type: 'image/jpeg' });
-                    const thumbResult = await uploadFile(thumbFile);
-                    thumbnailUrl = thumbResult.url;
+                    setUploadProgress(`Extracting thumbnail (server)...`);
+                    const { thumbnail_url } = await getVideoThumbnail(url);
+                    thumbnailUrl = thumbnail_url;
                 } catch (e) {
-                    console.warn('Thumbnail extraction failed:', e?.message || e);
-                    setUploadProgress('Thumbnail extraction failed, continuing...');
+                    console.warn('Server thumbnail extraction failed:', e?.message || e);
                 }
 
-                let aiName = null;
-                if (thumbnailUrl) {
-                    try {
-                        setUploadProgress(`Naming with AI...`);
-                        const { name } = await getAiName(thumbnailUrl);
-                        aiName = name;
-                    } catch (e) {
-                        console.warn('AI naming failed:', e);
-                    }
-                }
+                // Videos just use filename, no AI naming
+                const videoName = file.name.replace(/\.[^.]+$/, '');
 
                 await createLibraryItem({
                     brand_id: uploadBrand,
-                    name: aiName || file.name.replace(/\.[^.]+$/, ''),
+                    name: videoName,
                     media_type: 'video',
                     media_url: url,
                     thumbnail_url: thumbnailUrl,

--- a/frontend/src/pages/AdsLibrary.jsx
+++ b/frontend/src/pages/AdsLibrary.jsx
@@ -1,8 +1,15 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useToast } from '../context/ToastContext';
 import { useBrands } from '../context/BrandContext';
-import { getLibraryItems, createLibraryItem, updateLibraryItem, deleteLibraryItem, uploadFile, getAiName, getVideoThumbnail, detectAspectRatio } from '../api/adsLibrary';
-import { Upload, Image, Video, Trash2, Pencil, X, Download, Play, FolderOpen, Loader2, Wand2, Layers, Plus, Filter, Sparkles } from 'lucide-react';
+import {
+    getLibraryItems, createLibraryItem, updateLibraryItem, deleteLibraryItem,
+    uploadFile, getAiName, getVideoThumbnail, detectAspectRatio,
+    getFolders, createFolder, updateFolder, deleteFolder, moveItemsToFolder, getLibraryStats
+} from '../api/adsLibrary';
+import {
+    Upload, Image, Video, Trash2, Pencil, X, Download, Play, FolderOpen, Loader2,
+    Wand2, Layers, Plus, Filter, Sparkles, ChevronRight, Folder, FolderPlus, MoreVertical, Check
+} from 'lucide-react';
 import GenerateVideoModal from '../components/GenerateVideoModal';
 
 const FUNNEL_STAGES = [
@@ -44,42 +51,78 @@ const AdsLibrary = () => {
     const { showSuccess, showError } = useToast();
     const { brands } = useBrands();
 
-    // Data
-    const [items, setItems] = useState([]);
-    const [loading, setLoading] = useState(true);
+    // ── Navigation state (4-level breadcrumb) ──
+    const [currentBrandId, setCurrentBrandId] = useState(null);
+    const [currentMediaType, setCurrentMediaType] = useState(null); // 'image' | 'video'
+    const [currentFolderId, setCurrentFolderId] = useState(null);   // folder id, '__none__' for uncategorized, or null
 
-    // Filters
-    const [filterBrand, setFilterBrand] = useState('');
-    const [filterMediaType, setFilterMediaType] = useState('');
+    // Derived: current navigation level
+    // Level 0: brands grid (nothing selected)
+    // Level 1: media type picker (brand selected)
+    // Level 2: folder grid (brand + media type selected)
+    // Level 3: items inside folder (brand + media type + folder selected)
+    const navLevel = currentFolderId !== null ? 3 : currentMediaType !== null ? 2 : currentBrandId !== null ? 1 : 0;
+
+    // ── Data ──
+    const [items, setItems] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [folders, setFolders] = useState([]);
+    const [foldersLoading, setFoldersLoading] = useState(false);
+    const [brandStats, setBrandStats] = useState({}); // { brandId: { images, videos, total } }
+    const [uncategorizedCount, setUncategorizedCount] = useState(0);
+
+    // ── Filters (shown only at Level 3) ──
     const [filterFunnel, setFilterFunnel] = useState('');
     const [filterStatus, setFilterStatus] = useState('');
 
-    // Upload
+    // ── Upload ──
     const [uploading, setUploading] = useState(false);
     const [uploadProgress, setUploadProgress] = useState('');
-    const [uploadBrand, setUploadBrand] = useState('');
     const [dragActive, setDragActive] = useState(false);
     const fileInputRef = useRef(null);
 
-    // Add variant
+    // ── Add variant ──
     const [addVariantTarget, setAddVariantTarget] = useState(null);
     const variantInputRef = useRef(null);
 
-    // Review queue (items pending review before saving)
+    // ── Review queue (items pending review before saving) ──
     const [reviewQueue, setReviewQueue] = useState([]);
 
-    // Modals
+    // ── Modals ──
     const [selectedItem, setSelectedItem] = useState(null);
     const [editItem, setEditItem] = useState(null);
     const [deleteTarget, setDeleteTarget] = useState(null);
     const [videoGenImage, setVideoGenImage] = useState(null);
 
+    // ── Folder management ──
+    const [newFolderName, setNewFolderName] = useState('');
+    const [showNewFolderInput, setShowNewFolderInput] = useState(false);
+    const [renamingFolderId, setRenamingFolderId] = useState(null);
+    const [renameFolderName, setRenameFolderName] = useState('');
+    const [deleteFolderTarget, setDeleteFolderTarget] = useState(null);
+    const [folderMenuOpen, setFolderMenuOpen] = useState(null);
+    const newFolderInputRef = useRef(null);
+    const renameFolderInputRef = useRef(null);
+
+    // ── Helpers ──
+    const currentBrand = brands.find(b => b.id === currentBrandId);
+    const currentFolder = folders.find(f => f.id === currentFolderId);
+    const currentFolderName = currentFolderId === '__none__' ? 'Uncategorized' : (currentFolder?.name || '');
+
+    // ── Fetch items (Level 3) ──
     const fetchItems = useCallback(async () => {
+        if (navLevel < 3 || !currentBrandId || !currentMediaType || currentFolderId === null) return;
         try {
             setLoading(true);
-            const filters = {};
-            if (filterBrand) filters.brand_id = filterBrand;
-            if (filterMediaType) filters.media_type = filterMediaType;
+            const filters = {
+                brand_id: currentBrandId,
+                media_type: currentMediaType,
+            };
+            if (currentFolderId === '__none__') {
+                filters.folder_id = '__none__';
+            } else {
+                filters.folder_id = currentFolderId;
+            }
             if (filterFunnel) filters.funnel_stage = filterFunnel;
             if (filterStatus) filters.status = filterStatus;
             const data = await getLibraryItems(filters);
@@ -89,22 +132,71 @@ const AdsLibrary = () => {
         } finally {
             setLoading(false);
         }
-    }, [filterBrand, filterMediaType, filterFunnel, filterStatus]);
+    }, [currentBrandId, currentMediaType, currentFolderId, filterFunnel, filterStatus, navLevel]);
 
     useEffect(() => {
-        fetchItems();
-    }, [fetchItems]);
+        if (navLevel === 3) {
+            fetchItems();
+        }
+    }, [fetchItems, navLevel]);
+
+    // ── Fetch folders (Level 2) ──
+    const fetchFolders = useCallback(async () => {
+        if (!currentBrandId || !currentMediaType) return;
+        try {
+            setFoldersLoading(true);
+            const data = await getFolders({ brand_id: currentBrandId, media_type: currentMediaType });
+            setFolders(data);
+        } catch (error) {
+            showError('Failed to load folders');
+        } finally {
+            setFoldersLoading(false);
+        }
+    }, [currentBrandId, currentMediaType]);
+
+    // Fetch uncategorized count for Level 2
+    const fetchUncategorizedCount = useCallback(async () => {
+        if (!currentBrandId || !currentMediaType) return;
+        try {
+            const data = await getLibraryItems({
+                brand_id: currentBrandId,
+                media_type: currentMediaType,
+                folder_id: '__none__',
+            });
+            setUncategorizedCount(data.length);
+        } catch {
+            setUncategorizedCount(0);
+        }
+    }, [currentBrandId, currentMediaType]);
+
+    useEffect(() => {
+        if (navLevel === 2) {
+            fetchFolders();
+            fetchUncategorizedCount();
+        }
+    }, [navLevel, fetchFolders, fetchUncategorizedCount]);
+
+    // ── Fetch brand stats for Level 1 ──
+    const fetchBrandStats = useCallback(async (brandId) => {
+        try {
+            const stats = await getLibraryStats({ brand_id: brandId });
+            setBrandStats(prev => ({ ...prev, [brandId]: stats }));
+        } catch {
+            // Silently fail
+        }
+    }, []);
+
+    useEffect(() => {
+        if (navLevel === 1 && currentBrandId) {
+            fetchBrandStats(currentBrandId);
+        }
+    }, [navLevel, currentBrandId, fetchBrandStats]);
 
     // Standard ratios for FB ads
     const STANDARD_RATIOS = ['1:1', '9:16', '4:5'];
 
-    // Upload handlers — now populates review queue instead of creating items immediately
+    // ── Upload handlers — now populates review queue instead of creating items immediately ──
     const handleFiles = async (files) => {
-        if (!uploadBrand) {
-            showError('Please select a brand first');
-            return;
-        }
-
         setUploading(true);
 
         // Separate images and videos
@@ -116,9 +208,20 @@ const AdsLibrary = () => {
             else showError(`${file.name}: Unsupported file type`);
         }
 
+        // Filter by current media type context
+        const relevantImages = currentMediaType === 'video' ? [] : imageFiles;
+        const relevantVideos = currentMediaType === 'image' ? [] : videoFiles;
+
+        if (currentMediaType === 'video' && imageFiles.length > 0) {
+            showError('Only video files are accepted in the Videos section');
+        }
+        if (currentMediaType === 'image' && videoFiles.length > 0) {
+            showError('Only image files are accepted in the Images section');
+        }
+
         // Phase 1: Upload all image files and detect ratios
         const imageUploads = [];
-        for (const file of imageFiles) {
+        for (const file of relevantImages) {
             try {
                 setUploadProgress(`Uploading ${file.name}...`);
                 const { url } = await uploadFile(file);
@@ -192,7 +295,7 @@ const AdsLibrary = () => {
         }
 
         // Phase 4: Handle video files — upload + extract thumbnail, add to queue
-        for (const file of videoFiles) {
+        for (const file of relevantVideos) {
             try {
                 setUploadProgress(`Uploading ${file.name}...`);
                 const { url } = await uploadFile(file);
@@ -255,8 +358,8 @@ const AdsLibrary = () => {
         for (const item of reviewQueue) {
             try {
                 setUploadProgress(`Saving "${item.name}"...`);
-                await createLibraryItem({
-                    brand_id: uploadBrand,
+                const payload = {
+                    brand_id: currentBrandId,
                     name: item.name,
                     media_type: item.mediaType,
                     media_url: item.primaryUrl,
@@ -267,7 +370,12 @@ const AdsLibrary = () => {
                     funnel_stage: item.funnel_stage || null,
                     ad_format: item.ad_format || null,
                     status: item.status,
-                });
+                };
+                // Auto-set folder_id if inside a folder (Level 3)
+                if (currentFolderId && currentFolderId !== '__none__') {
+                    payload.folder_id = currentFolderId;
+                }
+                await createLibraryItem(payload);
                 saved++;
             } catch (error) {
                 showError(`Failed to save "${item.name}"`);
@@ -277,7 +385,11 @@ const AdsLibrary = () => {
         if (saved > 0) {
             showSuccess(`Saved ${saved} item${saved > 1 ? 's' : ''}`);
             setReviewQueue([]);
-            fetchItems();
+            if (navLevel === 3) fetchItems();
+            if (navLevel === 2) {
+                fetchFolders();
+                fetchUncategorizedCount();
+            }
         }
         setUploading(false);
         setUploadProgress('');
@@ -379,6 +491,7 @@ const AdsLibrary = () => {
                 ad_format: editItem.ad_format,
                 status: editItem.status,
                 brand_id: editItem.brand_id,
+                folder_id: editItem.folder_id || null,
             });
             showSuccess('Ad updated');
             setEditItem(null);
@@ -430,37 +543,167 @@ const AdsLibrary = () => {
         }
     };
 
-    return (
-        <div className="space-y-6">
-            {/* Header */}
-            <div className="flex items-center justify-between">
-                <div>
-                    <h1 className="text-2xl font-bold text-amber-900 flex items-center gap-2">
-                        <FolderOpen size={28} />
-                        Ads Library
-                    </h1>
-                    <p className="text-amber-600 text-sm">Upload and organize your ad creatives by brand</p>
-                </div>
-                <div className="text-sm text-gray-500">
-                    {items.length} ad{items.length !== 1 ? 's' : ''}
-                </div>
-            </div>
+    // ── Folder management handlers ──
+    const handleCreateFolder = async () => {
+        if (!newFolderName.trim()) return;
+        try {
+            await createFolder({
+                brand_id: currentBrandId,
+                media_type: currentMediaType,
+                name: newFolderName.trim(),
+            });
+            showSuccess(`Folder "${newFolderName.trim()}" created`);
+            setNewFolderName('');
+            setShowNewFolderInput(false);
+            fetchFolders();
+        } catch (error) {
+            showError(error?.response?.data?.detail || 'Failed to create folder');
+        }
+    };
 
-            {/* Upload Area */}
-            <div className="bg-white rounded-xl border border-amber-200 p-6">
-                <h2 className="text-lg font-semibold text-amber-900 mb-4">Upload Ads</h2>
-                <div className="flex gap-4 mb-4">
-                    <select
-                        value={uploadBrand}
-                        onChange={(e) => setUploadBrand(e.target.value)}
-                        className="px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+    const handleRenameFolder = async (folderId) => {
+        if (!renameFolderName.trim()) return;
+        try {
+            await updateFolder(folderId, { name: renameFolderName.trim() });
+            showSuccess('Folder renamed');
+            setRenamingFolderId(null);
+            setRenameFolderName('');
+            fetchFolders();
+        } catch (error) {
+            showError(error?.response?.data?.detail || 'Failed to rename folder');
+        }
+    };
+
+    const handleDeleteFolder = async () => {
+        if (!deleteFolderTarget) return;
+        try {
+            await deleteFolder(deleteFolderTarget.id);
+            showSuccess(`Folder "${deleteFolderTarget.name}" deleted. Items are now uncategorized.`);
+            setDeleteFolderTarget(null);
+            fetchFolders();
+            fetchUncategorizedCount();
+        } catch (error) {
+            showError('Failed to delete folder');
+        }
+    };
+
+    // Focus new folder input when it appears
+    useEffect(() => {
+        if (showNewFolderInput && newFolderInputRef.current) {
+            newFolderInputRef.current.focus();
+        }
+    }, [showNewFolderInput]);
+
+    useEffect(() => {
+        if (renamingFolderId && renameFolderInputRef.current) {
+            renameFolderInputRef.current.focus();
+        }
+    }, [renamingFolderId]);
+
+    // Close folder menu when clicking outside
+    useEffect(() => {
+        if (!folderMenuOpen) return;
+        const handler = () => setFolderMenuOpen(null);
+        document.addEventListener('click', handler);
+        return () => document.removeEventListener('click', handler);
+    }, [folderMenuOpen]);
+
+    // ── Navigation handlers ──
+    const navigateToBrand = (brandId) => {
+        setCurrentBrandId(brandId);
+        setCurrentMediaType(null);
+        setCurrentFolderId(null);
+        setItems([]);
+        setFolders([]);
+        setReviewQueue([]);
+        setFilterFunnel('');
+        setFilterStatus('');
+    };
+
+    const navigateToMediaType = (mediaType) => {
+        setCurrentMediaType(mediaType);
+        setCurrentFolderId(null);
+        setItems([]);
+        setReviewQueue([]);
+        setFilterFunnel('');
+        setFilterStatus('');
+    };
+
+    const navigateToFolder = (folderId) => {
+        setCurrentFolderId(folderId);
+        setItems([]);
+        setReviewQueue([]);
+        setFilterFunnel('');
+        setFilterStatus('');
+    };
+
+    const navigateToRoot = () => {
+        setCurrentBrandId(null);
+        setCurrentMediaType(null);
+        setCurrentFolderId(null);
+        setItems([]);
+        setFolders([]);
+        setReviewQueue([]);
+        setFilterFunnel('');
+        setFilterStatus('');
+    };
+
+    // ── Breadcrumb ──
+    const renderBreadcrumb = () => (
+        <div className="flex items-center gap-1 text-sm flex-wrap">
+            <button
+                onClick={navigateToRoot}
+                className={`px-2 py-1 rounded transition-colors ${navLevel === 0 ? 'text-amber-900 font-semibold' : 'text-amber-600 hover:text-amber-800 hover:bg-amber-50'}`}
+            >
+                Ads Library
+            </button>
+            {currentBrandId && (
+                <>
+                    <ChevronRight size={14} className="text-amber-400 flex-shrink-0" />
+                    <button
+                        onClick={() => { setCurrentMediaType(null); setCurrentFolderId(null); setItems([]); setReviewQueue([]); }}
+                        className={`px-2 py-1 rounded transition-colors ${navLevel === 1 ? 'text-amber-900 font-semibold' : 'text-amber-600 hover:text-amber-800 hover:bg-amber-50'}`}
                     >
-                        <option value="">Select Brand *</option>
-                        {brands.map((b) => (
-                            <option key={b.id} value={b.id}>{b.name}</option>
-                        ))}
-                    </select>
-                </div>
+                        {currentBrand?.name || 'Brand'}
+                    </button>
+                </>
+            )}
+            {currentMediaType && (
+                <>
+                    <ChevronRight size={14} className="text-amber-400 flex-shrink-0" />
+                    <button
+                        onClick={() => { setCurrentFolderId(null); setItems([]); setReviewQueue([]); }}
+                        className={`px-2 py-1 rounded transition-colors ${navLevel === 2 ? 'text-amber-900 font-semibold' : 'text-amber-600 hover:text-amber-800 hover:bg-amber-50'}`}
+                    >
+                        {currentMediaType === 'image' ? 'Images' : 'Videos'}
+                    </button>
+                </>
+            )}
+            {currentFolderId !== null && (
+                <>
+                    <ChevronRight size={14} className="text-amber-400 flex-shrink-0" />
+                    <span className="px-2 py-1 text-amber-900 font-semibold">
+                        {currentFolderName}
+                    </span>
+                </>
+            )}
+        </div>
+    );
+
+    // ── Upload area (shown at Level 2 and Level 3) ──
+    const renderUploadArea = () => {
+        const acceptTypes = currentMediaType === 'image' ? 'image/*' : currentMediaType === 'video' ? 'video/*' : 'image/*,video/*';
+        const helpText = currentMediaType === 'image'
+            ? 'JPG, PNG, WEBP, GIF — AI auto-names your ads'
+            : currentMediaType === 'video'
+            ? 'MP4, MOV, WEBM'
+            : 'JPG, PNG, WEBP, GIF, MP4, MOV, WEBM — AI auto-names your ads';
+
+        return (
+            <div className="bg-white rounded-xl border border-amber-200 p-6">
+                <h2 className="text-lg font-semibold text-amber-900 mb-4">
+                    Upload {currentMediaType === 'image' ? 'Images' : currentMediaType === 'video' ? 'Videos' : 'Ads'}
+                </h2>
 
                 <div
                     className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer ${
@@ -479,368 +722,684 @@ const AdsLibrary = () => {
                     ) : (
                         <>
                             <Upload size={32} className="mx-auto text-gray-400 mb-2" />
-                            <p className="text-gray-600">Drag & drop images or videos here</p>
-                            <p className="text-gray-400 text-sm mt-1">JPG, PNG, WEBP, GIF, MP4, MOV, WEBM &mdash; AI auto-names your ads</p>
+                            <p className="text-gray-600">
+                                Drag & drop {currentMediaType === 'image' ? 'images' : currentMediaType === 'video' ? 'videos' : 'files'} here
+                            </p>
+                            <p className="text-gray-400 text-sm mt-1">{helpText}</p>
+                            {currentFolderId && currentFolderId !== '__none__' && (
+                                <p className="text-amber-600 text-xs mt-2">
+                                    Uploads will be saved to folder: {currentFolderName}
+                                </p>
+                            )}
                         </>
                     )}
                     <input
                         ref={fileInputRef}
                         type="file"
-                        accept="image/*,video/*"
+                        accept={acceptTypes}
                         multiple
                         className="hidden"
                         onChange={(e) => handleFiles(Array.from(e.target.files))}
                     />
                 </div>
             </div>
+        );
+    };
 
-            {/* Review Queue */}
-            {reviewQueue.length > 0 && (
-                <div className="bg-white rounded-xl border border-indigo-200 p-6">
-                    <div className="flex items-center justify-between mb-4">
-                        <h2 className="text-lg font-semibold text-gray-900">
-                            Review Uploads ({reviewQueue.length} item{reviewQueue.length !== 1 ? 's' : ''})
-                        </h2>
-                        <div className="flex gap-3">
-                            <button onClick={() => setReviewQueue([])} className="px-4 py-2 text-gray-600 hover:bg-gray-100 rounded-lg text-sm">
-                                Discard All
-                            </button>
-                            <button
-                                onClick={handleSaveAll}
-                                disabled={uploading}
-                                className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 text-sm font-medium disabled:opacity-50"
-                            >
-                                Save All
-                            </button>
-                        </div>
-                    </div>
+    // ── Review queue ──
+    const renderReviewQueue = () => {
+        if (reviewQueue.length === 0) return null;
 
-                    <div className="space-y-4">
-                        {reviewQueue.map((qItem) => (
-                            <div key={qItem.id} className="flex gap-4 p-4 border border-gray-200 rounded-lg bg-gray-50">
-                                {/* Thumbnail */}
-                                <div className="w-32 h-32 flex-shrink-0 rounded-lg overflow-hidden bg-gray-200">
-                                    {qItem.mediaType === 'video' ? (
-                                        qItem.thumbnailUrl ? (
-                                            <img src={qItem.thumbnailUrl} alt="" className="w-full h-full object-cover" />
-                                        ) : (
-                                            <div className="w-full h-full flex items-center justify-center bg-gray-800">
-                                                <Video size={24} className="text-gray-500" />
-                                            </div>
-                                        )
-                                    ) : (
-                                        <img src={qItem.primaryUrl} alt="" className="w-full h-full object-cover" />
-                                    )}
-                                </div>
-
-                                {/* Fields */}
-                                <div className="flex-1 space-y-3">
-                                    {/* Name */}
-                                    <div className="flex items-center gap-2">
-                                        {qItem.nameLoading ? (
-                                            <div className="flex items-center gap-2 text-sm text-gray-500">
-                                                <Loader2 size={14} className="animate-spin" />
-                                                AI naming...
-                                            </div>
-                                        ) : null}
-                                        <input
-                                            type="text"
-                                            value={qItem.name}
-                                            onChange={(e) => updateQueueItem(qItem.id, { name: e.target.value })}
-                                            placeholder="Ad name"
-                                            className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
-                                        />
-                                    </div>
-
-                                    {/* Ratio badges (images only) */}
-                                    {qItem.mediaType === 'image' && (
-                                        <div className="flex flex-wrap gap-2">
-                                            {/* Uploaded ratios */}
-                                            {Object.keys(qItem.variants).map((ratio) => (
-                                                <span key={ratio} className="inline-flex items-center gap-1 px-2 py-1 bg-green-100 text-green-700 text-xs rounded-md font-medium">
-                                                    <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
-                                                    {ratio}
-                                                </span>
-                                            ))}
-                                            {/* Missing ratios as drop zones */}
-                                            {qItem.missingRatios.map((ratio) => (
-                                                <label
-                                                    key={ratio}
-                                                    className="inline-flex items-center gap-1 px-2 py-1 border border-dashed border-gray-400 text-gray-500 text-xs rounded-md cursor-pointer hover:border-amber-500 hover:text-amber-600 transition-colors"
-                                                    onDragOver={(e) => e.preventDefault()}
-                                                    onDrop={(e) => {
-                                                        e.preventDefault();
-                                                        handleDropOnMissingRatio(qItem.id, Array.from(e.dataTransfer.files));
-                                                    }}
-                                                >
-                                                    <Plus size={12} />
-                                                    {ratio}
-                                                    <input
-                                                        type="file"
-                                                        accept="image/*"
-                                                        className="hidden"
-                                                        onChange={(e) => handleDropOnMissingRatio(qItem.id, Array.from(e.target.files))}
-                                                    />
-                                                </label>
-                                            ))}
-                                        </div>
-                                    )}
-
-                                    {qItem.mediaType === 'video' && (
-                                        <span className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-700 text-xs rounded-md font-medium">
-                                            <Video size={12} /> Video
-                                        </span>
-                                    )}
-
-                                    {/* Metadata row */}
-                                    <div className="flex flex-wrap gap-2">
-                                        <select
-                                            value={qItem.funnel_stage}
-                                            onChange={(e) => updateQueueItem(qItem.id, { funnel_stage: e.target.value })}
-                                            className="px-2 py-1 text-xs border border-gray-300 rounded-lg"
-                                        >
-                                            <option value="">Funnel Stage</option>
-                                            <option value="tofu">TOFU</option>
-                                            <option value="mofu">MOFU</option>
-                                            <option value="bofu">BOFU</option>
-                                        </select>
-                                        <select
-                                            value={qItem.ad_format}
-                                            onChange={(e) => updateQueueItem(qItem.id, { ad_format: e.target.value })}
-                                            className="px-2 py-1 text-xs border border-gray-300 rounded-lg"
-                                        >
-                                            {AD_FORMATS.map((f) => (
-                                                <option key={f.value} value={f.value}>{f.label}</option>
-                                            ))}
-                                        </select>
-                                        <input
-                                            type="text"
-                                            value={qItem.tags.join(', ')}
-                                            onChange={(e) => updateQueueItem(qItem.id, {
-                                                tags: e.target.value.split(',').map(t => t.trim()).filter(Boolean)
-                                            })}
-                                            placeholder="Tags (comma-separated)"
-                                            className="flex-1 min-w-[120px] px-2 py-1 text-xs border border-gray-300 rounded-lg"
-                                        />
-                                        <button
-                                            onClick={() => removeFromQueue(qItem.id)}
-                                            className="px-2 py-1 text-red-500 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors"
-                                            title="Remove"
-                                        >
-                                            <Trash2 size={14} />
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            )}
-
-            {/* Filters */}
-            <div className="bg-white rounded-xl border border-amber-200 p-4">
-                <div className="flex flex-wrap gap-3 items-center">
-                    <Filter size={16} className="text-gray-400" />
-                    <select
-                        value={filterBrand}
-                        onChange={(e) => setFilterBrand(e.target.value)}
-                        className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
-                    >
-                        <option value="">All Brands</option>
-                        {brands.map((b) => (
-                            <option key={b.id} value={b.id}>{b.name}</option>
-                        ))}
-                    </select>
-
-                    <div className="flex rounded-lg border border-gray-300 overflow-hidden">
-                        {['', 'image', 'video'].map((type) => (
-                            <button
-                                key={type}
-                                onClick={() => setFilterMediaType(type)}
-                                className={`px-3 py-1.5 text-sm ${
-                                    filterMediaType === type
-                                        ? 'bg-amber-600 text-white'
-                                        : 'bg-white text-gray-600 hover:bg-gray-50'
-                                }`}
-                            >
-                                {type === '' ? 'All' : type === 'image' ? 'Images' : 'Videos'}
-                            </button>
-                        ))}
-                    </div>
-
-                    <select
-                        value={filterFunnel}
-                        onChange={(e) => setFilterFunnel(e.target.value)}
-                        className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
-                    >
-                        {FUNNEL_STAGES.map((s) => (
-                            <option key={s.value} value={s.value}>{s.label}</option>
-                        ))}
-                    </select>
-
-                    <select
-                        value={filterStatus}
-                        onChange={(e) => setFilterStatus(e.target.value)}
-                        className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
-                    >
-                        {STATUSES.map((s) => (
-                            <option key={s.value} value={s.value}>{s.label}</option>
-                        ))}
-                    </select>
-                </div>
-            </div>
-
-            {/* Grid */}
-            {loading ? (
-                <div className="flex items-center justify-center py-12 text-amber-600">
-                    <Loader2 size={24} className="animate-spin mr-2" />
-                    Loading...
-                </div>
-            ) : items.length === 0 ? (
-                <div className="bg-white rounded-xl border border-amber-200 p-12 text-center">
-                    <FolderOpen size={48} className="mx-auto text-gray-300 mb-4" />
-                    <p className="text-gray-500 text-lg">No ads yet</p>
-                    <p className="text-gray-400 text-sm mt-1">Upload your first ad above!</p>
-                </div>
-            ) : (
-                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-                    {items.map((item) => (
-                        <div
-                            key={item.id}
-                            className="bg-white rounded-lg border border-amber-200 overflow-hidden group"
+        return (
+            <div className="bg-white rounded-xl border border-indigo-200 p-6">
+                <div className="flex items-center justify-between mb-4">
+                    <h2 className="text-lg font-semibold text-gray-900">
+                        Review Uploads ({reviewQueue.length} item{reviewQueue.length !== 1 ? 's' : ''})
+                    </h2>
+                    <div className="flex gap-3">
+                        <button onClick={() => setReviewQueue([])} className="px-4 py-2 text-gray-600 hover:bg-gray-100 rounded-lg text-sm">
+                            Discard All
+                        </button>
+                        <button
+                            onClick={handleSaveAll}
+                            disabled={uploading}
+                            className="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 text-sm font-medium disabled:opacity-50"
                         >
+                            Save All
+                        </button>
+                    </div>
+                </div>
+
+                <div className="space-y-4">
+                    {reviewQueue.map((qItem) => (
+                        <div key={qItem.id} className="flex gap-4 p-4 border border-gray-200 rounded-lg bg-gray-50">
                             {/* Thumbnail */}
-                            <div
-                                className="aspect-video bg-gray-100 relative cursor-pointer"
-                                onClick={() => setSelectedItem(item)}
-                            >
-                                {item.media_type === 'video' ? (
-                                    <>
-                                        {item.thumbnail_url ? (
-                                            <img
-                                                src={item.thumbnail_url}
-                                                alt={item.name || 'Video'}
-                                                className="w-full h-full object-cover"
-                                            />
-                                        ) : (
-                                            <div className="w-full h-full flex items-center justify-center bg-gray-800">
-                                                <Video size={32} className="text-gray-500" />
-                                            </div>
-                                        )}
-                                        <div className="absolute inset-0 flex items-center justify-center">
-                                            <div className="w-10 h-10 bg-black/60 rounded-full flex items-center justify-center group-hover:bg-black/80 transition-colors">
-                                                <Play size={20} className="text-white ml-0.5" fill="white" />
-                                            </div>
+                            <div className="w-32 h-32 flex-shrink-0 rounded-lg overflow-hidden bg-gray-200">
+                                {qItem.mediaType === 'video' ? (
+                                    qItem.thumbnailUrl ? (
+                                        <img src={qItem.thumbnailUrl} alt="" className="w-full h-full object-cover" />
+                                    ) : (
+                                        <div className="w-full h-full flex items-center justify-center bg-gray-800">
+                                            <Video size={24} className="text-gray-500" />
                                         </div>
-                                    </>
+                                    )
                                 ) : (
-                                    <img
-                                        src={item.media_url}
-                                        alt={item.name || 'Ad'}
-                                        className="w-full h-full object-cover"
+                                    <img src={qItem.primaryUrl} alt="" className="w-full h-full object-cover" />
+                                )}
+                            </div>
+
+                            {/* Fields */}
+                            <div className="flex-1 space-y-3">
+                                {/* Name */}
+                                <div className="flex items-center gap-2">
+                                    {qItem.nameLoading ? (
+                                        <div className="flex items-center gap-2 text-sm text-gray-500">
+                                            <Loader2 size={14} className="animate-spin" />
+                                            AI naming...
+                                        </div>
+                                    ) : null}
+                                    <input
+                                        type="text"
+                                        value={qItem.name}
+                                        onChange={(e) => updateQueueItem(qItem.id, { name: e.target.value })}
+                                        placeholder="Ad name"
+                                        className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
                                     />
+                                </div>
+
+                                {/* Ratio badges (images only) */}
+                                {qItem.mediaType === 'image' && (
+                                    <div className="flex flex-wrap gap-2">
+                                        {/* Uploaded ratios */}
+                                        {Object.keys(qItem.variants).map((ratio) => (
+                                            <span key={ratio} className="inline-flex items-center gap-1 px-2 py-1 bg-green-100 text-green-700 text-xs rounded-md font-medium">
+                                                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>
+                                                {ratio}
+                                            </span>
+                                        ))}
+                                        {/* Missing ratios as drop zones */}
+                                        {qItem.missingRatios.map((ratio) => (
+                                            <label
+                                                key={ratio}
+                                                className="inline-flex items-center gap-1 px-2 py-1 border border-dashed border-gray-400 text-gray-500 text-xs rounded-md cursor-pointer hover:border-amber-500 hover:text-amber-600 transition-colors"
+                                                onDragOver={(e) => e.preventDefault()}
+                                                onDrop={(e) => {
+                                                    e.preventDefault();
+                                                    handleDropOnMissingRatio(qItem.id, Array.from(e.dataTransfer.files));
+                                                }}
+                                            >
+                                                <Plus size={12} />
+                                                {ratio}
+                                                <input
+                                                    type="file"
+                                                    accept="image/*"
+                                                    className="hidden"
+                                                    onChange={(e) => handleDropOnMissingRatio(qItem.id, Array.from(e.target.files))}
+                                                />
+                                            </label>
+                                        ))}
+                                    </div>
                                 )}
 
-                                {/* Media type badge */}
-                                <span className="absolute top-2 left-2 px-2 py-0.5 bg-black/60 text-white text-xs rounded flex items-center gap-1">
-                                    {item.media_type === 'video' ? <Video size={10} /> : <Image size={10} />}
-                                    {item.media_type}
-                                </span>
-
-                                {/* Variants badge */}
-                                {variantCount(item) > 1 && (
-                                    <span className="absolute bottom-2 left-2 px-2 py-0.5 bg-purple-600/90 text-white text-xs rounded flex items-center gap-1">
-                                        <Layers size={10} />
-                                        {variantCount(item)} sizes
+                                {qItem.mediaType === 'video' && (
+                                    <span className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-700 text-xs rounded-md font-medium">
+                                        <Video size={12} /> Video
                                     </span>
                                 )}
 
-                                {/* Status badge */}
-                                <span className={`absolute top-2 right-2 px-2 py-0.5 text-xs rounded ${STATUS_COLORS[item.status] || 'bg-gray-100 text-gray-700'}`}>
-                                    {item.status}
-                                </span>
-
-                                {/* Hover actions */}
-                                <div className="absolute bottom-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                                    {item.media_type === 'image' && (
-                                        <>
-                                            <button
-                                                onClick={(e) => { e.stopPropagation(); setVideoGenImage(item.media_url); }}
-                                                className="w-8 h-8 bg-purple-500/90 hover:bg-purple-600 rounded-full flex items-center justify-center text-white"
-                                                title="Generate Video"
-                                            >
-                                                <Wand2 size={14} />
-                                            </button>
-                                            <button
-                                                onClick={(e) => {
-                                                    e.stopPropagation();
-                                                    setAddVariantTarget(item);
-                                                    setTimeout(() => variantInputRef.current?.click(), 100);
-                                                }}
-                                                className="w-8 h-8 bg-indigo-500/90 hover:bg-indigo-600 rounded-full flex items-center justify-center text-white"
-                                                title="Add size variant"
-                                            >
-                                                <Plus size={14} />
-                                            </button>
-                                        </>
-                                    )}
-                                    <button
-                                        onClick={(e) => { e.stopPropagation(); setEditItem({ ...item }); }}
-                                        className="w-8 h-8 bg-white/90 hover:bg-white rounded-full flex items-center justify-center text-gray-700"
-                                        title="Edit"
+                                {/* Metadata row */}
+                                <div className="flex flex-wrap gap-2">
+                                    <select
+                                        value={qItem.funnel_stage}
+                                        onChange={(e) => updateQueueItem(qItem.id, { funnel_stage: e.target.value })}
+                                        className="px-2 py-1 text-xs border border-gray-300 rounded-lg"
                                     >
-                                        <Pencil size={14} />
-                                    </button>
+                                        <option value="">Funnel Stage</option>
+                                        <option value="tofu">TOFU</option>
+                                        <option value="mofu">MOFU</option>
+                                        <option value="bofu">BOFU</option>
+                                    </select>
+                                    <select
+                                        value={qItem.ad_format}
+                                        onChange={(e) => updateQueueItem(qItem.id, { ad_format: e.target.value })}
+                                        className="px-2 py-1 text-xs border border-gray-300 rounded-lg"
+                                    >
+                                        {AD_FORMATS.map((f) => (
+                                            <option key={f.value} value={f.value}>{f.label}</option>
+                                        ))}
+                                    </select>
+                                    <input
+                                        type="text"
+                                        value={qItem.tags.join(', ')}
+                                        onChange={(e) => updateQueueItem(qItem.id, {
+                                            tags: e.target.value.split(',').map(t => t.trim()).filter(Boolean)
+                                        })}
+                                        placeholder="Tags (comma-separated)"
+                                        className="flex-1 min-w-[120px] px-2 py-1 text-xs border border-gray-300 rounded-lg"
+                                    />
                                     <button
-                                        onClick={(e) => { e.stopPropagation(); setDeleteTarget(item); }}
-                                        className="w-8 h-8 bg-white/90 hover:bg-white rounded-full flex items-center justify-center text-red-600"
-                                        title="Delete"
+                                        onClick={() => removeFromQueue(qItem.id)}
+                                        className="px-2 py-1 text-red-500 hover:text-red-700 hover:bg-red-50 rounded-lg transition-colors"
+                                        title="Remove"
                                     >
                                         <Trash2 size={14} />
                                     </button>
                                 </div>
                             </div>
-
-                            {/* Info */}
-                            <div className="p-3">
-                                <p className="text-sm font-medium text-gray-900 truncate">
-                                    {item.name || 'Untitled'}
-                                </p>
-                                <p className="text-xs text-amber-600 truncate">
-                                    {item.brand_name || 'No brand'}
-                                </p>
-                                <div className="flex items-center gap-2 mt-1 flex-wrap">
-                                    {item.variants && Object.keys(item.variants).length > 0 && (
-                                        Object.keys(item.variants).map((ratio) => (
-                                            <span key={ratio} className="px-1.5 py-0.5 text-[10px] bg-indigo-100 text-indigo-700 rounded">
-                                                {ratio}
-                                            </span>
-                                        ))
-                                    )}
-                                    {item.funnel_stage && (
-                                        <span className="px-1.5 py-0.5 text-[10px] bg-purple-100 text-purple-700 rounded">
-                                            {item.funnel_stage.toUpperCase()}
-                                        </span>
-                                    )}
-                                    {item.ad_format && (
-                                        <span className="px-1.5 py-0.5 text-[10px] bg-blue-100 text-blue-700 rounded">
-                                            {item.ad_format.replace('_', ' ')}
-                                        </span>
-                                    )}
-                                    {item.tags && item.tags.map((tag, i) => (
-                                        <span key={i} className="px-1.5 py-0.5 text-[10px] bg-gray-100 text-gray-600 rounded">
-                                            {tag}
-                                        </span>
-                                    ))}
-                                </div>
-                                {item.file_size && (
-                                    <p className="text-[10px] text-gray-400 mt-1">{formatSize(item.file_size)}</p>
-                                )}
-                            </div>
                         </div>
                     ))}
                 </div>
+            </div>
+        );
+    };
+
+    // ── Level 0: Brand cards grid ──
+    const renderBrandCards = () => {
+        if (brands.length === 0) {
+            return (
+                <div className="bg-white rounded-xl border border-amber-200 p-12 text-center">
+                    <FolderOpen size={48} className="mx-auto text-gray-300 mb-4" />
+                    <p className="text-gray-500 text-lg">No brands yet</p>
+                    <p className="text-gray-400 text-sm mt-1">Create a brand first to start uploading ads.</p>
+                </div>
+            );
+        }
+
+        return (
+            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                {brands.map((brand) => (
+                    <button
+                        key={brand.id}
+                        onClick={() => navigateToBrand(brand.id)}
+                        className="bg-white rounded-xl border border-amber-200 p-6 text-left hover:border-amber-400 hover:shadow-md transition-all group"
+                    >
+                        <div className="flex items-center gap-3 mb-3">
+                            {brand.logo_url ? (
+                                <img
+                                    src={brand.logo_url}
+                                    alt={brand.name}
+                                    className="w-12 h-12 rounded-lg object-cover border border-gray-200"
+                                />
+                            ) : (
+                                <div
+                                    className="w-12 h-12 rounded-lg flex items-center justify-center text-white font-bold text-lg"
+                                    style={{ backgroundColor: brand.primary_color || '#d97706' }}
+                                >
+                                    {brand.name?.charAt(0)?.toUpperCase() || 'B'}
+                                </div>
+                            )}
+                            <div className="flex-1 min-w-0">
+                                <p className="font-semibold text-gray-900 truncate group-hover:text-amber-700 transition-colors">
+                                    {brand.name}
+                                </p>
+                            </div>
+                        </div>
+                        <div className="flex items-center gap-1 text-xs text-gray-400">
+                            <ChevronRight size={12} />
+                            <span>View library</span>
+                        </div>
+                    </button>
+                ))}
+            </div>
+        );
+    };
+
+    // ── Level 1: Media type picker ──
+    const renderMediaTypePicker = () => {
+        const stats = brandStats[currentBrandId] || {};
+        return (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 max-w-2xl">
+                {/* Images card */}
+                <button
+                    onClick={() => navigateToMediaType('image')}
+                    className="bg-white rounded-xl border border-amber-200 p-8 text-left hover:border-amber-400 hover:shadow-md transition-all group"
+                >
+                    <div className="w-14 h-14 rounded-xl bg-amber-50 flex items-center justify-center mb-4 group-hover:bg-amber-100 transition-colors">
+                        <Image size={28} className="text-amber-600" />
+                    </div>
+                    <h3 className="text-lg font-semibold text-gray-900 group-hover:text-amber-700 transition-colors">Images</h3>
+                    <p className="text-sm text-gray-500 mt-1">
+                        {stats.images !== undefined ? `${stats.images} image${stats.images !== 1 ? 's' : ''}` : 'Browse image ads'}
+                    </p>
+                </button>
+
+                {/* Videos card */}
+                <button
+                    onClick={() => navigateToMediaType('video')}
+                    className="bg-white rounded-xl border border-amber-200 p-8 text-left hover:border-amber-400 hover:shadow-md transition-all group"
+                >
+                    <div className="w-14 h-14 rounded-xl bg-amber-50 flex items-center justify-center mb-4 group-hover:bg-amber-100 transition-colors">
+                        <Video size={28} className="text-amber-600" />
+                    </div>
+                    <h3 className="text-lg font-semibold text-gray-900 group-hover:text-amber-700 transition-colors">Videos</h3>
+                    <p className="text-sm text-gray-500 mt-1">
+                        {stats.videos !== undefined ? `${stats.videos} video${stats.videos !== 1 ? 's' : ''}` : 'Browse video ads'}
+                    </p>
+                </button>
+            </div>
+        );
+    };
+
+    // ── Level 2: Folder grid ──
+    const renderFolderGrid = () => {
+        if (foldersLoading) {
+            return (
+                <div className="flex items-center justify-center py-12 text-amber-600">
+                    <Loader2 size={24} className="animate-spin mr-2" />
+                    Loading folders...
+                </div>
+            );
+        }
+
+        return (
+            <div className="space-y-6">
+                {/* Upload area at folder level */}
+                {renderUploadArea()}
+
+                {/* Review queue */}
+                {renderReviewQueue()}
+
+                {/* Folder grid */}
+                <div>
+                    <div className="flex items-center justify-between mb-4">
+                        <h2 className="text-lg font-semibold text-amber-900">Folders</h2>
+                    </div>
+
+                    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                        {/* Folder cards */}
+                        {folders.map((folder) => (
+                            <div
+                                key={folder.id}
+                                className="bg-white rounded-xl border border-amber-200 overflow-hidden hover:border-amber-400 hover:shadow-md transition-all group relative"
+                            >
+                                {renamingFolderId === folder.id ? (
+                                    <div className="p-4">
+                                        <input
+                                            ref={renameFolderInputRef}
+                                            type="text"
+                                            value={renameFolderName}
+                                            onChange={(e) => setRenameFolderName(e.target.value)}
+                                            onKeyDown={(e) => {
+                                                if (e.key === 'Enter') handleRenameFolder(folder.id);
+                                                if (e.key === 'Escape') { setRenamingFolderId(null); setRenameFolderName(''); }
+                                            }}
+                                            className="w-full px-3 py-2 text-sm border border-amber-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+                                            placeholder="Folder name"
+                                        />
+                                        <div className="flex gap-2 mt-2">
+                                            <button
+                                                onClick={() => handleRenameFolder(folder.id)}
+                                                className="flex-1 px-3 py-1.5 bg-amber-600 text-white rounded-lg text-xs hover:bg-amber-700"
+                                            >
+                                                Save
+                                            </button>
+                                            <button
+                                                onClick={() => { setRenamingFolderId(null); setRenameFolderName(''); }}
+                                                className="flex-1 px-3 py-1.5 text-gray-600 hover:bg-gray-100 rounded-lg text-xs"
+                                            >
+                                                Cancel
+                                            </button>
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <button
+                                        onClick={() => navigateToFolder(folder.id)}
+                                        className="w-full p-5 text-left"
+                                    >
+                                        <div className="flex items-start justify-between">
+                                            <div className="w-12 h-12 rounded-lg bg-amber-50 flex items-center justify-center mb-3 group-hover:bg-amber-100 transition-colors">
+                                                <Folder size={24} className="text-amber-600" />
+                                            </div>
+                                            {/* Menu button */}
+                                            <div
+                                                className="opacity-0 group-hover:opacity-100 transition-opacity relative"
+                                                onClick={(e) => e.stopPropagation()}
+                                            >
+                                                <button
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        e.preventDefault();
+                                                        setFolderMenuOpen(folderMenuOpen === folder.id ? null : folder.id);
+                                                    }}
+                                                    className="p-1 rounded hover:bg-gray-100 text-gray-400 hover:text-gray-600"
+                                                >
+                                                    <MoreVertical size={16} />
+                                                </button>
+                                                {folderMenuOpen === folder.id && (
+                                                    <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg z-10 py-1 min-w-[120px]">
+                                                        <button
+                                                            onClick={(e) => {
+                                                                e.stopPropagation();
+                                                                e.preventDefault();
+                                                                setRenamingFolderId(folder.id);
+                                                                setRenameFolderName(folder.name);
+                                                                setFolderMenuOpen(null);
+                                                            }}
+                                                            className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 flex items-center gap-2"
+                                                        >
+                                                            <Pencil size={14} /> Rename
+                                                        </button>
+                                                        <button
+                                                            onClick={(e) => {
+                                                                e.stopPropagation();
+                                                                e.preventDefault();
+                                                                setDeleteFolderTarget(folder);
+                                                                setFolderMenuOpen(null);
+                                                            }}
+                                                            className="w-full text-left px-3 py-2 text-sm text-red-600 hover:bg-red-50 flex items-center gap-2"
+                                                        >
+                                                            <Trash2 size={14} /> Delete
+                                                        </button>
+                                                    </div>
+                                                )}
+                                            </div>
+                                        </div>
+                                        <p className="font-medium text-gray-900 truncate group-hover:text-amber-700 transition-colors">
+                                            {folder.name}
+                                        </p>
+                                        <p className="text-xs text-gray-500 mt-1">
+                                            {folder.item_count} item{folder.item_count !== 1 ? 's' : ''}
+                                        </p>
+                                    </button>
+                                )}
+                            </div>
+                        ))}
+
+                        {/* Uncategorized card */}
+                        <button
+                            onClick={() => navigateToFolder('__none__')}
+                            className="bg-white rounded-xl border border-dashed border-gray-300 p-5 text-left hover:border-amber-400 hover:shadow-md transition-all group"
+                        >
+                            <div className="w-12 h-12 rounded-lg bg-gray-50 flex items-center justify-center mb-3 group-hover:bg-gray-100 transition-colors">
+                                <FolderOpen size={24} className="text-gray-400" />
+                            </div>
+                            <p className="font-medium text-gray-600 truncate group-hover:text-amber-700 transition-colors">
+                                Uncategorized
+                            </p>
+                            <p className="text-xs text-gray-400 mt-1">
+                                {uncategorizedCount} item{uncategorizedCount !== 1 ? 's' : ''}
+                            </p>
+                        </button>
+
+                        {/* New Folder card / input */}
+                        {showNewFolderInput ? (
+                            <div className="bg-white rounded-xl border border-amber-300 p-4">
+                                <div className="w-12 h-12 rounded-lg bg-amber-50 flex items-center justify-center mb-3">
+                                    <FolderPlus size={24} className="text-amber-600" />
+                                </div>
+                                <input
+                                    ref={newFolderInputRef}
+                                    type="text"
+                                    value={newFolderName}
+                                    onChange={(e) => setNewFolderName(e.target.value)}
+                                    onKeyDown={(e) => {
+                                        if (e.key === 'Enter') handleCreateFolder();
+                                        if (e.key === 'Escape') { setShowNewFolderInput(false); setNewFolderName(''); }
+                                    }}
+                                    className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-amber-500 mb-2"
+                                    placeholder="Folder name"
+                                />
+                                <div className="flex gap-2">
+                                    <button
+                                        onClick={handleCreateFolder}
+                                        className="flex-1 px-3 py-1.5 bg-amber-600 text-white rounded-lg text-xs hover:bg-amber-700"
+                                    >
+                                        Create
+                                    </button>
+                                    <button
+                                        onClick={() => { setShowNewFolderInput(false); setNewFolderName(''); }}
+                                        className="flex-1 px-3 py-1.5 text-gray-600 hover:bg-gray-100 rounded-lg text-xs"
+                                    >
+                                        Cancel
+                                    </button>
+                                </div>
+                            </div>
+                        ) : (
+                            <button
+                                onClick={() => setShowNewFolderInput(true)}
+                                className="bg-white rounded-xl border border-dashed border-amber-300 p-5 text-left hover:border-amber-500 hover:bg-amber-50 transition-all group flex flex-col items-center justify-center min-h-[140px]"
+                            >
+                                <div className="w-12 h-12 rounded-lg bg-amber-50 flex items-center justify-center mb-3 group-hover:bg-amber-100 transition-colors">
+                                    <FolderPlus size={24} className="text-amber-500" />
+                                </div>
+                                <p className="font-medium text-amber-600 text-sm">New Folder</p>
+                            </button>
+                        )}
+                    </div>
+                </div>
+            </div>
+        );
+    };
+
+    // ── Level 3: Items inside folder ──
+    const renderItemsGrid = () => {
+        return (
+            <div className="space-y-6">
+                {/* Upload area */}
+                {renderUploadArea()}
+
+                {/* Review queue */}
+                {renderReviewQueue()}
+
+                {/* Filters (no media type filter — implicit from navigation; no brand filter — implicit) */}
+                <div className="bg-white rounded-xl border border-amber-200 p-4">
+                    <div className="flex flex-wrap gap-3 items-center">
+                        <Filter size={16} className="text-gray-400" />
+
+                        <select
+                            value={filterFunnel}
+                            onChange={(e) => setFilterFunnel(e.target.value)}
+                            className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+                        >
+                            {FUNNEL_STAGES.map((s) => (
+                                <option key={s.value} value={s.value}>{s.label}</option>
+                            ))}
+                        </select>
+
+                        <select
+                            value={filterStatus}
+                            onChange={(e) => setFilterStatus(e.target.value)}
+                            className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+                        >
+                            {STATUSES.map((s) => (
+                                <option key={s.value} value={s.value}>{s.label}</option>
+                            ))}
+                        </select>
+
+                        <span className="text-xs text-gray-400 ml-auto">
+                            {items.length} item{items.length !== 1 ? 's' : ''}
+                        </span>
+                    </div>
+                </div>
+
+                {/* Grid */}
+                {loading ? (
+                    <div className="flex items-center justify-center py-12 text-amber-600">
+                        <Loader2 size={24} className="animate-spin mr-2" />
+                        Loading...
+                    </div>
+                ) : items.length === 0 ? (
+                    <div className="bg-white rounded-xl border border-amber-200 p-12 text-center">
+                        <FolderOpen size={48} className="mx-auto text-gray-300 mb-4" />
+                        <p className="text-gray-500 text-lg">No ads in this folder</p>
+                        <p className="text-gray-400 text-sm mt-1">Upload your first ad above!</p>
+                    </div>
+                ) : (
+                    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                        {items.map((item) => (
+                            <div
+                                key={item.id}
+                                className="bg-white rounded-lg border border-amber-200 overflow-hidden group"
+                            >
+                                {/* Thumbnail */}
+                                <div
+                                    className="aspect-video bg-gray-100 relative cursor-pointer"
+                                    onClick={() => setSelectedItem(item)}
+                                >
+                                    {item.media_type === 'video' ? (
+                                        <>
+                                            {item.thumbnail_url ? (
+                                                <img
+                                                    src={item.thumbnail_url}
+                                                    alt={item.name || 'Video'}
+                                                    className="w-full h-full object-cover"
+                                                />
+                                            ) : (
+                                                <div className="w-full h-full flex items-center justify-center bg-gray-800">
+                                                    <Video size={32} className="text-gray-500" />
+                                                </div>
+                                            )}
+                                            <div className="absolute inset-0 flex items-center justify-center">
+                                                <div className="w-10 h-10 bg-black/60 rounded-full flex items-center justify-center group-hover:bg-black/80 transition-colors">
+                                                    <Play size={20} className="text-white ml-0.5" fill="white" />
+                                                </div>
+                                            </div>
+                                        </>
+                                    ) : (
+                                        <img
+                                            src={item.media_url}
+                                            alt={item.name || 'Ad'}
+                                            className="w-full h-full object-cover"
+                                        />
+                                    )}
+
+                                    {/* Media type badge */}
+                                    <span className="absolute top-2 left-2 px-2 py-0.5 bg-black/60 text-white text-xs rounded flex items-center gap-1">
+                                        {item.media_type === 'video' ? <Video size={10} /> : <Image size={10} />}
+                                        {item.media_type}
+                                    </span>
+
+                                    {/* Variants badge */}
+                                    {variantCount(item) > 1 && (
+                                        <span className="absolute bottom-2 left-2 px-2 py-0.5 bg-purple-600/90 text-white text-xs rounded flex items-center gap-1">
+                                            <Layers size={10} />
+                                            {variantCount(item)} sizes
+                                        </span>
+                                    )}
+
+                                    {/* Status badge */}
+                                    <span className={`absolute top-2 right-2 px-2 py-0.5 text-xs rounded ${STATUS_COLORS[item.status] || 'bg-gray-100 text-gray-700'}`}>
+                                        {item.status}
+                                    </span>
+
+                                    {/* Hover actions */}
+                                    <div className="absolute bottom-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                                        {item.media_type === 'image' && (
+                                            <>
+                                                <button
+                                                    onClick={(e) => { e.stopPropagation(); setVideoGenImage(item.media_url); }}
+                                                    className="w-8 h-8 bg-purple-500/90 hover:bg-purple-600 rounded-full flex items-center justify-center text-white"
+                                                    title="Generate Video"
+                                                >
+                                                    <Wand2 size={14} />
+                                                </button>
+                                                <button
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        setAddVariantTarget(item);
+                                                        setTimeout(() => variantInputRef.current?.click(), 100);
+                                                    }}
+                                                    className="w-8 h-8 bg-indigo-500/90 hover:bg-indigo-600 rounded-full flex items-center justify-center text-white"
+                                                    title="Add size variant"
+                                                >
+                                                    <Plus size={14} />
+                                                </button>
+                                            </>
+                                        )}
+                                        <button
+                                            onClick={(e) => { e.stopPropagation(); setEditItem({ ...item }); }}
+                                            className="w-8 h-8 bg-white/90 hover:bg-white rounded-full flex items-center justify-center text-gray-700"
+                                            title="Edit"
+                                        >
+                                            <Pencil size={14} />
+                                        </button>
+                                        <button
+                                            onClick={(e) => { e.stopPropagation(); setDeleteTarget(item); }}
+                                            className="w-8 h-8 bg-white/90 hover:bg-white rounded-full flex items-center justify-center text-red-600"
+                                            title="Delete"
+                                        >
+                                            <Trash2 size={14} />
+                                        </button>
+                                    </div>
+                                </div>
+
+                                {/* Info */}
+                                <div className="p-3">
+                                    <p className="text-sm font-medium text-gray-900 truncate">
+                                        {item.name || 'Untitled'}
+                                    </p>
+                                    {item.folder_name && (
+                                        <p className="text-xs text-amber-600 truncate">
+                                            {item.folder_name}
+                                        </p>
+                                    )}
+                                    <div className="flex items-center gap-2 mt-1 flex-wrap">
+                                        {item.variants && Object.keys(item.variants).length > 0 && (
+                                            Object.keys(item.variants).map((ratio) => (
+                                                <span key={ratio} className="px-1.5 py-0.5 text-[10px] bg-indigo-100 text-indigo-700 rounded">
+                                                    {ratio}
+                                                </span>
+                                            ))
+                                        )}
+                                        {item.funnel_stage && (
+                                            <span className="px-1.5 py-0.5 text-[10px] bg-purple-100 text-purple-700 rounded">
+                                                {item.funnel_stage.toUpperCase()}
+                                            </span>
+                                        )}
+                                        {item.ad_format && (
+                                            <span className="px-1.5 py-0.5 text-[10px] bg-blue-100 text-blue-700 rounded">
+                                                {item.ad_format.replace('_', ' ')}
+                                            </span>
+                                        )}
+                                        {item.tags && item.tags.map((tag, i) => (
+                                            <span key={i} className="px-1.5 py-0.5 text-[10px] bg-gray-100 text-gray-600 rounded">
+                                                {tag}
+                                            </span>
+                                        ))}
+                                    </div>
+                                    {item.file_size && (
+                                        <p className="text-[10px] text-gray-400 mt-1">{formatSize(item.file_size)}</p>
+                                    )}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        );
+    };
+
+    // ── Main render ──
+    return (
+        <div className="space-y-6">
+            {/* Header */}
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold text-amber-900 flex items-center gap-2">
+                        <FolderOpen size={28} />
+                        Ads Library
+                    </h1>
+                    <p className="text-amber-600 text-sm">Upload and organize your ad creatives by brand</p>
+                </div>
+                {navLevel === 3 && (
+                    <div className="text-sm text-gray-500">
+                        {items.length} ad{items.length !== 1 ? 's' : ''}
+                    </div>
+                )}
+            </div>
+
+            {/* Breadcrumb */}
+            {navLevel > 0 && (
+                <div className="bg-white rounded-lg border border-amber-100 px-4 py-2.5">
+                    {renderBreadcrumb()}
+                </div>
             )}
+
+            {/* Level-specific content */}
+            {navLevel === 0 && renderBrandCards()}
+            {navLevel === 1 && renderMediaTypePicker()}
+            {navLevel === 2 && renderFolderGrid()}
+            {navLevel === 3 && renderItemsGrid()}
 
             {/* Hidden input for adding variant */}
             <input
@@ -929,6 +1488,9 @@ const AdsLibrary = () => {
                                         <p className="text-amber-400 text-sm font-medium">{selectedItem.brand_name}</p>
                                     )}
                                     <p className="text-white font-medium mt-1">{selectedItem.name || 'Untitled'}</p>
+                                    {selectedItem.folder_name && (
+                                        <p className="text-white/50 text-xs mt-0.5">Folder: {selectedItem.folder_name}</p>
+                                    )}
                                     {selectedItem.headline && (
                                         <p className="text-white/80 text-sm mt-1">{selectedItem.headline}</p>
                                     )}
@@ -1025,6 +1587,21 @@ const AdsLibrary = () => {
                                     <option value="">No Brand</option>
                                     {brands.map((b) => (
                                         <option key={b.id} value={b.id}>{b.name}</option>
+                                    ))}
+                                </select>
+                            </div>
+
+                            {/* Folder selector */}
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">Folder</label>
+                                <select
+                                    value={editItem.folder_id || ''}
+                                    onChange={(e) => setEditItem({ ...editItem, folder_id: e.target.value || null })}
+                                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500"
+                                >
+                                    <option value="">Uncategorized</option>
+                                    {folders.map((f) => (
+                                        <option key={f.id} value={f.id}>{f.name}</option>
                                     ))}
                                 </select>
                             </div>
@@ -1157,6 +1734,32 @@ const AdsLibrary = () => {
                                 className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
                             >
                                 Delete
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Delete Folder Modal */}
+            {deleteFolderTarget && (
+                <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+                    <div className="bg-white rounded-xl p-6 max-w-md w-full mx-4">
+                        <h3 className="text-lg font-semibold text-gray-900 mb-2">Delete Folder?</h3>
+                        <p className="text-gray-600 mb-4">
+                            This will delete the folder "{deleteFolderTarget.name}". All items inside will become uncategorized. This action cannot be undone.
+                        </p>
+                        <div className="flex gap-3 justify-end">
+                            <button
+                                onClick={() => setDeleteFolderTarget(null)}
+                                className="px-4 py-2 text-gray-600 hover:bg-gray-100 rounded-lg"
+                            >
+                                Cancel
+                            </button>
+                            <button
+                                onClick={handleDeleteFolder}
+                                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
+                            >
+                                Delete Folder
                             </button>
                         </div>
                     </div>

--- a/frontend/src/pages/BrandScrapes.jsx
+++ b/frontend/src/pages/BrandScrapes.jsx
@@ -1,8 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { useToast } from '../context/ToastContext';
-import { createBrandScrape, getBrandScrapes, getBrandScrape, deleteBrandScrape } from '../api/research';
-import { Search, Trash2, ChevronDown, ChevronRight, ExternalLink, Image, Video, Loader2, RefreshCw, X, Download, ChevronLeft, Wand2 } from 'lucide-react';
+import { createBrandScrape, getBrandScrapes, getBrandScrape, deleteBrandScrape, updateBrandScrape, refreshBrandScrape } from '../api/research';
+import { Search, Trash2, ChevronDown, ChevronRight, ExternalLink, Image, Video, Loader2, RefreshCw, X, Download, ChevronLeft, Wand2, Pencil, Check } from 'lucide-react';
 import GenerateVideoModal from '../components/GenerateVideoModal';
+
+const VIDEO_PLACEHOLDER = 'https://pub-11870393a7f1464a9a0bf4fce09be525.r2.dev/placeholders/video_ad.png';
 
 const BrandScrapes = () => {
     const { showSuccess, showError, showInfo } = useToast();
@@ -36,6 +38,9 @@ const BrandScrapes = () => {
     const [selectedAd, setSelectedAd] = useState(null);
     const [mediaIndex, setMediaIndex] = useState(0);
     const [videoGenImage, setVideoGenImage] = useState(null);
+    const [editingScrapeId, setEditingScrapeId] = useState(null);
+    const [editName, setEditName] = useState('');
+    const [refreshingScrapeId, setRefreshingScrapeId] = useState(null);
 
     const handleDownload = async (url) => {
         try {
@@ -142,6 +147,35 @@ const BrandScrapes = () => {
             fetchScrapes();
         } catch (error) {
             showError('Failed to delete brand scrape');
+        }
+    };
+
+    const handleRename = async (scrapeId) => {
+        if (!editName.trim()) {
+            showError('Name cannot be empty');
+            return;
+        }
+        try {
+            await updateBrandScrape(scrapeId, { brand_name: editName.trim() });
+            showSuccess('Brand scrape renamed');
+            setEditingScrapeId(null);
+            fetchScrapes();
+        } catch (error) {
+            showError('Failed to rename brand scrape');
+        }
+    };
+
+    const handleRefresh = async (scrape) => {
+        setRefreshingScrapeId(scrape.id);
+        try {
+            await refreshBrandScrape(scrape.id);
+            showSuccess(`Re-scraping ${scrape.brand_name}...`);
+            fetchScrapes();
+        } catch (error) {
+            const msg = error.response?.data?.detail || 'Failed to refresh';
+            showError(msg);
+        } finally {
+            setRefreshingScrapeId(null);
         }
     };
 
@@ -268,7 +302,37 @@ const BrandScrapes = () => {
                                             )}
                                         </button>
                                         <div>
-                                            <h3 className="font-medium text-gray-900">{scrape.brand_name}</h3>
+                                            {editingScrapeId === scrape.id ? (
+                                                <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+                                                    <input
+                                                        type="text"
+                                                        value={editName}
+                                                        onChange={(e) => setEditName(e.target.value)}
+                                                        onKeyDown={(e) => {
+                                                            if (e.key === 'Enter') handleRename(scrape.id);
+                                                            if (e.key === 'Escape') setEditingScrapeId(null);
+                                                        }}
+                                                        className="px-2 py-1 border border-amber-300 rounded text-sm font-medium focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
+                                                        autoFocus
+                                                    />
+                                                    <button
+                                                        onClick={() => handleRename(scrape.id)}
+                                                        className="p-1 text-green-600 hover:bg-green-50 rounded"
+                                                        title="Save"
+                                                    >
+                                                        <Check size={16} />
+                                                    </button>
+                                                    <button
+                                                        onClick={() => setEditingScrapeId(null)}
+                                                        className="p-1 text-gray-400 hover:bg-gray-100 rounded"
+                                                        title="Cancel"
+                                                    >
+                                                        <X size={16} />
+                                                    </button>
+                                                </div>
+                                            ) : (
+                                                <h3 className="font-medium text-gray-900">{scrape.brand_name}</h3>
+                                            )}
                                             <p className="text-sm text-gray-500">
                                                 {scrape.page_name || `Page ID: ${scrape.page_id}`}
                                             </p>
@@ -287,6 +351,28 @@ const BrandScrapes = () => {
                                         <span className="text-xs text-gray-400">
                                             {formatDate(scrape.created_at)}
                                         </span>
+                                        <button
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                setEditingScrapeId(scrape.id);
+                                                setEditName(scrape.brand_name);
+                                            }}
+                                            className="p-2 text-gray-500 hover:bg-gray-100 rounded-lg"
+                                            title="Rename"
+                                        >
+                                            <Pencil size={16} />
+                                        </button>
+                                        <button
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                handleRefresh(scrape);
+                                            }}
+                                            disabled={refreshingScrapeId === scrape.id || scrape.status === 'scraping'}
+                                            className="p-2 text-amber-600 hover:bg-amber-50 rounded-lg disabled:opacity-50"
+                                            title="Re-scrape current ads"
+                                        >
+                                            <RefreshCw size={16} className={refreshingScrapeId === scrape.id ? 'animate-spin' : ''} />
+                                        </button>
                                         <button
                                             onClick={(e) => {
                                                 e.stopPropagation();
@@ -322,9 +408,9 @@ const BrandScrapes = () => {
                                                         >
                                                             {ad.media_urls && ad.media_urls.length > 0 ? (
                                                                 <img
-                                                                    src={ad.media_urls[0]}
+                                                                    src={ad.media_type === 'video' ? VIDEO_PLACEHOLDER : ad.media_urls[0]}
                                                                     alt={ad.headline || 'Ad'}
-                                                                    className="w-full h-full object-cover"
+                                                                    className={`w-full h-full ${ad.media_type === 'video' ? 'object-contain bg-gray-900' : 'object-cover'}`}
                                                                 />
                                                             ) : (
                                                                 <div className="w-full h-full flex items-center justify-center text-gray-400">
@@ -440,6 +526,7 @@ const BrandScrapes = () => {
                         {(() => {
                             const currentUrl = selectedAd.media_urls[mediaIndex];
                             const isActualVideo = currentUrl?.match(/\.(mp4|webm|mov)(\?|$)/i);
+                            const displayUrl = selectedAd.media_type === 'video' ? VIDEO_PLACEHOLDER : currentUrl;
                             return isActualVideo ? (
                                 <video
                                     key={currentUrl}
@@ -450,7 +537,7 @@ const BrandScrapes = () => {
                                 />
                             ) : (
                                 <img
-                                    src={currentUrl}
+                                    src={displayUrl}
                                     alt={selectedAd.headline || 'Ad'}
                                     className="w-full rounded-lg max-h-[70vh] object-contain bg-black"
                                 />

--- a/frontend/src/pages/BrandScrapes.jsx
+++ b/frontend/src/pages/BrandScrapes.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useToast } from '../context/ToastContext';
 import { createBrandScrape, getBrandScrapes, getBrandScrape, deleteBrandScrape } from '../api/research';
-import { Search, Trash2, ChevronDown, ChevronRight, ExternalLink, Image, Video, Loader2, RefreshCw } from 'lucide-react';
+import { Search, Trash2, ChevronDown, ChevronRight, ExternalLink, Image, Video, Loader2, RefreshCw, X, Download, ChevronLeft, Play } from 'lucide-react';
 
 const BrandScrapes = () => {
     const { showSuccess, showError, showInfo } = useToast();
@@ -32,6 +32,8 @@ const BrandScrapes = () => {
     const [scrapeDetails, setScrapeDetails] = useState(null);
     const [showDeleteModal, setShowDeleteModal] = useState(false);
     const [scrapeToDelete, setScrapeToDelete] = useState(null);
+    const [selectedAd, setSelectedAd] = useState(null);
+    const [mediaIndex, setMediaIndex] = useState(0);
 
     useEffect(() => {
         fetchScrapes();
@@ -295,14 +297,24 @@ const BrandScrapes = () => {
                                                         className="bg-white rounded-lg border border-amber-200 overflow-hidden"
                                                     >
                                                         {/* Media Preview */}
-                                                        <div className="aspect-video bg-gray-100 relative">
+                                                        <div
+                                                            className="aspect-video bg-gray-100 relative cursor-pointer group"
+                                                            onClick={() => { setSelectedAd(ad); setMediaIndex(0); }}
+                                                        >
                                                             {ad.media_urls && ad.media_urls.length > 0 ? (
                                                                 ad.media_type === 'video' ? (
-                                                                    <video
-                                                                        src={ad.media_urls[0]}
-                                                                        className="w-full h-full object-cover"
-                                                                        controls
-                                                                    />
+                                                                    <>
+                                                                        <img
+                                                                            src={ad.media_urls[0]}
+                                                                            alt={ad.headline || 'Ad'}
+                                                                            className="w-full h-full object-cover"
+                                                                        />
+                                                                        <div className="absolute inset-0 flex items-center justify-center">
+                                                                            <div className="w-12 h-12 bg-black/60 rounded-full flex items-center justify-center group-hover:bg-black/80 transition-colors">
+                                                                                <Play size={24} className="text-white ml-1" fill="white" />
+                                                                            </div>
+                                                                        </div>
+                                                                    </>
                                                                 ) : (
                                                                     <img
                                                                         src={ad.media_urls[0]}
@@ -408,6 +420,130 @@ const BrandScrapes = () => {
                     </div>
                 )}
             </div>
+
+            {/* Media Viewer Modal */}
+            {selectedAd && selectedAd.media_urls && selectedAd.media_urls.length > 0 && (
+                <div
+                    className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4"
+                    onClick={() => setSelectedAd(null)}
+                >
+                    <div className="relative w-full max-w-4xl" onClick={(e) => e.stopPropagation()}>
+                        {/* Close button */}
+                        <button
+                            onClick={() => setSelectedAd(null)}
+                            className="absolute -top-10 right-0 text-white hover:text-gray-300 transition-colors z-10"
+                        >
+                            <X size={28} />
+                        </button>
+
+                        {/* Main media display */}
+                        {(() => {
+                            const currentUrl = selectedAd.media_urls[mediaIndex];
+                            const isVideo = selectedAd.media_type === 'video' || currentUrl?.endsWith('.mp4');
+                            return isVideo ? (
+                                <video
+                                    key={currentUrl}
+                                    src={currentUrl}
+                                    controls
+                                    autoPlay
+                                    className="w-full rounded-lg max-h-[70vh] object-contain bg-black"
+                                />
+                            ) : (
+                                <img
+                                    src={currentUrl}
+                                    alt={selectedAd.headline || 'Ad'}
+                                    className="w-full rounded-lg max-h-[70vh] object-contain bg-black"
+                                />
+                            );
+                        })()}
+
+                        {/* Carousel navigation */}
+                        {selectedAd.media_urls.length > 1 && (
+                            <>
+                                <button
+                                    onClick={() => setMediaIndex((mediaIndex - 1 + selectedAd.media_urls.length) % selectedAd.media_urls.length)}
+                                    className="absolute left-2 top-1/2 -translate-y-1/2 w-10 h-10 bg-black/60 hover:bg-black/80 rounded-full flex items-center justify-center text-white transition-colors"
+                                >
+                                    <ChevronLeft size={24} />
+                                </button>
+                                <button
+                                    onClick={() => setMediaIndex((mediaIndex + 1) % selectedAd.media_urls.length)}
+                                    className="absolute right-2 top-1/2 -translate-y-1/2 w-10 h-10 bg-black/60 hover:bg-black/80 rounded-full flex items-center justify-center text-white transition-colors"
+                                >
+                                    <ChevronRight size={24} />
+                                </button>
+                                <div className="text-center text-white/70 text-sm mt-2">
+                                    {mediaIndex + 1} of {selectedAd.media_urls.length}
+                                </div>
+                            </>
+                        )}
+
+                        {/* Thumbnail strip for multiple media */}
+                        {selectedAd.media_urls.length > 1 && (
+                            <div className="flex gap-2 mt-3 justify-center overflow-x-auto">
+                                {selectedAd.media_urls.map((url, i) => (
+                                    <button
+                                        key={i}
+                                        onClick={() => setMediaIndex(i)}
+                                        className={`w-16 h-12 rounded overflow-hidden flex-shrink-0 border-2 transition-colors ${
+                                            i === mediaIndex ? 'border-amber-500' : 'border-transparent opacity-60 hover:opacity-100'
+                                        }`}
+                                    >
+                                        <img src={url} alt="" className="w-full h-full object-cover" />
+                                    </button>
+                                ))}
+                            </div>
+                        )}
+
+                        {/* Ad info + download */}
+                        <div className="mt-4 bg-white/10 backdrop-blur rounded-lg p-4">
+                            <div className="flex items-start justify-between gap-4">
+                                <div className="flex-1 min-w-0">
+                                    {selectedAd.page_name && (
+                                        <p className="text-amber-400 text-sm font-medium">{selectedAd.page_name}</p>
+                                    )}
+                                    {selectedAd.headline && (
+                                        <p className="text-white font-medium mt-1">{selectedAd.headline}</p>
+                                    )}
+                                    {selectedAd.ad_copy && (
+                                        <p className="text-white/70 text-sm mt-1">{selectedAd.ad_copy}</p>
+                                    )}
+                                    <div className="flex items-center gap-3 mt-2">
+                                        {selectedAd.cta_text && (
+                                            <span className="px-2 py-0.5 text-xs bg-amber-500/20 text-amber-300 rounded">
+                                                {selectedAd.cta_text}
+                                            </span>
+                                        )}
+                                        {selectedAd.start_date && (
+                                            <span className="text-white/50 text-xs">{selectedAd.start_date}</span>
+                                        )}
+                                        {selectedAd.ad_link && (
+                                            <a
+                                                href={selectedAd.ad_link}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="text-amber-400 hover:text-amber-300 text-xs flex items-center gap-1"
+                                            >
+                                                <ExternalLink size={12} /> View in Ad Library
+                                            </a>
+                                        )}
+                                    </div>
+                                </div>
+                                <a
+                                    href={selectedAd.media_urls[mediaIndex]}
+                                    download
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="flex items-center gap-2 px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white rounded-lg transition-colors flex-shrink-0"
+                                >
+                                    <Download size={16} />
+                                    Download
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            )}
 
             {/* Delete Confirmation Modal */}
             {showDeleteModal && scrapeToDelete && (

--- a/frontend/src/pages/BrandScrapes.jsx
+++ b/frontend/src/pages/BrandScrapes.jsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useToast } from '../context/ToastContext';
 import { createBrandScrape, getBrandScrapes, getBrandScrape, deleteBrandScrape } from '../api/research';
-import { Search, Trash2, ChevronDown, ChevronRight, ExternalLink, Image, Video, Loader2, RefreshCw, X, Download, ChevronLeft, Play } from 'lucide-react';
+import { Search, Trash2, ChevronDown, ChevronRight, ExternalLink, Image, Video, Loader2, RefreshCw, X, Download, ChevronLeft, Wand2 } from 'lucide-react';
+import GenerateVideoModal from '../components/GenerateVideoModal';
 
 const BrandScrapes = () => {
     const { showSuccess, showError, showInfo } = useToast();
@@ -34,6 +35,24 @@ const BrandScrapes = () => {
     const [scrapeToDelete, setScrapeToDelete] = useState(null);
     const [selectedAd, setSelectedAd] = useState(null);
     const [mediaIndex, setMediaIndex] = useState(0);
+    const [videoGenImage, setVideoGenImage] = useState(null);
+
+    const handleDownload = async (url) => {
+        try {
+            const response = await fetch(url);
+            const blob = await response.blob();
+            const blobUrl = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = blobUrl;
+            a.download = url.split('/').pop() || 'download';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(blobUrl);
+        } catch {
+            window.open(url, '_blank');
+        }
+    };
 
     useEffect(() => {
         fetchScrapes();
@@ -302,38 +321,19 @@ const BrandScrapes = () => {
                                                             onClick={() => { setSelectedAd(ad); setMediaIndex(0); }}
                                                         >
                                                             {ad.media_urls && ad.media_urls.length > 0 ? (
-                                                                ad.media_type === 'video' ? (
-                                                                    <>
-                                                                        <img
-                                                                            src={ad.media_urls[0]}
-                                                                            alt={ad.headline || 'Ad'}
-                                                                            className="w-full h-full object-cover"
-                                                                        />
-                                                                        <div className="absolute inset-0 flex items-center justify-center">
-                                                                            <div className="w-12 h-12 bg-black/60 rounded-full flex items-center justify-center group-hover:bg-black/80 transition-colors">
-                                                                                <Play size={24} className="text-white ml-1" fill="white" />
-                                                                            </div>
-                                                                        </div>
-                                                                    </>
-                                                                ) : (
-                                                                    <img
-                                                                        src={ad.media_urls[0]}
-                                                                        alt={ad.headline || 'Ad'}
-                                                                        className="w-full h-full object-cover"
-                                                                    />
-                                                                )
+                                                                <img
+                                                                    src={ad.media_urls[0]}
+                                                                    alt={ad.headline || 'Ad'}
+                                                                    className="w-full h-full object-cover"
+                                                                />
                                                             ) : (
                                                                 <div className="w-full h-full flex items-center justify-center text-gray-400">
                                                                     <Image size={32} />
                                                                 </div>
                                                             )}
                                                             {ad.media_type && (
-                                                                <span className="absolute top-2 right-2 px-2 py-0.5 bg-black/60 text-white text-xs rounded">
-                                                                    {ad.media_type === 'video' ? (
-                                                                        <Video size={12} className="inline mr-1" />
-                                                                    ) : (
-                                                                        <Image size={12} className="inline mr-1" />
-                                                                    )}
+                                                                <span className="absolute top-2 right-2 px-2 py-0.5 bg-black/60 text-white text-xs rounded flex items-center gap-1">
+                                                                    {ad.media_type === 'video' ? <Video size={12} /> : <Image size={12} />}
                                                                     {ad.media_type}
                                                                 </span>
                                                             )}
@@ -439,8 +439,8 @@ const BrandScrapes = () => {
                         {/* Main media display */}
                         {(() => {
                             const currentUrl = selectedAd.media_urls[mediaIndex];
-                            const isVideo = selectedAd.media_type === 'video' || currentUrl?.endsWith('.mp4');
-                            return isVideo ? (
+                            const isActualVideo = currentUrl?.match(/\.(mp4|webm|mov)(\?|$)/i);
+                            return isActualVideo ? (
                                 <video
                                     key={currentUrl}
                                     src={currentUrl}
@@ -495,7 +495,7 @@ const BrandScrapes = () => {
                             </div>
                         )}
 
-                        {/* Ad info + download */}
+                        {/* Ad info + actions */}
                         <div className="mt-4 bg-white/10 backdrop-blur rounded-lg p-4">
                             <div className="flex items-start justify-between gap-4">
                                 <div className="flex-1 min-w-0">
@@ -517,28 +517,39 @@ const BrandScrapes = () => {
                                         {selectedAd.start_date && (
                                             <span className="text-white/50 text-xs">{selectedAd.start_date}</span>
                                         )}
-                                        {selectedAd.ad_link && (
-                                            <a
-                                                href={selectedAd.ad_link}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                                className="text-amber-400 hover:text-amber-300 text-xs flex items-center gap-1"
-                                            >
-                                                <ExternalLink size={12} /> View in Ad Library
-                                            </a>
-                                        )}
                                     </div>
                                 </div>
-                                <a
-                                    href={selectedAd.media_urls[mediaIndex]}
-                                    download
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    className="flex items-center gap-2 px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white rounded-lg transition-colors flex-shrink-0"
-                                >
-                                    <Download size={16} />
-                                    Download
-                                </a>
+                                <div className="flex items-center gap-2 flex-shrink-0">
+                                    <button
+                                        onClick={() => {
+                                            setVideoGenImage(selectedAd.media_urls[mediaIndex]);
+                                            setSelectedAd(null);
+                                        }}
+                                        className="flex items-center gap-2 px-4 py-2 bg-purple-600 hover:bg-purple-700 text-white rounded-lg transition-colors"
+                                        title="Generate video from this image"
+                                    >
+                                        <Wand2 size={16} />
+                                        Generate Video
+                                    </button>
+                                    {selectedAd.ad_link && (
+                                        <a
+                                            href={selectedAd.ad_link}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
+                                        >
+                                            <ExternalLink size={16} />
+                                            {selectedAd.media_type === 'video' ? 'Watch on Facebook' : 'View on Facebook'}
+                                        </a>
+                                    )}
+                                    <button
+                                        onClick={() => handleDownload(selectedAd.media_urls[mediaIndex])}
+                                        className="flex items-center gap-2 px-4 py-2 bg-amber-600 hover:bg-amber-700 text-white rounded-lg transition-colors"
+                                    >
+                                        <Download size={16} />
+                                        Download
+                                    </button>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -574,6 +585,18 @@ const BrandScrapes = () => {
                         </div>
                     </div>
                 </div>
+            )}
+
+            {/* Generate Video Modal */}
+            {videoGenImage && (
+                <GenerateVideoModal
+                    imageUrl={videoGenImage}
+                    onClose={() => setVideoGenImage(null)}
+                    onVideoReady={(videoUrl) => {
+                        showSuccess('Video saved! Check your Ads Library.');
+                        setVideoGenImage(null);
+                    }}
+                />
             )}
         </div>
     );

--- a/frontend/src/pages/Brands.jsx
+++ b/frontend/src/pages/Brands.jsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import { useBrands } from '../context/BrandContext';
+import { useToast } from '../context/ToastContext';
 import BrandForm from '../components/BrandForm';
 import { Plus, Edit2, Trash2, Briefcase, LayoutGrid, List } from 'lucide-react';
 import ConfirmationModal from '../components/ConfirmationModal';
 
 const Brands = () => {
     const { brands, addBrand, updateBrand, deleteBrand } = useBrands();
+    const { showSuccess, showError } = useToast();
     const [isFormOpen, setIsFormOpen] = useState(false);
     const [editingBrand, setEditingBrand] = useState(null);
     const [viewMode, setViewMode] = useState(localStorage.getItem('preferred_view_mode') || 'list'); // 'list' or 'grid'
@@ -17,14 +19,20 @@ const Brands = () => {
 
     const [brandToDelete, setBrandToDelete] = useState(null);
 
-    const handleSave = (brandData) => {
-        if (editingBrand) {
-            updateBrand(editingBrand.id, brandData);
-        } else {
-            addBrand(brandData);
+    const handleSave = async (brandData) => {
+        try {
+            if (editingBrand) {
+                await updateBrand(editingBrand.id, brandData);
+                showSuccess('Brand updated successfully');
+            } else {
+                await addBrand(brandData);
+                showSuccess('Brand created successfully');
+            }
+            setIsFormOpen(false);
+            setEditingBrand(null);
+        } catch (error) {
+            showError(error.message || 'Failed to save brand');
         }
-        setIsFormOpen(false);
-        setEditingBrand(null);
     };
 
     const handleEdit = (brand) => {

--- a/frontend/src/pages/CustomerProfiles.jsx
+++ b/frontend/src/pages/CustomerProfiles.jsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import { useBrands } from '../context/BrandContext';
+import { useToast } from '../context/ToastContext';
 import CustomerProfileForm from '../components/CustomerProfileForm';
 import { Plus, Edit2, Trash2, Users, LayoutGrid, List, Search, UserCircle } from 'lucide-react';
 import ConfirmationModal from '../components/ConfirmationModal';
 
 const CustomerProfiles = () => {
     const { customerProfiles, brands, addProfile, updateProfile, deleteProfile } = useBrands();
+    const { showSuccess, showError } = useToast();
     const [isFormOpen, setIsFormOpen] = useState(false);
     const [editingProfile, setEditingProfile] = useState(null);
     const [viewMode, setViewMode] = useState(localStorage.getItem('preferred_view_mode') || 'list');
@@ -27,14 +29,20 @@ const CustomerProfiles = () => {
         profile.name.toLowerCase().includes(searchTerm.toLowerCase())
     );
 
-    const handleSave = (profileData) => {
-        if (editingProfile) {
-            updateProfile(editingProfile.id, profileData);
-        } else {
-            addProfile(profileData);
+    const handleSave = async (profileData) => {
+        try {
+            if (editingProfile) {
+                await updateProfile(editingProfile.id, profileData);
+                showSuccess('Profile updated successfully');
+            } else {
+                await addProfile(profileData);
+                showSuccess('Profile created successfully');
+            }
+            setIsFormOpen(false);
+            setEditingProfile(null);
+        } catch (error) {
+            showError(error.message || 'Failed to save profile');
         }
-        setIsFormOpen(false);
-        setEditingProfile(null);
     };
 
     const handleEdit = (profile) => {

--- a/frontend/src/pages/GeneratedAds.jsx
+++ b/frontend/src/pages/GeneratedAds.jsx
@@ -242,7 +242,7 @@ export default function GeneratedAds() {
                 <div>
                     <h1 className="text-3xl font-bold text-gray-900 flex items-center gap-3">
                         <Image size={32} className="text-amber-600" />
-                        Generated Ads
+                        BreadWinner Ads
                     </h1>
                     <p className="text-gray-600 mt-1">View and manage all your AI-generated ad creatives</p>
                 </div>

--- a/frontend/src/pages/Headlines.jsx
+++ b/frontend/src/pages/Headlines.jsx
@@ -1,0 +1,429 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { Sparkles, Trash2, Plus, Upload, X, Loader, FileText, Check } from 'lucide-react';
+import { useBrands } from '../context/BrandContext';
+import { useAuth } from '../context/AuthContext';
+import { useToast } from '../context/ToastContext';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api/v1';
+
+const CATEGORIES = [
+    { value: '', label: 'All' },
+    { value: 'curiosity', label: 'Curiosity' },
+    { value: 'urgency', label: 'Urgency' },
+    { value: 'benefit', label: 'Benefit' },
+    { value: 'social_proof', label: 'Social Proof' },
+    { value: 'fomo', label: 'FOMO' },
+];
+
+const CATEGORY_COLORS = {
+    curiosity: 'bg-blue-100 text-blue-700',
+    urgency: 'bg-red-100 text-red-700',
+    benefit: 'bg-green-100 text-green-700',
+    social_proof: 'bg-purple-100 text-purple-700',
+    fomo: 'bg-amber-100 text-amber-700',
+};
+
+export default function Headlines() {
+    const { brands } = useBrands();
+    const { authFetch } = useAuth();
+    const { showSuccess, showError, showWarning } = useToast();
+
+    const [selectedBrandId, setSelectedBrandId] = useState('');
+    const [selectedProductId, setSelectedProductId] = useState('');
+    const [researchFile, setResearchFile] = useState(null);
+    const [generating, setGenerating] = useState(false);
+    const [headlines, setHeadlines] = useState([]);
+    const [loading, setLoading] = useState(false);
+    const [filterCategory, setFilterCategory] = useState('');
+    const [selectedIds, setSelectedIds] = useState(new Set());
+    const [newHeadlineText, setNewHeadlineText] = useState('');
+    const [showAddInput, setShowAddInput] = useState(false);
+    const fileInputRef = useRef(null);
+
+    const selectedBrand = brands.find(b => b.id === selectedBrandId);
+    const products = selectedBrand?.products || [];
+
+    // Fetch headlines when brand changes
+    useEffect(() => {
+        if (selectedBrandId) {
+            fetchHeadlines();
+        } else {
+            setHeadlines([]);
+        }
+    }, [selectedBrandId, selectedProductId]);
+
+    const fetchHeadlines = async () => {
+        setLoading(true);
+        try {
+            let url = `${API_URL}/headlines?brand_id=${selectedBrandId}`;
+            if (selectedProductId) url += `&product_id=${selectedProductId}`;
+            const res = await authFetch(url);
+            if (!res.ok) throw new Error('Failed to fetch headlines');
+            const data = await res.json();
+            setHeadlines(data);
+        } catch (err) {
+            showError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleGenerate = async () => {
+        if (!selectedBrandId) {
+            showWarning('Please select a brand');
+            return;
+        }
+        if (!researchFile) {
+            showWarning('Please upload a research document');
+            return;
+        }
+
+        setGenerating(true);
+        try {
+            const formData = new FormData();
+            formData.append('brand_id', selectedBrandId);
+            if (selectedProductId) formData.append('product_id', selectedProductId);
+            formData.append('file', researchFile);
+
+            const res = await authFetch(`${API_URL}/headlines/generate`, {
+                method: 'POST',
+                body: formData,
+            });
+
+            if (!res.ok) {
+                const err = await res.json().catch(() => ({}));
+                throw new Error(err.detail || 'Generation failed');
+            }
+
+            const newHeadlines = await res.json();
+            setHeadlines(prev => [...newHeadlines, ...prev]);
+            showSuccess(`Generated ${newHeadlines.length} headlines`);
+        } catch (err) {
+            showError(err.message);
+        } finally {
+            setGenerating(false);
+        }
+    };
+
+    const handleAddManual = async () => {
+        const text = newHeadlineText.trim();
+        if (!text) return;
+        if (!selectedBrandId) {
+            showWarning('Please select a brand first');
+            return;
+        }
+
+        try {
+            const res = await authFetch(`${API_URL}/headlines`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    text,
+                    brand_id: selectedBrandId,
+                    product_id: selectedProductId || null,
+                    source: 'manual',
+                }),
+            });
+            if (!res.ok) throw new Error('Failed to save headline');
+            const saved = await res.json();
+            setHeadlines(prev => [saved, ...prev]);
+            setNewHeadlineText('');
+            setShowAddInput(false);
+            showSuccess('Headline added');
+        } catch (err) {
+            showError(err.message);
+        }
+    };
+
+    const handleDeleteSelected = async () => {
+        if (selectedIds.size === 0) return;
+        try {
+            const res = await authFetch(`${API_URL}/headlines/batch`, {
+                method: 'DELETE',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ ids: Array.from(selectedIds) }),
+            });
+            if (!res.ok) throw new Error('Failed to delete');
+            setHeadlines(prev => prev.filter(h => !selectedIds.has(h.id)));
+            showSuccess(`Deleted ${selectedIds.size} headline${selectedIds.size > 1 ? 's' : ''}`);
+            setSelectedIds(new Set());
+        } catch (err) {
+            showError(err.message);
+        }
+    };
+
+    const toggleSelect = (id) => {
+        setSelectedIds(prev => {
+            const next = new Set(prev);
+            if (next.has(id)) next.delete(id);
+            else next.add(id);
+            return next;
+        });
+    };
+
+    const toggleSelectAll = () => {
+        const filtered = filteredHeadlines;
+        if (selectedIds.size === filtered.length) {
+            setSelectedIds(new Set());
+        } else {
+            setSelectedIds(new Set(filtered.map(h => h.id)));
+        }
+    };
+
+    const handleFileChange = (e) => {
+        const file = e.target.files?.[0];
+        if (file) setResearchFile(file);
+    };
+
+    const filteredHeadlines = filterCategory
+        ? headlines.filter(h => h.category === filterCategory)
+        : headlines;
+
+    return (
+        <div className="max-w-5xl mx-auto">
+            <div className="mb-8">
+                <h1 className="text-3xl font-bold text-gray-900">Headlines</h1>
+                <p className="text-gray-500 mt-1">Generate and manage ad headlines by brand</p>
+            </div>
+
+            {/* Top Controls */}
+            <div className="bg-white rounded-xl border border-gray-200 p-6 mb-6 space-y-5">
+                {/* Brand & Product Selectors */}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Brand *</label>
+                        <select
+                            value={selectedBrandId}
+                            onChange={(e) => {
+                                setSelectedBrandId(e.target.value);
+                                setSelectedProductId('');
+                                setSelectedIds(new Set());
+                            }}
+                            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                        >
+                            <option value="">Select a brand...</option>
+                            {brands.map(b => (
+                                <option key={b.id} value={b.id}>{b.name}</option>
+                            ))}
+                        </select>
+                    </div>
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Product</label>
+                        <select
+                            value={selectedProductId}
+                            onChange={(e) => setSelectedProductId(e.target.value)}
+                            disabled={!selectedBrandId}
+                            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent disabled:opacity-50"
+                        >
+                            <option value="">All Products</option>
+                            {products.map(p => (
+                                <option key={p.id} value={p.id}>{p.name}</option>
+                            ))}
+                        </select>
+                    </div>
+                </div>
+
+                {/* Research Document Upload */}
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">Research Document</label>
+                    {researchFile ? (
+                        <div className="flex items-center gap-3 bg-gray-50 border border-gray-200 rounded-lg px-4 py-3">
+                            <FileText size={20} className="text-amber-600 flex-shrink-0" />
+                            <span className="text-sm text-gray-800 truncate flex-1">{researchFile.name}</span>
+                            <span className="text-xs text-gray-400">{(researchFile.size / 1024).toFixed(0)} KB</span>
+                            <button onClick={() => { setResearchFile(null); if (fileInputRef.current) fileInputRef.current.value = ''; }}
+                                className="text-gray-400 hover:text-red-500">
+                                <X size={16} />
+                            </button>
+                        </div>
+                    ) : (
+                        <div
+                            onClick={() => fileInputRef.current?.click()}
+                            className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center cursor-pointer hover:border-amber-500 transition-colors"
+                        >
+                            <Upload size={24} className="mx-auto text-gray-400 mb-2" />
+                            <p className="text-sm text-gray-600">Click to upload research document</p>
+                            <p className="text-xs text-gray-400 mt-1">PDF, TXT, CSV, or DOC</p>
+                        </div>
+                    )}
+                    <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept=".pdf,.txt,.csv,.doc,.docx,.md"
+                        onChange={handleFileChange}
+                        className="hidden"
+                    />
+                </div>
+
+                {/* Generate Button */}
+                <button
+                    onClick={handleGenerate}
+                    disabled={generating || !selectedBrandId || !researchFile}
+                    className="flex items-center gap-2 px-6 py-3 bg-amber-600 text-white rounded-lg font-medium hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                    {generating ? (
+                        <>
+                            <Loader size={18} className="animate-spin" />
+                            Generating Headlines...
+                        </>
+                    ) : (
+                        <>
+                            <Sparkles size={18} />
+                            Generate Headlines
+                        </>
+                    )}
+                </button>
+            </div>
+
+            {/* Headlines List */}
+            {selectedBrandId && (
+                <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+                    {/* List Header */}
+                    <div className="px-6 py-4 border-b border-gray-100 flex items-center justify-between flex-wrap gap-3">
+                        <div className="flex items-center gap-3">
+                            <h2 className="text-lg font-semibold text-gray-900">
+                                Saved Headlines
+                                <span className="text-sm font-normal text-gray-400 ml-2">({filteredHeadlines.length})</span>
+                            </h2>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            {/* Category Filter */}
+                            <div className="flex rounded-lg border border-gray-200 overflow-hidden">
+                                {CATEGORIES.map(cat => (
+                                    <button
+                                        key={cat.value}
+                                        onClick={() => setFilterCategory(cat.value)}
+                                        className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                                            filterCategory === cat.value
+                                                ? 'bg-amber-600 text-white'
+                                                : 'bg-white text-gray-600 hover:bg-gray-50'
+                                        }`}
+                                    >
+                                        {cat.label}
+                                    </button>
+                                ))}
+                            </div>
+
+                            {/* Add Manual */}
+                            <button
+                                onClick={() => setShowAddInput(!showAddInput)}
+                                className="flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-amber-700 bg-amber-50 rounded-lg hover:bg-amber-100 border border-amber-200"
+                            >
+                                <Plus size={14} /> Add
+                            </button>
+                        </div>
+                    </div>
+
+                    {/* Manual Add Input */}
+                    {showAddInput && (
+                        <div className="px-6 py-3 border-b border-gray-100 bg-amber-50 flex gap-2">
+                            <input
+                                type="text"
+                                value={newHeadlineText}
+                                onChange={(e) => setNewHeadlineText(e.target.value)}
+                                placeholder="Type a headline..."
+                                maxLength={100}
+                                className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent text-sm"
+                                onKeyDown={(e) => { if (e.key === 'Enter') handleAddManual(); }}
+                                autoFocus
+                            />
+                            <button
+                                onClick={handleAddManual}
+                                disabled={!newHeadlineText.trim()}
+                                className="px-4 py-2 bg-amber-600 text-white rounded-lg text-sm font-medium hover:bg-amber-700 disabled:opacity-50"
+                            >
+                                Save
+                            </button>
+                            <button
+                                onClick={() => { setShowAddInput(false); setNewHeadlineText(''); }}
+                                className="px-3 py-2 text-gray-500 hover:bg-gray-100 rounded-lg"
+                            >
+                                <X size={16} />
+                            </button>
+                        </div>
+                    )}
+
+                    {/* Bulk Actions */}
+                    {selectedIds.size > 0 && (
+                        <div className="px-6 py-2 border-b border-gray-100 bg-red-50 flex items-center justify-between">
+                            <span className="text-sm text-red-700 font-medium">{selectedIds.size} selected</span>
+                            <button
+                                onClick={handleDeleteSelected}
+                                className="flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-red-700 bg-red-100 rounded-lg hover:bg-red-200"
+                            >
+                                <Trash2 size={14} /> Delete Selected
+                            </button>
+                        </div>
+                    )}
+
+                    {/* Headlines */}
+                    <div className="divide-y divide-gray-50">
+                        {loading ? (
+                            <div className="flex items-center justify-center py-12">
+                                <Loader size={24} className="animate-spin text-amber-600" />
+                            </div>
+                        ) : filteredHeadlines.length === 0 ? (
+                            <div className="text-center py-12 text-gray-400">
+                                {headlines.length === 0
+                                    ? 'No headlines yet. Upload a research doc and generate some!'
+                                    : 'No headlines match this filter.'}
+                            </div>
+                        ) : (
+                            <>
+                                {/* Select All */}
+                                <div className="px-6 py-2 bg-gray-50 flex items-center gap-3">
+                                    <button
+                                        onClick={toggleSelectAll}
+                                        className={`w-5 h-5 rounded border-2 flex items-center justify-center transition-colors ${
+                                            selectedIds.size === filteredHeadlines.length && filteredHeadlines.length > 0
+                                                ? 'bg-amber-600 border-amber-600'
+                                                : 'border-gray-300 hover:border-amber-400'
+                                        }`}
+                                    >
+                                        {selectedIds.size === filteredHeadlines.length && filteredHeadlines.length > 0 && (
+                                            <Check size={12} className="text-white" />
+                                        )}
+                                    </button>
+                                    <span className="text-xs text-gray-500 font-medium">Select All</span>
+                                </div>
+
+                                {filteredHeadlines.map(headline => (
+                                    <div
+                                        key={headline.id}
+                                        className={`px-6 py-3 flex items-center gap-3 hover:bg-gray-50 transition-colors ${
+                                            selectedIds.has(headline.id) ? 'bg-amber-50' : ''
+                                        }`}
+                                    >
+                                        <button
+                                            onClick={() => toggleSelect(headline.id)}
+                                            className={`w-5 h-5 rounded border-2 flex items-center justify-center flex-shrink-0 transition-colors ${
+                                                selectedIds.has(headline.id)
+                                                    ? 'bg-amber-600 border-amber-600'
+                                                    : 'border-gray-300 hover:border-amber-400'
+                                            }`}
+                                        >
+                                            {selectedIds.has(headline.id) && (
+                                                <Check size={12} className="text-white" />
+                                            )}
+                                        </button>
+                                        <span className="flex-1 text-gray-800">{headline.text}</span>
+                                        {headline.category && (
+                                            <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                                                CATEGORY_COLORS[headline.category] || 'bg-gray-100 text-gray-600'
+                                            }`}>
+                                                {headline.category.replace('_', ' ')}
+                                            </span>
+                                        )}
+                                        {headline.source === 'manual' && (
+                                            <span className="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500">manual</span>
+                                        )}
+                                    </div>
+                                ))}
+                            </>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/pages/ImageAds.jsx
+++ b/frontend/src/pages/ImageAds.jsx
@@ -21,7 +21,8 @@ export default function ImageAds() {
     const [generatedImages, setGeneratedImages] = useState([]);
     const [selectedCopy, setSelectedCopy] = useState(null);
     const [customImagePrompt, setCustomImagePrompt] = useState('');
-    const [templateMode, setTemplateMode] = useState('style'); // 'style' or 'template'
+    const [templateMode, setTemplateMode] = useState('style'); // 'style', 'template', or 'custom'
+    const [step4CustomPrompt, setStep4CustomPrompt] = useState('');
 
     // Load saved campaign details from localStorage on mount
     const [wizardData, setWizardData] = useState(() => {
@@ -99,7 +100,10 @@ export default function ImageAds() {
             case 1: return wizardData.brand !== null;
             case 2: return wizardData.product !== null;
             case 3: return wizardData.profile !== null;
-            case 4: return wizardData.template !== null;
+            case 4: {
+                if (wizardData.template?.type === 'custom') return !!step4CustomPrompt.trim();
+                return wizardData.template !== null;
+            }
             case 5: return wizardData.variationCount >= 1 && wizardData.variationCount <= 10;
             case 6: return wizardData.imageSizes && wizardData.imageSizes.length > 0;
             case 7: return wizardData.campaignDetails.offer && wizardData.campaignDetails.messaging;
@@ -174,7 +178,9 @@ export default function ImageAds() {
                     model: wizardData.model,
                     productShots: wizardData.useProductShots ? wizardData.product?.product_shots : [],
                     useProductImage: wizardData.useProductShots,
-                    customPrompt: customImagePrompt
+                    customPrompt: wizardData.template?.type === 'custom'
+                        ? wizardData.template.customPrompt
+                        : customImagePrompt
                 })
             });
 
@@ -379,6 +385,18 @@ export default function ImageAds() {
                                     Browse Templates
                                 </div>
                             </button>
+                            <button
+                                onClick={() => setTemplateMode('custom')}
+                                className={`px-6 py-2 rounded-md font-medium transition-all ${templateMode === 'custom'
+                                    ? 'bg-white text-amber-600 shadow-sm'
+                                    : 'text-gray-600 hover:text-gray-900'
+                                    }`}
+                            >
+                                <div className="flex items-center gap-2">
+                                    <FileText size={18} />
+                                    Custom Prompt
+                                </div>
+                            </button>
                         </div>
 
                         {/* Conditional Rendering */}
@@ -392,7 +410,7 @@ export default function ImageAds() {
                                     nextStep();
                                 }}
                             />
-                        ) : (
+                        ) : templateMode === 'template' ? (
                             <ImageTemplateSelector
                                 onSelect={(template) => {
                                     updateData('template', {
@@ -404,6 +422,69 @@ export default function ImageAds() {
                                 onClose={() => { }}
                                 embedded={true}
                             />
+                        ) : (
+                            <div className="max-w-2xl">
+                                <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-6">
+                                    <p className="text-sm text-amber-800">
+                                        <strong>Custom Prompt Mode:</strong> Write your own image generation prompt directly.
+                                        Brand, product, and campaign details will still inform copy generation.
+                                    </p>
+                                </div>
+
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-2">
+                                        Image Generation Prompt *
+                                    </label>
+                                    <textarea
+                                        value={step4CustomPrompt}
+                                        onChange={(e) => {
+                                            setStep4CustomPrompt(e.target.value);
+                                            updateData('template', {
+                                                type: 'custom',
+                                                name: 'Custom Prompt',
+                                                customPrompt: e.target.value,
+                                            });
+                                        }}
+                                        placeholder="Describe the image you want to generate. E.g.: 'A luxurious skincare product on a marble surface with soft golden lighting, surrounded by fresh botanicals, premium advertising photography, 4k quality'"
+                                        rows={6}
+                                        className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent font-mono text-sm"
+                                    />
+                                    <div className="flex justify-between mt-2">
+                                        <p className="text-xs text-gray-500">
+                                            Be descriptive about lighting, composition, mood, and style.
+                                        </p>
+                                        <span className="text-xs text-gray-400">
+                                            {step4CustomPrompt.length} chars
+                                        </span>
+                                    </div>
+                                </div>
+
+                                <div className="mt-6">
+                                    <p className="text-sm font-medium text-gray-700 mb-3">Example Prompts:</p>
+                                    <div className="space-y-2">
+                                        {[
+                                            'Professional flat lay product photography on marble surface, soft diffused lighting, minimalist style, luxury aesthetic, 4k',
+                                            'Split-screen before and after transformation, clean white background, bright natural lighting, testimonial style ad',
+                                            'Close-up macro shot of product texture with dramatic side lighting, dark moody background, premium feel',
+                                        ].map((example, i) => (
+                                            <button
+                                                key={i}
+                                                onClick={() => {
+                                                    setStep4CustomPrompt(example);
+                                                    updateData('template', {
+                                                        type: 'custom',
+                                                        name: 'Custom Prompt',
+                                                        customPrompt: example,
+                                                    });
+                                                }}
+                                                className="block w-full text-left px-3 py-2 text-sm text-gray-600 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors"
+                                            >
+                                                {example}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </div>
+                            </div>
                         )}
                     </div>
                 )}
@@ -1011,6 +1092,11 @@ function CopySelectionStep({ generatedCopy, wizardData, onBack, onRegenerate, is
 
     // Build comprehensive prompt (matching backend logic)
     const buildComprehensivePrompt = () => {
+        // If custom prompt mode, use the custom prompt directly
+        if (wizardData.template?.type === 'custom' && wizardData.template.customPrompt) {
+            return wizardData.template.customPrompt;
+        }
+
         const currentCopy = editedCopy || generatedCopy.variations[selectedIndex];
 
         // Extract all context

--- a/frontend/src/pages/PromptsAndDocs.jsx
+++ b/frontend/src/pages/PromptsAndDocs.jsx
@@ -1,0 +1,392 @@
+import React, { useState, useEffect } from 'react';
+import { Plus, Copy, Trash2, Edit3, X, Check, Search, FileText, Loader, ChevronDown, ChevronUp } from 'lucide-react';
+import { useAuth } from '../context/AuthContext';
+import { useToast } from '../context/ToastContext';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000/api/v1';
+
+const CATEGORIES = [
+    'Higgsfield',
+    'Image Generation',
+    'Video Analysis',
+    'Ad Copy',
+    'Research',
+    'Other',
+];
+
+const CATEGORY_COLORS = {
+    'Higgsfield': 'bg-purple-100 text-purple-700 border-purple-200',
+    'Image Generation': 'bg-blue-100 text-blue-700 border-blue-200',
+    'Video Analysis': 'bg-green-100 text-green-700 border-green-200',
+    'Ad Copy': 'bg-amber-100 text-amber-700 border-amber-200',
+    'Research': 'bg-indigo-100 text-indigo-700 border-indigo-200',
+    'Other': 'bg-gray-100 text-gray-700 border-gray-200',
+};
+
+function generateId() {
+    return `prompt_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+}
+
+export default function PromptsAndDocs() {
+    const { authFetch } = useAuth();
+    const { showSuccess, showError } = useToast();
+
+    const [prompts, setPrompts] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [searchQuery, setSearchQuery] = useState('');
+    const [filterCategory, setFilterCategory] = useState('');
+    const [showForm, setShowForm] = useState(false);
+    const [editingId, setEditingId] = useState(null);
+    const [expandedId, setExpandedId] = useState(null);
+    const [formData, setFormData] = useState({
+        name: '',
+        category: 'Other',
+        description: '',
+        template: '',
+        notes: '',
+    });
+
+    useEffect(() => {
+        fetchPrompts();
+    }, []);
+
+    const fetchPrompts = async () => {
+        setLoading(true);
+        try {
+            const res = await authFetch(`${API_URL}/prompts/`);
+            if (!res.ok) throw new Error('Failed to fetch prompts');
+            const data = await res.json();
+            setPrompts(data);
+        } catch (err) {
+            showError(err.message);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleSave = async () => {
+        if (!formData.name.trim() || !formData.template.trim()) {
+            showError('Name and prompt text are required');
+            return;
+        }
+
+        try {
+            if (editingId) {
+                // Update
+                const res = await authFetch(`${API_URL}/prompts/${editingId}`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        name: formData.name,
+                        category: formData.category,
+                        description: formData.description,
+                        template: formData.template,
+                        notes: formData.notes,
+                    }),
+                });
+                if (!res.ok) throw new Error('Failed to update');
+                const updated = await res.json();
+                setPrompts(prev => prev.map(p => p.id === editingId ? updated : p));
+                showSuccess('Prompt updated');
+            } else {
+                // Create
+                const res = await authFetch(`${API_URL}/prompts/`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        id: generateId(),
+                        name: formData.name,
+                        category: formData.category,
+                        description: formData.description || null,
+                        template: formData.template,
+                        notes: formData.notes || null,
+                        variables: [],
+                    }),
+                });
+                if (!res.ok) {
+                    const err = await res.json().catch(() => ({}));
+                    throw new Error(err.detail || 'Failed to create');
+                }
+                const created = await res.json();
+                setPrompts(prev => [created, ...prev]);
+                showSuccess('Prompt saved');
+            }
+            resetForm();
+        } catch (err) {
+            showError(err.message);
+        }
+    };
+
+    const handleDelete = async (id) => {
+        try {
+            const res = await authFetch(`${API_URL}/prompts/${id}`, { method: 'DELETE' });
+            if (!res.ok) throw new Error('Failed to delete');
+            setPrompts(prev => prev.filter(p => p.id !== id));
+            showSuccess('Prompt deleted');
+            if (expandedId === id) setExpandedId(null);
+        } catch (err) {
+            showError(err.message);
+        }
+    };
+
+    const handleEdit = (prompt) => {
+        setEditingId(prompt.id);
+        setFormData({
+            name: prompt.name,
+            category: prompt.category,
+            description: prompt.description || '',
+            template: prompt.template,
+            notes: prompt.notes || '',
+        });
+        setShowForm(true);
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+
+    const handleCopy = (text) => {
+        navigator.clipboard.writeText(text);
+        showSuccess('Copied to clipboard');
+    };
+
+    const resetForm = () => {
+        setShowForm(false);
+        setEditingId(null);
+        setFormData({ name: '', category: 'Other', description: '', template: '', notes: '' });
+    };
+
+    // Filter
+    const filtered = prompts.filter(p => {
+        if (filterCategory && p.category !== filterCategory) return false;
+        if (searchQuery) {
+            const q = searchQuery.toLowerCase();
+            return (
+                p.name.toLowerCase().includes(q) ||
+                p.template.toLowerCase().includes(q) ||
+                (p.description || '').toLowerCase().includes(q) ||
+                (p.notes || '').toLowerCase().includes(q)
+            );
+        }
+        return true;
+    });
+
+    return (
+        <div className="max-w-5xl mx-auto">
+            <div className="flex items-center justify-between mb-8">
+                <div>
+                    <h1 className="text-3xl font-bold text-gray-900">Prompts & Docs</h1>
+                    <p className="text-gray-500 mt-1">Save and recall prompts you use across tools</p>
+                </div>
+                <button
+                    onClick={() => { resetForm(); setShowForm(true); }}
+                    className="flex items-center gap-2 px-5 py-2.5 bg-amber-600 text-white rounded-lg font-medium hover:bg-amber-700"
+                >
+                    <Plus size={18} /> New Prompt
+                </button>
+            </div>
+
+            {/* Create / Edit Form */}
+            {showForm && (
+                <div className="bg-white rounded-xl border border-gray-200 p-6 mb-6 space-y-4">
+                    <div className="flex items-center justify-between">
+                        <h2 className="text-lg font-semibold text-gray-900">
+                            {editingId ? 'Edit Prompt' : 'New Prompt'}
+                        </h2>
+                        <button onClick={resetForm} className="text-gray-400 hover:text-gray-600">
+                            <X size={20} />
+                        </button>
+                    </div>
+
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 mb-1">Name *</label>
+                            <input
+                                type="text"
+                                value={formData.name}
+                                onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
+                                placeholder="e.g. Higgsfield Character Prompt"
+                                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 mb-1">Category</label>
+                            <select
+                                value={formData.category}
+                                onChange={(e) => setFormData(prev => ({ ...prev, category: e.target.value }))}
+                                className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                            >
+                                {CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
+                            </select>
+                        </div>
+                    </div>
+
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+                        <input
+                            type="text"
+                            value={formData.description}
+                            onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
+                            placeholder="Brief description of what this prompt does"
+                            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                        />
+                    </div>
+
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Prompt Text *</label>
+                        <textarea
+                            value={formData.template}
+                            onChange={(e) => setFormData(prev => ({ ...prev, template: e.target.value }))}
+                            placeholder="Paste your full prompt here..."
+                            rows="10"
+                            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent font-mono text-sm"
+                        />
+                        <p className="text-xs text-gray-400 mt-1">{formData.template.length} characters</p>
+                    </div>
+
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Notes</label>
+                        <textarea
+                            value={formData.notes}
+                            onChange={(e) => setFormData(prev => ({ ...prev, notes: e.target.value }))}
+                            placeholder="Any notes, tips, or context for this prompt..."
+                            rows="3"
+                            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                        />
+                    </div>
+
+                    <div className="flex justify-end gap-3 pt-2">
+                        <button onClick={resetForm} className="px-4 py-2 text-gray-600 hover:bg-gray-100 rounded-lg">
+                            Cancel
+                        </button>
+                        <button
+                            onClick={handleSave}
+                            disabled={!formData.name.trim() || !formData.template.trim()}
+                            className="flex items-center gap-2 px-6 py-2 bg-amber-600 text-white rounded-lg font-medium hover:bg-amber-700 disabled:opacity-50"
+                        >
+                            <Check size={16} /> {editingId ? 'Update' : 'Save'}
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            {/* Search & Filter */}
+            <div className="flex items-center gap-3 mb-4 flex-wrap">
+                <div className="relative flex-1 min-w-[200px]">
+                    <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+                    <input
+                        type="text"
+                        value={searchQuery}
+                        onChange={(e) => setSearchQuery(e.target.value)}
+                        placeholder="Search prompts..."
+                        className="w-full pl-9 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-amber-500 focus:border-transparent text-sm"
+                    />
+                </div>
+                <div className="flex rounded-lg border border-gray-200 overflow-hidden">
+                    <button
+                        onClick={() => setFilterCategory('')}
+                        className={`px-3 py-2 text-xs font-medium ${!filterCategory ? 'bg-amber-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+                    >
+                        All
+                    </button>
+                    {CATEGORIES.map(cat => (
+                        <button
+                            key={cat}
+                            onClick={() => setFilterCategory(filterCategory === cat ? '' : cat)}
+                            className={`px-3 py-2 text-xs font-medium ${filterCategory === cat ? 'bg-amber-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+                        >
+                            {cat}
+                        </button>
+                    ))}
+                </div>
+            </div>
+
+            {/* Prompts List */}
+            {loading ? (
+                <div className="flex items-center justify-center py-16">
+                    <Loader size={28} className="animate-spin text-amber-600" />
+                </div>
+            ) : filtered.length === 0 ? (
+                <div className="bg-white rounded-xl border border-gray-200 p-12 text-center">
+                    <FileText size={40} className="mx-auto text-gray-300 mb-3" />
+                    <p className="text-gray-500">
+                        {prompts.length === 0 ? 'No prompts saved yet. Click "New Prompt" to get started.' : 'No prompts match your search.'}
+                    </p>
+                </div>
+            ) : (
+                <div className="space-y-3">
+                    {filtered.map(prompt => {
+                        const isExpanded = expandedId === prompt.id;
+                        return (
+                            <div key={prompt.id} className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+                                {/* Header row */}
+                                <div
+                                    className="px-5 py-4 flex items-center gap-3 cursor-pointer hover:bg-gray-50 transition-colors"
+                                    onClick={() => setExpandedId(isExpanded ? null : prompt.id)}
+                                >
+                                    <div className="flex-1 min-w-0">
+                                        <div className="flex items-center gap-2 flex-wrap">
+                                            <h3 className="font-semibold text-gray-900">{prompt.name}</h3>
+                                            <span className={`text-xs px-2 py-0.5 rounded-full border ${CATEGORY_COLORS[prompt.category] || CATEGORY_COLORS['Other']}`}>
+                                                {prompt.category}
+                                            </span>
+                                        </div>
+                                        {prompt.description && (
+                                            <p className="text-sm text-gray-500 mt-0.5 truncate">{prompt.description}</p>
+                                        )}
+                                    </div>
+                                    <div className="flex items-center gap-1 flex-shrink-0">
+                                        <button
+                                            onClick={(e) => { e.stopPropagation(); handleCopy(prompt.template); }}
+                                            className="p-2 text-gray-400 hover:text-amber-600 hover:bg-amber-50 rounded-lg transition-colors"
+                                            title="Copy prompt"
+                                        >
+                                            <Copy size={16} />
+                                        </button>
+                                        <button
+                                            onClick={(e) => { e.stopPropagation(); handleEdit(prompt); }}
+                                            className="p-2 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+                                            title="Edit"
+                                        >
+                                            <Edit3 size={16} />
+                                        </button>
+                                        <button
+                                            onClick={(e) => { e.stopPropagation(); handleDelete(prompt.id); }}
+                                            className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                                            title="Delete"
+                                        >
+                                            <Trash2 size={16} />
+                                        </button>
+                                        {isExpanded ? <ChevronUp size={16} className="text-gray-400" /> : <ChevronDown size={16} className="text-gray-400" />}
+                                    </div>
+                                </div>
+
+                                {/* Expanded content */}
+                                {isExpanded && (
+                                    <div className="px-5 pb-5 border-t border-gray-100">
+                                        <div className="mt-4 bg-gray-50 rounded-lg p-4 relative">
+                                            <button
+                                                onClick={() => handleCopy(prompt.template)}
+                                                className="absolute top-2 right-2 p-1.5 text-gray-400 hover:text-amber-600 hover:bg-white rounded transition-colors"
+                                                title="Copy"
+                                            >
+                                                <Copy size={14} />
+                                            </button>
+                                            <pre className="text-sm text-gray-800 whitespace-pre-wrap font-mono pr-8 max-h-96 overflow-y-auto">
+                                                {prompt.template}
+                                            </pre>
+                                        </div>
+                                        <p className="text-xs text-gray-400 mt-2">{prompt.template.length} characters</p>
+                                        {prompt.notes && (
+                                            <div className="mt-3 text-sm text-gray-600 bg-amber-50 rounded-lg p-3 border border-amber-100">
+                                                <span className="font-medium text-amber-700">Notes: </span>
+                                                {prompt.notes}
+                                            </div>
+                                        )}
+                                    </div>
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/pages/Reporting.jsx
+++ b/frontend/src/pages/Reporting.jsx
@@ -1,119 +1,478 @@
-import React from 'react';
-import { ArrowUpRight, ArrowDownRight, MousePointer, Eye, BarChart2, BarChart, Download } from 'lucide-react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import {
+    BarChart3,
+    Eye,
+    MousePointer,
+    TrendingUp,
+    DollarSign,
+    CreditCard,
+    Percent,
+    Target,
+    Loader2,
+    AlertTriangle,
+    ArrowUpDown,
+    ArrowUp,
+    ArrowDown,
+    Calendar,
+    Filter,
+} from 'lucide-react';
+import { getClickflareStatus, getClickflareReports } from '../api/clickflare';
+import { useToast } from '../context/ToastContext';
 
-const StatCard = ({ title, value, change, trend, icon: Icon }) => (
-    <div className="bg-white p-6 rounded-xl shadow-sm border border-gray-200">
-        <div className="flex items-center justify-between mb-4">
-            <div className="p-2 bg-gray-50 rounded-lg text-gray-600">
-                <Icon size={20} />
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const formatDate = (date) => {
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, '0');
+    const d = String(date.getDate()).padStart(2, '0');
+    return `${y}-${m}-${d}`;
+};
+
+const getDateRange = (preset) => {
+    const to = new Date();
+    const from = new Date();
+    switch (preset) {
+        case '7d':
+            from.setDate(to.getDate() - 7);
+            break;
+        case '30d':
+            from.setDate(to.getDate() - 30);
+            break;
+        case '90d':
+            from.setDate(to.getDate() - 90);
+            break;
+        default:
+            from.setDate(to.getDate() - 7);
+    }
+    return { from: formatDate(from), to: formatDate(to) };
+};
+
+const fmtNum = (n) => {
+    if (n == null || isNaN(n)) return '0';
+    if (Math.abs(n) >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+    if (Math.abs(n) >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+    return Number(n).toLocaleString(undefined, { maximumFractionDigits: 2 });
+};
+
+const fmtCurrency = (n) => {
+    if (n == null || isNaN(n)) return '$0.00';
+    return '$' + Number(n).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+};
+
+const fmtPercent = (n) => {
+    if (n == null || isNaN(n)) return '0.00%';
+    return Number(n).toFixed(2) + '%';
+};
+
+const safeDiv = (a, b) => (b && b !== 0 ? a / b : 0);
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+const StatCard = ({ title, value, icon: Icon, iconBg, iconColor }) => (
+    <div className="bg-white p-5 rounded-xl border border-gray-200 shadow-sm">
+        <div className="flex items-center gap-4">
+            <div className={`p-3 rounded-lg ${iconBg}`}>
+                <Icon size={22} className={iconColor} />
             </div>
-            <span className={`flex items-center text-sm font-medium ${trend === 'up' ? 'text-green-600' : 'text-red-600'}`}>
-                {change}
-                {trend === 'up' ? <ArrowUpRight size={16} className="ml-1" /> : <ArrowDownRight size={16} className="ml-1" />}
-            </span>
+            <div className="min-w-0">
+                <p className="text-sm text-gray-500 font-medium truncate">{title}</p>
+                <p className="text-xl font-bold text-gray-900 mt-0.5">{value}</p>
+            </div>
         </div>
-        <h3 className="text-gray-500 text-sm font-medium">{title}</h3>
-        <p className="text-2xl font-bold text-gray-900 mt-1">{value}</p>
     </div>
 );
 
+const SortIcon = ({ column, sortConfig }) => {
+    if (sortConfig.key !== column) return <ArrowUpDown size={14} className="text-gray-300" />;
+    return sortConfig.direction === 'asc'
+        ? <ArrowUp size={14} className="text-amber-600" />
+        : <ArrowDown size={14} className="text-amber-600" />;
+};
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
 const Reporting = () => {
-    const stats = [
-        { label: "Total Impressions", value: "124.5K", change: "+12.3%", trend: "up", icon: Eye, color: "text-amber-600" },
-        { label: "Total Clicks", value: "3,842", change: "+5.4%", trend: "up", icon: MousePointer, color: "text-green-600" },
-        { label: "Avg. CTR", value: "3.1%", change: "-0.2%", trend: "down", icon: BarChart2, color: "text-red-600" },
-        { label: "Conversion Rate", value: "1.8%", change: "+0.1%", trend: "up", icon: BarChart, color: "text-purple-600" },
+    const { showError } = useToast();
+
+    // Clickflare status
+    const [configured, setConfigured] = useState(null); // null = loading
+    const [statusLoading, setStatusLoading] = useState(true);
+
+    // Data
+    const [reportData, setReportData] = useState(null);
+    const [dataLoading, setDataLoading] = useState(false);
+
+    // Filters
+    const [datePreset, setDatePreset] = useState('7d');
+    const [customFrom, setCustomFrom] = useState('');
+    const [customTo, setCustomTo] = useState('');
+    const [groupBy, setGroupBy] = useState('campaign');
+
+    // Sort
+    const [sortConfig, setSortConfig] = useState({ key: null, direction: 'desc' });
+
+    // ---- Check Clickflare status on mount ----
+    useEffect(() => {
+        (async () => {
+            try {
+                const status = await getClickflareStatus();
+                setConfigured(!!status?.configured);
+            } catch {
+                setConfigured(false);
+            } finally {
+                setStatusLoading(false);
+            }
+        })();
+    }, []);
+
+    // ---- Fetch report data when filters change ----
+    const fetchReport = useCallback(async () => {
+        if (!configured) return;
+
+        let dateFrom, dateTo;
+        if (datePreset === 'custom') {
+            if (!customFrom || !customTo) return;
+            dateFrom = customFrom;
+            dateTo = customTo;
+        } else {
+            const range = getDateRange(datePreset);
+            dateFrom = range.from;
+            dateTo = range.to;
+        }
+
+        setDataLoading(true);
+        try {
+            const response = await getClickflareReports(dateFrom, dateTo, groupBy);
+            // Resilient data extraction
+            const rows = response?.data || response?.rows || (Array.isArray(response) ? response : []);
+            setReportData(Array.isArray(rows) ? rows : []);
+        } catch (err) {
+            console.error('Failed to fetch Clickflare reports:', err);
+            showError('Failed to load reporting data. Please try again.');
+            setReportData([]);
+        } finally {
+            setDataLoading(false);
+        }
+    }, [configured, datePreset, customFrom, customTo, groupBy, showError]);
+
+    useEffect(() => {
+        if (configured) {
+            fetchReport();
+        }
+    }, [configured, fetchReport]);
+
+    // ---- Compute summary stats from rows ----
+    const summary = useMemo(() => {
+        if (!reportData || reportData.length === 0) {
+            return { visits: 0, clicks: 0, conversions: 0, revenue: 0, cost: 0, roi: 0, cpc: 0, cpa: 0 };
+        }
+        const totals = reportData.reduce(
+            (acc, row) => {
+                acc.visits += Number(row.visits || row.impressions || 0);
+                acc.clicks += Number(row.clicks || 0);
+                acc.conversions += Number(row.conversions || row.cv || 0);
+                acc.revenue += Number(row.revenue || row.payout || 0);
+                acc.cost += Number(row.cost || row.spend || 0);
+                return acc;
+            },
+            { visits: 0, clicks: 0, conversions: 0, revenue: 0, cost: 0 },
+        );
+
+        totals.roi = safeDiv((totals.revenue - totals.cost), totals.cost) * 100;
+        totals.cpc = safeDiv(totals.cost, totals.clicks);
+        totals.cpa = safeDiv(totals.cost, totals.conversions);
+        return totals;
+    }, [reportData]);
+
+    // ---- Sorting ----
+    const handleSort = (key) => {
+        setSortConfig((prev) => ({
+            key,
+            direction: prev.key === key && prev.direction === 'desc' ? 'asc' : 'desc',
+        }));
+    };
+
+    const sortedRows = useMemo(() => {
+        if (!reportData || reportData.length === 0) return [];
+        if (!sortConfig.key) return reportData;
+
+        return [...reportData].sort((a, b) => {
+            let aVal = a[sortConfig.key] ?? '';
+            let bVal = b[sortConfig.key] ?? '';
+            // Try numeric comparison
+            const aNum = Number(aVal);
+            const bNum = Number(bVal);
+            if (!isNaN(aNum) && !isNaN(bNum)) {
+                return sortConfig.direction === 'asc' ? aNum - bNum : bNum - aNum;
+            }
+            // String comparison
+            aVal = String(aVal).toLowerCase();
+            bVal = String(bVal).toLowerCase();
+            if (aVal < bVal) return sortConfig.direction === 'asc' ? -1 : 1;
+            if (aVal > bVal) return sortConfig.direction === 'asc' ? 1 : -1;
+            return 0;
+        });
+    }, [reportData, sortConfig]);
+
+    // ---- Determine table columns based on groupBy ----
+    const groupColumn = useMemo(() => {
+        switch (groupBy) {
+            case 'campaign': return { key: 'campaign_name', label: 'Campaign' };
+            case 'day': return { key: 'date', label: 'Date' };
+            case 'country': return { key: 'country', label: 'Country' };
+            case 'device': return { key: 'device', label: 'Device' };
+            default: return { key: 'campaign_name', label: 'Campaign' };
+        }
+    }, [groupBy]);
+
+    const metricColumns = [
+        { key: 'visits', label: 'Visits', fmt: fmtNum },
+        { key: 'clicks', label: 'Clicks', fmt: fmtNum },
+        { key: 'conversions', label: 'Conv.', fmt: fmtNum },
+        { key: 'revenue', label: 'Revenue', fmt: fmtCurrency },
+        { key: 'cost', label: 'Cost', fmt: fmtCurrency },
+        { key: 'roi', label: 'ROI', fmt: fmtPercent },
+        { key: 'cpc', label: 'CPC', fmt: fmtCurrency },
+    ];
+
+    // Enrich each row with computed fields
+    const enrichedRows = useMemo(() => {
+        return sortedRows.map((row) => {
+            const visits = Number(row.visits || row.impressions || 0);
+            const clicks = Number(row.clicks || 0);
+            const conversions = Number(row.conversions || row.cv || 0);
+            const revenue = Number(row.revenue || row.payout || 0);
+            const cost = Number(row.cost || row.spend || 0);
+            const roi = safeDiv((revenue - cost), cost) * 100;
+            const cpc = safeDiv(cost, clicks);
+            return {
+                ...row,
+                visits,
+                clicks,
+                conversions,
+                revenue,
+                cost,
+                roi,
+                cpc,
+                // Fallback group key: try common field names
+                [groupColumn.key]: row[groupColumn.key]
+                    || row.name
+                    || row.campaign
+                    || row.label
+                    || row.group
+                    || '-',
+            };
+        });
+    }, [sortedRows, groupColumn.key]);
+
+    // ---- Loading / status check ----
+    if (statusLoading) {
+        return (
+            <div className="max-w-7xl mx-auto flex items-center justify-center py-32">
+                <Loader2 size={32} className="animate-spin text-amber-600" />
+            </div>
+        );
+    }
+
+    // ---- Not configured ----
+    if (!configured) {
+        return (
+            <div className="max-w-7xl mx-auto space-y-8">
+                {/* Header */}
+                <div>
+                    <h1 className="text-3xl font-bold text-gray-900 flex items-center gap-3">
+                        <BarChart3 size={32} className="text-amber-600" />
+                        Reporting
+                    </h1>
+                    <p className="text-gray-600 mt-2">Track performance across all your campaigns</p>
+                </div>
+
+                {/* Setup prompt */}
+                <div className="bg-amber-50 border border-amber-200 rounded-xl p-8 text-center">
+                    <AlertTriangle size={48} className="mx-auto text-amber-500 mb-4" />
+                    <h2 className="text-xl font-bold text-gray-900 mb-2">Clickflare Not Configured</h2>
+                    <p className="text-gray-600 mb-6 max-w-md mx-auto">
+                        Connect your Clickflare account to start tracking real campaign performance data, conversions, and ROI.
+                    </p>
+                    <Link
+                        to="/settings"
+                        className="inline-flex items-center gap-2 bg-amber-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-amber-700 transition-colors"
+                    >
+                        Go to Settings
+                    </Link>
+                </div>
+            </div>
+        );
+    }
+
+    // ---- Configured: full reporting UI ----
+    const statCards = [
+        { title: 'Visits', value: fmtNum(summary.visits), icon: Eye, iconBg: 'bg-amber-50', iconColor: 'text-amber-600' },
+        { title: 'Clicks', value: fmtNum(summary.clicks), icon: MousePointer, iconBg: 'bg-purple-50', iconColor: 'text-purple-600' },
+        { title: 'Conversions', value: fmtNum(summary.conversions), icon: TrendingUp, iconBg: 'bg-green-50', iconColor: 'text-green-600' },
+        { title: 'Revenue', value: fmtCurrency(summary.revenue), icon: DollarSign, iconBg: 'bg-blue-50', iconColor: 'text-blue-600' },
+        { title: 'Cost', value: fmtCurrency(summary.cost), icon: CreditCard, iconBg: 'bg-amber-50', iconColor: 'text-amber-600' },
+        { title: 'ROI', value: fmtPercent(summary.roi), icon: Percent, iconBg: 'bg-purple-50', iconColor: 'text-purple-600' },
+        { title: 'CPC', value: fmtCurrency(summary.cpc), icon: MousePointer, iconBg: 'bg-green-50', iconColor: 'text-green-600' },
+        { title: 'CPA', value: fmtCurrency(summary.cpa), icon: Target, iconBg: 'bg-blue-50', iconColor: 'text-blue-600' },
     ];
 
     return (
-        <div className="max-w-6xl mx-auto space-y-8">
+        <div className="max-w-7xl mx-auto space-y-8">
             {/* Header */}
-            <div className="flex justify-between items-center">
-                <div>
-                    <h1 className="text-3xl font-bold text-gray-900 mb-2 flex items-center gap-3">
-                        <BarChart size={32} className="text-amber-600" />
-                        Campaign Reporting
-                    </h1>
-                    <p className="text-gray-600">Track performance across all your campaigns</p>
-                </div>
-                <div className="flex gap-2">
-                    <select className="border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-amber-500 focus:border-transparent">
-                        <option>Last 7 Days</option>
-                        <option>Last 30 Days</option>
-                        <option>This Month</option>
-                        <option>Last Month</option>
+            <div>
+                <h1 className="text-3xl font-bold text-gray-900 flex items-center gap-3">
+                    <BarChart3 size={32} className="text-amber-600" />
+                    Reporting
+                </h1>
+                <p className="text-gray-600 mt-2">Track performance across all your campaigns</p>
+            </div>
+
+            {/* Filters bar */}
+            <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4 flex flex-wrap items-end gap-4">
+                {/* Date range */}
+                <div className="flex flex-col gap-1">
+                    <label className="text-xs font-medium text-gray-500 flex items-center gap-1">
+                        <Calendar size={12} /> Date Range
+                    </label>
+                    <select
+                        value={datePreset}
+                        onChange={(e) => setDatePreset(e.target.value)}
+                        className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                    >
+                        <option value="7d">Last 7 Days</option>
+                        <option value="30d">Last 30 Days</option>
+                        <option value="90d">Last 90 Days</option>
+                        <option value="custom">Custom</option>
                     </select>
-                    <button className="p-2 text-gray-400 hover:text-amber-600 hover:bg-amber-50 rounded-lg transition-colors">
-                        <Download size={20} />
-                    </button>
+                </div>
+
+                {datePreset === 'custom' && (
+                    <>
+                        <div className="flex flex-col gap-1">
+                            <label className="text-xs font-medium text-gray-500">From</label>
+                            <input
+                                type="date"
+                                value={customFrom}
+                                onChange={(e) => setCustomFrom(e.target.value)}
+                                className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                            />
+                        </div>
+                        <div className="flex flex-col gap-1">
+                            <label className="text-xs font-medium text-gray-500">To</label>
+                            <input
+                                type="date"
+                                value={customTo}
+                                onChange={(e) => setCustomTo(e.target.value)}
+                                className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                            />
+                        </div>
+                    </>
+                )}
+
+                {/* Group by */}
+                <div className="flex flex-col gap-1">
+                    <label className="text-xs font-medium text-gray-500 flex items-center gap-1">
+                        <Filter size={12} /> Group By
+                    </label>
+                    <select
+                        value={groupBy}
+                        onChange={(e) => setGroupBy(e.target.value)}
+                        className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-amber-500 focus:border-transparent"
+                    >
+                        <option value="campaign">Campaign</option>
+                        <option value="day">Day</option>
+                        <option value="country">Country</option>
+                        <option value="device">Device</option>
+                    </select>
                 </div>
             </div>
 
-            {/* Stats Grid */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-                {stats.map((stat, index) => (
-                    <div key={index} className="bg-white p-6 rounded-xl border border-gray-200 shadow-sm">
-                        <div className="flex justify-between items-start mb-4">
-                            <div className={`p-3 rounded-lg ${stat.color.replace('text-', 'bg-').replace('600', '50')}`}>
-                                <stat.icon className={stat.color} size={24} />
-                            </div>
-                            <span className={`flex items-center text-sm font-medium ${stat.trend === 'up' ? 'text-green-600' : 'text-red-600'
-                                }`}>
-                                {stat.trend === 'up' ? <ArrowUpRight size={16} /> : <ArrowDownRight size={16} />}
-                                {stat.change}
-                            </span>
-                        </div>
-                        <h3 className="text-gray-500 text-sm font-medium">{stat.label}</h3>
-                        <p className="text-2xl font-bold text-gray-900 mt-1">{stat.value}</p>
-                    </div>
-                ))}
-            </div>
-
-            {/* Charts Section */}
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-                <div className="bg-white p-6 rounded-xl border border-gray-200 shadow-sm">
-                    <h3 className="text-lg font-bold text-gray-900 mb-6">Performance Over Time</h3>
-                    <div className="h-64 flex items-end justify-between gap-2">
-                        {[...Array(12)].map((_, i) => (
-                            <div key={i} className="w-full bg-amber-100 rounded-t-sm relative group">
-                                <div
-                                    className="absolute bottom-0 left-0 w-full bg-amber-500 rounded-t-sm transition-all duration-500 group-hover:bg-amber-600"
-                                    style={{ height: `${Math.random() * 100}%` }}
-                                ></div>
-                            </div>
+            {/* Loading overlay for data */}
+            {dataLoading ? (
+                <div className="flex items-center justify-center py-20">
+                    <Loader2 size={32} className="animate-spin text-amber-600" />
+                    <span className="ml-3 text-gray-500 font-medium">Loading report data...</span>
+                </div>
+            ) : (
+                <>
+                    {/* Summary stat cards */}
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                        {statCards.map((card) => (
+                            <StatCard key={card.title} {...card} />
                         ))}
                     </div>
-                </div>
 
-                <div className="bg-white p-6 rounded-xl border border-gray-200 shadow-sm">
-                    <h3 className="text-lg font-bold text-gray-900 mb-6">Platform Distribution</h3>
-                    <div className="flex items-center justify-center h-64">
-                        <div className="relative w-48 h-48">
-                            <svg viewBox="0 0 36 36" className="w-full h-full transform -rotate-90">
-                                <path
-                                    className="text-gray-100"
-                                    d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    strokeWidth="3.8"
-                                />
-                                <path
-                                    className="text-amber-500"
-                                    strokeDasharray="75, 100"
-                                    d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    strokeWidth="3.8"
-                                />
-                            </svg>
-                            <div className="absolute inset-0 flex items-center justify-center flex-col">
-                                <span className="text-3xl font-bold text-gray-900">75%</span>
-                                <span className="text-xs text-gray-500 uppercase font-medium">Facebook</span>
-                            </div>
+                    {/* Performance data table */}
+                    <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+                        <div className="px-6 py-4 border-b border-gray-100">
+                            <h2 className="text-lg font-bold text-gray-900">Performance Data</h2>
                         </div>
+
+                        {!reportData || reportData.length === 0 ? (
+                            <div className="px-6 py-16 text-center">
+                                <BarChart3 size={40} className="mx-auto text-gray-300 mb-3" />
+                                <p className="text-gray-500 font-medium">No data available for the selected period.</p>
+                                <p className="text-gray-400 text-sm mt-1">Try adjusting your date range or filters.</p>
+                            </div>
+                        ) : (
+                            <div className="overflow-x-auto">
+                                <table className="w-full text-sm">
+                                    <thead>
+                                        <tr className="bg-gray-50 text-left">
+                                            <th
+                                                className="px-6 py-3 font-semibold text-gray-600 cursor-pointer hover:text-amber-600 transition-colors select-none"
+                                                onClick={() => handleSort(groupColumn.key)}
+                                            >
+                                                <span className="inline-flex items-center gap-1">
+                                                    {groupColumn.label}
+                                                    <SortIcon column={groupColumn.key} sortConfig={sortConfig} />
+                                                </span>
+                                            </th>
+                                            {metricColumns.map((col) => (
+                                                <th
+                                                    key={col.key}
+                                                    className="px-4 py-3 font-semibold text-gray-600 text-right cursor-pointer hover:text-amber-600 transition-colors select-none"
+                                                    onClick={() => handleSort(col.key)}
+                                                >
+                                                    <span className="inline-flex items-center gap-1 justify-end">
+                                                        {col.label}
+                                                        <SortIcon column={col.key} sortConfig={sortConfig} />
+                                                    </span>
+                                                </th>
+                                            ))}
+                                        </tr>
+                                    </thead>
+                                    <tbody className="divide-y divide-gray-100">
+                                        {enrichedRows.map((row, idx) => (
+                                            <tr
+                                                key={idx}
+                                                className={`hover:bg-amber-50/40 transition-colors ${idx % 2 === 0 ? 'bg-white' : 'bg-gray-50/50'}`}
+                                            >
+                                                <td className="px-6 py-3 font-medium text-gray-900 whitespace-nowrap max-w-xs truncate">
+                                                    {row[groupColumn.key]}
+                                                </td>
+                                                {metricColumns.map((col) => (
+                                                    <td key={col.key} className="px-4 py-3 text-right text-gray-700 whitespace-nowrap">
+                                                        {col.fmt(row[col.key])}
+                                                    </td>
+                                                ))}
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        )}
                     </div>
-                </div>
-            </div>
+                </>
+            )}
         </div>
     );
 };

--- a/frontend/src/pages/Research.jsx
+++ b/frontend/src/pages/Research.jsx
@@ -878,25 +878,36 @@ const Research = () => {
                                 ← Back to Searches
                             </button>
                             <h2 className="text-2xl font-bold text-gray-800">
-                                {selectedVertical.name} - All Ads
+                                {selectedSearch
+                                    ? `"${selectedSearch.query}" in ${selectedSearch.country || 'US'}`
+                                    : `${selectedVertical.name} - All Ads`}
                             </h2>
                             <p className="text-gray-600 mt-1">
-                                Grouped by page
+                                {selectedSearch
+                                    ? `${selectedSearch.ads?.length || 0} ads • Grouped by page`
+                                    : 'Grouped by page'}
                             </p>
                         </div>
                     </div>
 
                     {(() => {
-                        // Get all ads from all searches in this vertical
-                        const allAds = savedSearches
-                            .filter(s => s.vertical_id === selectedVertical.id)
-                            .flatMap(search =>
-                                (search.ads || []).map(ad => ({
-                                    ...ad,
-                                    searchQuery: search.query,
-                                    searchId: search.id
-                                }))
-                            );
+                        // If viewing a specific search, use only that search's ads
+                        // Otherwise, aggregate all searches in the vertical
+                        const allAds = selectedSearch
+                            ? (selectedSearch.ads || []).map(ad => ({
+                                ...ad,
+                                searchQuery: selectedSearch.query,
+                                searchId: selectedSearch.id
+                            }))
+                            : savedSearches
+                                .filter(s => s.vertical_id === selectedVertical.id)
+                                .flatMap(search =>
+                                    (search.ads || []).map(ad => ({
+                                        ...ad,
+                                        searchQuery: search.query,
+                                        searchId: search.id
+                                    }))
+                                );
 
                         // Filter out blacklisted pages
                         const blacklistedPageNames = blacklist.map(b => b.page_name.toLowerCase());

--- a/frontend/src/pages/Research.jsx
+++ b/frontend/src/pages/Research.jsx
@@ -12,6 +12,16 @@ const COUNTRIES = [
     { code: 'AU', name: 'Australia' },
 ];
 
+const LANGUAGES = [
+    { code: '', name: 'All Languages' },
+    { code: 'en', name: 'English' },
+    { code: 'es', name: 'Spanish' },
+    { code: 'de', name: 'German' },
+    { code: 'fr', name: 'French' },
+    { code: 'pt', name: 'Portuguese' },
+    { code: 'it', name: 'Italian' },
+];
+
 const LIMIT_OPTIONS = [
     { value: 100, label: '100 ads', apiCalls: 1 },
     { value: 300, label: '300 ads', apiCalls: 3 },
@@ -27,6 +37,7 @@ const Research = () => {
     const location = useLocation();
     const [query, setQuery] = useState('');
     const [country, setCountry] = useState('US');
+    const [language, setLanguage] = useState('');
     const [negativeKeywords, setNegativeKeywords] = useState('');
     const [limit, setLimit] = useState(300);
     const [savedSearches, setSavedSearches] = useState([]);
@@ -225,6 +236,7 @@ const Research = () => {
                 platform: 'facebook',
                 limit,
                 country,
+                language,
                 offset: 0,
                 exclude_ids: [],
                 negative_keywords: negativeList,
@@ -691,6 +703,17 @@ const Research = () => {
                                     {COUNTRIES.map((c) => (
                                         <option key={c.code} value={c.code}>
                                             {c.name}
+                                        </option>
+                                    ))}
+                                </select>
+                                <select
+                                    value={language}
+                                    onChange={(e) => setLanguage(e.target.value)}
+                                    className="p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 outline-none bg-white"
+                                >
+                                    {LANGUAGES.map((l) => (
+                                        <option key={l.code} value={l.code}>
+                                            {l.name}
                                         </option>
                                     ))}
                                 </select>

--- a/frontend/src/pages/Settings.jsx
+++ b/frontend/src/pages/Settings.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { Settings as SettingsIcon, Plus, Sparkles, Edit, Trash2, Save, X, FileText, Code, AlertTriangle } from 'lucide-react';
+import { Settings as SettingsIcon, Plus, Sparkles, Edit, Trash2, Save, X, FileText, Code, AlertTriangle, Link, Loader2, CheckCircle, Zap } from 'lucide-react';
+import { getClickflareConfig, saveClickflareConfig, testClickflareConnection, setupTrafficSource } from '../api/clickflare';
 import { useToast } from '../context/ToastContext';
 import { adStyles as initialStyles, AD_CATEGORIES } from '../data/adStyles';
 import { PROMPT_CATEGORIES } from '../data/prompts';
@@ -57,6 +58,7 @@ export default function Settings() {
     const tabs = [
         { id: 'styles', label: 'Ad Styles', count: styles.length },
         { id: 'prompts', label: 'Prompts', count: prompts.length },
+        { id: 'clickflare', label: 'Clickflare', count: null },
         { id: 'general', label: 'General', count: null }
     ];
 
@@ -167,6 +169,9 @@ export default function Settings() {
                             onCancel={() => setEditingPrompt(null)}
                             onUpdate={(updatedPrompt) => setEditingPrompt(updatedPrompt)}
                         />
+                    )}
+                    {activeTab === 'clickflare' && (
+                        <ClickflareSettings showSuccess={showSuccess} showError={showError} />
                     )}
                     {activeTab === 'general' && (
                         <GeneralSettings />
@@ -729,6 +734,210 @@ function EditPromptForm({ prompt, onChange, onSave, onCancel }) {
                     <Save size={18} />
                     Save Changes
                 </button>
+            </div>
+        </div>
+    );
+}
+
+function ClickflareSettings({ showSuccess, showError }) {
+    const [config, setConfig] = useState({ configured: false });
+    const [apiKey, setApiKey] = useState('');
+    const [trackingDomain, setTrackingDomain] = useState('clicks.thebestchoiceadviser.com');
+    const [pixelId, setPixelId] = useState('');
+    const [testing, setTesting] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        loadConfig();
+    }, []);
+
+    const loadConfig = async () => {
+        try {
+            const data = await getClickflareConfig();
+            setConfig(data);
+            if (data.tracking_domain) setTrackingDomain(data.tracking_domain);
+            if (data.facebook_pixel_id) setPixelId(data.facebook_pixel_id);
+        } catch {
+            // Not configured yet
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleSave = async () => {
+        if (!apiKey && !config.configured) {
+            showError('API Key is required');
+            return;
+        }
+        if (!trackingDomain) {
+            showError('Tracking domain is required');
+            return;
+        }
+        setSaving(true);
+        try {
+            await saveClickflareConfig({
+                api_key: apiKey || undefined,
+                tracking_domain: trackingDomain,
+                facebook_pixel_id: pixelId || null,
+            });
+            showSuccess('Clickflare settings saved');
+            setApiKey('');
+            await loadConfig();
+            try {
+                await setupTrafficSource();
+            } catch {}
+        } catch (err) {
+            showError(err?.response?.data?.detail || 'Failed to save settings');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const handleTestConnection = async () => {
+        setTesting(true);
+        try {
+            await testClickflareConnection();
+            showSuccess('Connected to Clickflare successfully!');
+        } catch (err) {
+            showError(`Connection failed: ${err?.response?.data?.detail || err.message}`);
+        } finally {
+            setTesting(false);
+        }
+    };
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center py-12">
+                <Loader2 size={24} className="animate-spin text-purple-600" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            {/* Connection Status */}
+            <div className={`flex items-center gap-3 p-4 rounded-lg border ${
+                config.configured
+                    ? 'bg-green-50 border-green-200'
+                    : 'bg-amber-50 border-amber-200'
+            }`}>
+                {config.configured ? (
+                    <>
+                        <CheckCircle size={20} className="text-green-600" />
+                        <span className="text-green-800 font-medium">Clickflare is configured</span>
+                        <span className="text-green-600 text-sm ml-auto">Key: {config.api_key_masked}</span>
+                    </>
+                ) : (
+                    <>
+                        <Zap size={20} className="text-amber-600" />
+                        <span className="text-amber-800 font-medium">Clickflare is not configured</span>
+                        <span className="text-amber-600 text-sm ml-auto">Enter your API key to get started</span>
+                    </>
+                )}
+            </div>
+
+            {/* Config Form */}
+            <div className="bg-gray-50 border border-gray-200 rounded-lg p-6 space-y-4">
+                <h3 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+                    <Link size={20} className="text-purple-600" />
+                    API Configuration
+                </h3>
+
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                        API Key (Access Key)
+                    </label>
+                    <input
+                        type="password"
+                        value={apiKey}
+                        onChange={(e) => setApiKey(e.target.value)}
+                        placeholder={config.configured ? 'Leave blank to keep current key' : 'Enter your Clickflare API key'}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-600 focus:border-transparent"
+                    />
+                    <p className="text-xs text-gray-500 mt-1">
+                        Find this in Clickflare: Settings &gt; Security &gt; API Access
+                    </p>
+                </div>
+
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                        Tracking Domain
+                    </label>
+                    <input
+                        type="text"
+                        value={trackingDomain}
+                        onChange={(e) => setTrackingDomain(e.target.value)}
+                        placeholder="e.g., clicks.yourdomain.com"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-600 focus:border-transparent"
+                    />
+                </div>
+
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                        Facebook Pixel ID (optional)
+                    </label>
+                    <input
+                        type="text"
+                        value={pixelId}
+                        onChange={(e) => setPixelId(e.target.value)}
+                        placeholder="e.g., 123456789012345"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-600 focus:border-transparent"
+                    />
+                    <p className="text-xs text-gray-500 mt-1">
+                        For cross-referencing with Facebook CAPI (configured in Clickflare dashboard)
+                    </p>
+                </div>
+
+                <div className="flex gap-3 pt-2">
+                    <button
+                        onClick={handleSave}
+                        disabled={saving}
+                        className="flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:opacity-50"
+                    >
+                        {saving ? <Loader2 size={16} className="animate-spin" /> : <Save size={16} />}
+                        {saving ? 'Saving...' : 'Save Settings'}
+                    </button>
+                    {config.configured && (
+                        <button
+                            onClick={handleTestConnection}
+                            disabled={testing}
+                            className="flex items-center gap-2 px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 disabled:opacity-50"
+                        >
+                            {testing ? <Loader2 size={16} className="animate-spin" /> : <Zap size={16} />}
+                            {testing ? 'Testing...' : 'Test Connection'}
+                        </button>
+                    )}
+                </div>
+            </div>
+
+            {/* How It Works */}
+            <div className="bg-purple-50 border border-purple-200 rounded-lg p-6">
+                <h3 className="text-lg font-semibold text-purple-900 mb-3">How Clickflare Integration Works</h3>
+                <ul className="text-purple-800 text-sm space-y-2">
+                    <li><strong>Tracking URLs:</strong> When you create Facebook ads, the destination URL is automatically wrapped with a Clickflare tracking link.</li>
+                    <li><strong>Performance Data:</strong> Clicks, conversions, and revenue data flow into the Reporting page.</li>
+                    <li><strong>Cost Sync:</strong> Clickflare auto-pulls Facebook ad spend every 30 minutes.</li>
+                    <li><strong>Graceful Fallback:</strong> If Clickflare is down or not configured, ads are created with the raw URL.</li>
+                </ul>
+            </div>
+
+            {/* CAPI Instructions */}
+            <div className="bg-blue-50 border border-blue-200 rounded-lg p-6">
+                <h3 className="text-lg font-semibold text-blue-900 mb-3">Facebook CAPI Integration</h3>
+                <p className="text-blue-800 text-sm mb-4">
+                    Clickflare handles Facebook Conversions API (CAPI) natively. To enable server-side conversion tracking:
+                </p>
+                <ol className="list-decimal list-inside text-blue-800 text-sm space-y-2">
+                    <li>Log into your Clickflare dashboard</li>
+                    <li>Go to <strong>Settings &gt; Integrations &gt; Conversion API &gt; Facebook</strong></li>
+                    <li>Enter your Facebook <strong>Pixel ID</strong> and <strong>Access Token</strong></li>
+                    <li>Map conversion events (Purchase, Lead, etc.)</li>
+                    <li>Clickflare will automatically send server-side events to Meta</li>
+                </ol>
+                <p className="text-blue-700 text-xs mt-4">
+                    This works regardless of iOS restrictions, ad blockers, or cookie blocking.
+                </p>
             </div>
         </div>
     );

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,6 +6,9 @@ import react from '@vitejs/plugin-react'
 // API calls should be made from a backend server, not the frontend
 export default defineConfig({
   plugins: [react()],
+  preview: {
+    allowedHosts: ['frontend-production-9f4d.up.railway.app'],
+  },
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
## Summary
- Adds "Analyze with AI" sparkles button on video thumbnails in the Ad Creative step
- Uploads video to Gemini 2.0 Flash which watches video + listens to audio, then auto-generates 3 primary text and 3 headline variations
- New `POST /api/v1/video-analysis/analyze` backend endpoint with temp file + Gemini File API cleanup

## Test plan
- [ ] Upload a video in Facebook Campaigns > Ad Creative step
- [ ] Hover over the video thumbnail, click the amber sparkles button
- [ ] Wait 30-60s for Gemini to process
- [ ] Primary text and headline fields should auto-fill with 3 variations each

🤖 Generated with [Claude Code](https://claude.com/claude-code)