### PR TITLE
fix: fix security issue in facebook.py

### DIFF
--- a/backend/app/api/v1/facebook.py
+++ b/backend/app/api/v1/facebook.py
@@ -20,7 +20,7 @@ def get_facebook_service():
 @router.get("/accounts")
 def get_ad_accounts(
     service: FacebookService = Depends(get_facebook_service),
-    current_user: User = Depends(get_current_active_user)
+    current_user: User = Depends(require_permission("campaigns:read"))
 ):
     try:
         return service.get_ad_accounts()
@@ -31,7 +31,7 @@ def get_ad_accounts(
 def read_campaigns(
     ad_account_id: Optional[str] = None,
     service: FacebookService = Depends(get_facebook_service),
-    current_user: User = Depends(get_current_active_user)
+    current_user: User = Depends(require_permission("campaigns:read"))
 ):
     try:
         campaigns = service.get_campaigns(ad_account_id)
@@ -59,7 +59,7 @@ def create_campaign(
 def read_pixels(
     ad_account_id: Optional[str] = None,
     service: FacebookService = Depends(get_facebook_service),
-    current_user: User = Depends(get_current_active_user)
+    current_user: User = Depends(require_permission("campaigns:read"))
 ):
     try:
         pixels = service.get_pixels(ad_account_id)
@@ -71,7 +71,7 @@ def read_pixels(
 @router.get("/pages")
 def read_pages(
     service: FacebookService = Depends(get_facebook_service),
-    current_user: User = Depends(get_current_active_user)
+    current_user: User = Depends(require_permission("campaigns:read"))
 ):
     try:
         pages = service.get_pages()


### PR DESCRIPTION
## Summary
Fix high severity security issue in `backend/app/api/v1/facebook.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-005 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-005` |
| **File** | `backend/app/api/v1/facebook.py:20` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 2-step |

**Description**: Facebook API endpoints only verify authentication, not authorization scope. Any authenticated user can access ALL Facebook advertising data across all connected business accounts, including campaigns, ad accounts, tracking pixels, and pages belonging to other users or organizations.

## Evidence

**Exploitation scenario**: Attacker authenticates with any valid credentials, then calls GET /api/v1/facebook/accounts to enumerate all ad accounts, followed by GET /api/v1/facebook/campaigns?ad_account_id={id} to exfiltrate.

**Scanner confirmation**: multi_agent_ai rule `V-005` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This API endpoint appears to be publicly accessible.

## Changes
- `backend/app/api/v1/facebook.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

## Security Invariant
> **Property**: Protected endpoints reject unauthenticated requests

<details>
<summary>Regression test</summary>

```python
import pytest
from fastapi.testclient import TestClient
from backend.app.main import app
from backend.app.api.v1.facebook import router


client = TestClient(app)


@pytest.mark.parametrize("auth_header,expected_status", [
    (None, 401),  # Missing token - must reject
    ("Bearer invalid_malformed_token", 401),  # Invalid token - must reject
    ("Bearer expired_token_placeholder", 401),  # Expired/invalid token - must reject
])
def test_facebook_endpoints_reject_unauthenticated_requests(auth_header, expected_status):
    """Invariant: All Facebook API endpoints must reject requests without valid authentication (401/403)"""
    headers = {"Authorization": auth_header} if auth_header else {}
    
    protected_endpoints = [
        "/api/v1/facebook/accounts",
        "/api/v1/facebook/campaigns",
        "/api/v1/facebook/pixels",
        "/api/v1/facebook/pages",
    ]
    
    for endpoint in protected_endpoints:
        response = client.get(endpoint, headers=headers)
        assert response.status_code in [401, 403], (
            f"Endpoint {endpoint} must reject unauthenticated requests, "
            f"got {response.status_code}"
        )
```

</details>

This test guards against regressions — it's useful independent of the code change above.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-005 scanner=multi_agent_ai -->
