### PR TITLE
feat: rename product and repository to Ad Studio

### DIFF
--- a/.railway/railway.ts
+++ b/.railway/railway.ts
@@ -6,7 +6,7 @@ export default defineRailway((ctx) => {
     if (ctx.projectName !== 'test-breadwinner-installer') {
         throw new Error('This scaffold only targets the isolated test-breadwinner-installer project.');
     }
-    const source = github('jasonakatiff/iscale-facebook-ad-builder', { branch: 'main' });
+    const source = github('jasonakatiff/theleadrouter-ad-studio', { branch: 'main' });
     const databaseVolume = volume('Database data', { sizeMB: 1024, region: 'us-west2' });
     const mediaVolume = volume('Creative media', { sizeMB: 1024, region: 'us-west2' });
     const database = service('Postgres', {

--- a/.railway/serialized-template.json
+++ b/.railway/serialized-template.json
@@ -49,7 +49,7 @@
     "f70dd9bc-b0bd-445f-8291-a0cb152d23ac": {
       "name": "Backend",
       "source": {
-        "repo": "jasonakatiff/iscale-facebook-ad-builder",
+        "repo": "jasonakatiff/theleadrouter-ad-studio",
         "branch": "main",
         "rootDirectory": "/"
       },
@@ -86,7 +86,7 @@
         "ADMIN_EMAIL": {
           "defaultValue": "",
           "isOptional": false,
-          "description": "Owner email: sign in to your new Ad Builder & Manager workspace.",
+          "description": "Owner email: sign in to your new Ad Studio workspace.",
           "preserveExisting": true
         },
         "ADMIN_PASSWORD": {
@@ -142,7 +142,7 @@
     "0926662b-61e0-4703-a465-59552bfddfb5": {
       "name": "Frontend",
       "source": {
-        "repo": "jasonakatiff/iscale-facebook-ad-builder",
+        "repo": "jasonakatiff/theleadrouter-ad-studio",
         "branch": "main",
         "rootDirectory": "/frontend"
       },
@@ -181,7 +181,7 @@
     "422b8f0c-4516-40aa-b732-4d5c15953808": {
       "name": "Worker",
       "source": {
-        "repo": "jasonakatiff/iscale-facebook-ad-builder",
+        "repo": "jasonakatiff/theleadrouter-ad-studio",
         "branch": "main",
         "rootDirectory": "/"
       },

--- a/.railway/template.json
+++ b/.railway/template.json
@@ -1,9 +1,9 @@
 {
-  "name": "theLeadRouter \u2014 Ad Builder & Manager",
+  "name": "theLeadRouter \u2014 Ad Studio",
   "description": "Deploy your application, sign in, and connect Gemini and fal.ai in the setup wizard. Create, save, and download your first image ad. Railway and AI services bill your own accounts.",
   "publicationStatus": "unlisted_preview_automated_install_verified",
   "templateUrl": "https://railway.com/deploy/rNhJ3h",
-  "sourceRepository": "jasonakatiff/iscale-facebook-ad-builder",
+  "sourceRepository": "jasonakatiff/theleadrouter-ad-studio",
   "sourceRevision": "e4c64143404b4389d39d2a66a4e24ee74bae92b2",
   "sourceGate": "Release from reviewed public main after CI and pull-request merge; private Git history is excluded.",
   "installFields": [
@@ -56,7 +56,7 @@
     "Postgres": "/var/lib/postgresql/data",
     "Backend": "/app/uploads"
   },
-  "support": "https://github.com/jasonakatiff/iscale-facebook-ad-builder/issues",
+  "support": "https://github.com/jasonakatiff/theleadrouter-ad-studio/issues",
   "customerGuide": "docs/deployment/install-on-railway.md",
   "generatedPublicDomains": {
     "Frontend": 8080,

--- a/.railway/verify.ts
+++ b/.railway/verify.ts
@@ -32,7 +32,8 @@ const templateServices = Object.values(template.services) as Array<{
 }>;
 assert.equal(templateServices.length, 4);
 assert.equal(spec.sourceBranch, 'main', 'Public installs must use the release branch');
-assert.equal(spec.name, 'theLeadRouter — Ad Builder & Manager');
+assert.equal(spec.sourceRepository, 'jasonakatiff/theleadrouter-ad-studio');
+assert.equal(spec.name, 'theLeadRouter — Ad Studio');
 const customerInputs: string[] = [];
 for (const service of templateServices) {
     if (service.source.repo) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Ad Studio naming — 2026-09-08
+
+Use **theLeadRouter — Ad Studio** for the public product and `theleadrouter-ad-studio` for its repository. Update the UI, API title, guides, downloads, package metadata, and Railway source references. Existing workspace branding overrides and integration identifiers remain compatible. See the [release and rename plan](docs/deployment/v2-railway-release.md). Verification: 85 frontend tests, production build, scoped lint, installer checks, public login smoke, and desktop/mobile branding passed. Hosted Railway naming is recorded separately from checked-in configuration.
+
 ## Railway installer preview — 2026-09-08
 
 An unlisted [Deploy on Railway preview](https://railway.com/deploy/rNhJ3h) creates the four connected services and persistent storage from two owner fields. Sign in to configure AI keys in the first-run wizard or Settings → Integrations.

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/rNhJ3h)
 
-Deploy your own **theLeadRouter — Ad Builder & Manager** workspace, enter your owner email/password, then connect AI keys in the setup wizard. Keys can be changed later in **Settings → Integrations**. No terminal or manual database wiring is needed.
+Deploy your own **theLeadRouter — Ad Studio** workspace, enter your owner email/password, then connect AI keys in the setup wizard. Keys can be changed later in **Settings → Integrations**. No terminal or manual database wiring is needed.
 
 The unlisted preview passed fresh cloud installation and persistence checks. Paid AI generation and nontechnical pilot acceptance remain open. Hosting and AI usage use your own accounts. See the [installation guide](docs/deployment/install-on-railway.md).
 
 <p align="center">
-  <img src="frontend/public/leadrouter-mark.svg" alt="theLeadRouter — Ad Builder &amp; Manager" width="120" />
+  <img src="frontend/public/leadrouter-mark.svg" alt="theLeadRouter — Ad Studio" width="120" />
 </p>
 
-<h1 align="center">theLeadRouter — Ad Builder &amp; Manager</h1>
+<h1 align="center">theLeadRouter — Ad Studio</h1>
 
 <p align="center">
   <strong>Version 2 · Release candidate</strong><br>
@@ -42,7 +42,7 @@ The unlisted preview passed fresh cloud installation and persistence checks. Pai
 
 ## Overview
 
-**theLeadRouter — Ad Builder & Manager** is the v2 ad workspace, formerly BreadWinner / Facebook Ad Builder. Research competitors, generate ad copy and creative, launch campaigns, manage delivery, and review performance in one place. LeadRouter campaign connections, workspace API keys, plugins, and guided setup are included in the v2 release candidate.
+**theLeadRouter — Ad Studio** is the v2 ad workspace, formerly BreadWinner / Facebook Ad Builder. Research competitors, generate ad copy and creative, launch campaigns, manage delivery, and review performance in one place. LeadRouter campaign connections, workspace API keys, plugins, and guided setup are included in the v2 release candidate.
 
 ### Guided Railway installation (release preview)
 
@@ -106,8 +106,8 @@ Manage Facebook campaigns directly:
 Run the setup wizard which will guide you through the entire configuration:
 
 ```bash
-git clone https://github.com/jasonakatiff/iscale-facebook-ad-builder.git leadrouter-ad-builder-manager
-cd leadrouter-ad-builder-manager
+git clone https://github.com/jasonakatiff/theleadrouter-ad-studio.git theleadrouter-ad-studio
+cd theleadrouter-ad-studio
 ./setup.sh
 ```
 
@@ -125,8 +125,8 @@ The wizard will:
 #### 1. Clone and Install
 
 ```bash
-git clone https://github.com/jasonakatiff/iscale-facebook-ad-builder.git leadrouter-ad-builder-manager
-cd leadrouter-ad-builder-manager
+git clone https://github.com/jasonakatiff/theleadrouter-ad-studio.git theleadrouter-ad-studio
+cd theleadrouter-ad-studio
 
 # Backend
 cd backend

--- a/backend/app/api/v1/help.py
+++ b/backend/app/api/v1/help.py
@@ -46,7 +46,7 @@ def read_doc(slug: str, download: bool = False):
 
 def endpoint_index(schema):
     lines = [
-        "# theLeadRouter — Ad Builder & Manager API endpoint index",
+        "# theLeadRouter — Ad Studio API endpoint index",
         "",
         "Generated from this deployment’s OpenAPI contract. See openapi.json for schemas and permissions.",
         "",
@@ -86,7 +86,7 @@ def download_bundle(request: Request):
         output.getvalue(),
         media_type="application/zip",
         headers={
-            "Content-Disposition": 'attachment; filename="leadrouter-ad-builder-manager-docs.zip"',
+            "Content-Disposition": 'attachment; filename="theleadrouter-ad-studio-docs.zip"',
             "Cache-Control": "no-cache",
         },
     )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -4,11 +4,11 @@ from dotenv import load_dotenv
 load_dotenv()
 
 class Settings:
-    PROJECT_NAME: str = "theLeadRouter — Ad Builder & Manager"
+    PROJECT_NAME: str = "theLeadRouter — Ad Studio"
     API_V1_STR: str = "/api/v1"
 
     # White-label brand (per-client deployments; server-side references)
-    BRAND_NAME: str = os.getenv("BRAND_NAME", "theLeadRouter — Ad Builder & Manager")
+    BRAND_NAME: str = os.getenv("BRAND_NAME", "theLeadRouter — Ad Studio")
 
     # Where to send the browser after a successful OAuth connect flow
     FRONTEND_URL: str = os.getenv("FRONTEND_URL", "http://localhost:5173")

--- a/backend/app/docs/api-guide.md
+++ b/backend/app/docs/api-guide.md
@@ -1,6 +1,6 @@
 # API guide and examples
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
 ## Base URL and authentication
 Production API origin: https://ad-builder-backend-production.up.railway.app

--- a/backend/app/docs/api-keys.md
+++ b/backend/app/docs/api-keys.md
@@ -1,10 +1,10 @@
 # User API keys
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
 Open API Keys and choose a descriptive name, access level, and expiry. Read-only is the default. Read/write adds POST, PUT, PATCH, and DELETE access but still enforces the user's roles and resource permissions. Keys expire after 1–365 days; the default is 90 days. A user can have at most 20 active keys.
 
-The key is displayed once after creation. Copy it before dismissing the panel. Ad Builder & Manager stores only its SHA-256 hash and a short display prefix. Existing keys list their name, scope, creation, last-use, expiry, and revocation state. Rename a label without changing its token. Revoke a key to stop future authentication; revocation is idempotent.
+The key is displayed once after creation. Copy it before dismissing the panel. Ad Studio stores only its SHA-256 hash and a short display prefix. Existing keys list their name, scope, creation, last-use, expiry, and revocation state. Rename a label without changing its token. Revoke a key to stop future authentication; revocation is idempotent.
 
 Send `Authorization: Bearer bw_live_REPLACE_WITH_YOUR_KEY` on requests. Never put a key in a URL, Git repository, shared Markdown file, screenshot, or committed Claude Code settings. API keys cannot create/list/rename/revoke other API keys; management requires a signed-in browser session.
 

--- a/backend/app/docs/brand-scrapes.md
+++ b/backend/app/docs/brand-scrapes.md
@@ -1,6 +1,6 @@
 # Scrape Brand Ads
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
 Open Research → Scrape Brand Ads. Enter a brand name and Facebook Page ID or supported Ads Library URL, then start the scrape. The list shows pending, scraping, completed, or failed status and media counts. Open a completed scrape to inspect its ads.
 

--- a/backend/app/docs/brands-products-profiles.md
+++ b/backend/app/docs/brands-products-profiles.md
@@ -1,6 +1,6 @@
 # Brands, Products, and Customer Profiles
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
 Start with Brands. Add a brand name, voice, colors, and logo. Use Products to attach product descriptions, product shots, and default landing-page URLs to that brand. Use Customer Profiles to describe demographics, pain points, and goals, then associate profiles with brands.
 

--- a/backend/app/docs/claude-code.md
+++ b/backend/app/docs/claude-code.md
@@ -1,15 +1,15 @@
-# Use Ad Builder & Manager from Claude Code
+# Use Ad Studio from Claude Code
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
 ## Documentation pack
 Download the documentation ZIP from Help & API Docs. Extract the Markdown files and openapi.json into your working project. Add this folder to Claude Code context. The files contain documentation only; they do not authenticate Claude Code and contain no private API key.
 
-Create a user API key in Ad Builder & Manager. Start with read-only. Provide BREADWINNER_API_URL and BREADWINNER_API_KEY through your existing secure shell environment. Never paste the key into a committed document, prompt transcript, theme file, or repository. A read/write key is necessary for changes and remains limited by the owner's current permissions.
+Create a user API key in Ad Studio. Start with read-only. Provide BREADWINNER_API_URL and BREADWINNER_API_KEY through your existing secure shell environment. Never paste the key into a committed document, prompt transcript, theme file, or repository. A read/write key is necessary for changes and remains limited by the owner's current permissions.
 
 ## Suggested project instructions
 ```text
-Use the Ad Builder & Manager Markdown guides and openapi.json in this project as the API contract.
+Use the Ad Studio Markdown guides and openapi.json in this project as the API contract.
 Read BREADWINNER_API_URL and BREADWINNER_API_KEY from the process environment.
 Do not print, log, commit, or embed the key in URLs or generated files.
 Verify the authenticated identity with GET /api/v1/auth/me before acting.
@@ -22,4 +22,4 @@ Do not treat prototype or legacy Reporting sample values as live performance.
 
 Start with: “Read the docs, verify my identity, and list the brands I can access.” Then use specific requests such as listing workspace accounts, creating a brand, generating draft creative, or inspecting campaign insights. Only the actual API operations are automatable; a visual prototype does not imply a backend endpoint exists.
 
-No MCP server installation is required for ordinary HTTP access from Claude Code. The downloadable JSON can also be used with an OpenAPI client generator. Inspect any generated client before supplying credentials. Revoke the integration key from Ad Builder & Manager when it is no longer needed.
+No MCP server installation is required for ordinary HTTP access from Claude Code. The downloadable JSON can also be used with an OpenAPI client generator. Inspect any generated client before supplying credentials. Revoke the integration key from Ad Studio when it is no longer needed.

--- a/backend/app/docs/connections.md
+++ b/backend/app/docs/connections.md
@@ -1,6 +1,6 @@
 # Connections, workspaces, and refresh
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
 Open Connections. Select an existing workspace or, as an administrator, create one and add members. Choose the accounts the team is allowed to use. Membership, role, and account grants control visibility and refresh access.
 

--- a/backend/app/docs/creative-building.md
+++ b/backend/app/docs/creative-building.md
@@ -1,6 +1,6 @@
 # Creative Building: image, video, and remix
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
 Open Creative Building and choose a format. Image Ads uses a brand, product, audience profile, style or template, and generation settings. Review those choices, generate, and inspect the result before saving or using it in a campaign.
 

--- a/backend/app/docs/facebook-campaigns.md
+++ b/backend/app/docs/facebook-campaigns.md
@@ -1,6 +1,6 @@
 # Facebook campaigns and tracking
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
 Open Ad Deployment → Facebook Campaigns. The connection panel distinguishes managed workspace access, a personal connection, disconnected status, expired access, and account selection. Personal connection controls are unavailable until the deployment's Meta OAuth setup is complete.
 

--- a/backend/app/docs/getting-started.md
+++ b/backend/app/docs/getting-started.md
@@ -1,8 +1,8 @@
 # Getting started
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
-Ad Builder & Manager is an ad workspace powered by theLeadRouter.com. Research competitors, build creatives, configure campaigns, and inspect performance. An administrator creates your user account; sign in at /login.
+Ad Studio is an ad workspace powered by theLeadRouter.com. Research competitors, build creatives, configure campaigns, and inspect performance. An administrator creates your user account; sign in at /login.
 
 ## Your workflow
 1. Research: find ads and save useful references.

--- a/backend/app/docs/google-tiktok.md
+++ b/backend/app/docs/google-tiktok.md
@@ -1,6 +1,6 @@
 # Google Ads and TikTok Ads
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
 Open Ad Deployment and select Google Ads or TikTok Ads. Connect an account through the browser, choose the account, and review the platform-specific campaign and performance controls. Provider OAuth setup must be configured for that deployment. Reconnect when the app reports expired or unavailable access.
 

--- a/backend/app/docs/help.md
+++ b/backend/app/docs/help.md
@@ -1,6 +1,6 @@
 # Help and downloadable documentation
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
 Open Help & API Docs from the sidebar. Browse the user-guide list, download an individual Markdown file, search the endpoint list, open Swagger, or download the complete ZIP. The ZIP includes all Markdown guides plus OpenAPI JSON and an endpoint index generated from the running application.
 

--- a/backend/app/docs/leadrouter-integration.md
+++ b/backend/app/docs/leadrouter-integration.md
@@ -1,15 +1,15 @@
 # Native LeadRouter integration
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
-LeadRouter is built into Ad Builder & Manager. No plugin installation is required.
+LeadRouter is built into Ad Studio. No plugin installation is required.
 
 ## Connect once
 
 Open Connections → Configure LeadRouter, or Settings → Configure LeadRouter.
-Choose Partner account for a LeadRouter partner portal key, or Organization API key for organization campaign access. Enter an `lr_` API key with campaign read access and select Connect LeadRouter. Ad Builder & Manager verifies the key before saving it.
+Choose Partner account for a LeadRouter partner portal key, or Organization API key for organization campaign access. Enter an `lr_` API key with campaign read access and select Connect LeadRouter. Ad Studio verifies the key before saving it.
 
-The connection is private to your Ad Builder & Manager user. Even an organization key does not grant its access to your Ad Builder & Manager teammates. Credentials are encrypted on the backend, never returned to the browser, and never included in exported docs, campaign drafts, or AI prompts. A `pk_` posting key is a different credential and cannot be used to browse campaigns.
+The connection is private to your Ad Studio user. Even an organization key does not grant its access to your Ad Studio teammates. Credentials are encrypted on the backend, never returned to the browser, and never included in exported docs, campaign drafts, or AI prompts. A `pk_` posting key is a different credential and cannot be used to browse campaigns.
 
 To replace a key or switch accounts, disconnect and reconnect. Disconnecting removes your stored credential and personal default/campaign associations. It does not alter your LeadRouter account or published ads. Existing browser drafts retain their campaign reference until cleared; an old connection reference cannot pass live validation after reconnection.
 
@@ -25,7 +25,7 @@ The built-in connector uses https://theleadrouter.com. Custom installation domai
 | Image Ads → Campaign | Select a campaign or explicitly use the product/brand default; Use LeadRouter offer in brief copies its current offer name into the editable offer field. |
 | Facebook Campaigns → Campaign Setup | Select an optional LeadRouter campaign. The browser draft keeps the association. |
 | Review & Launch | Review the association; current connection and campaign access are checked before publishing. The resulting local campaign gets a private association. |
-| Campaign Reporting | Select a LeadRouter campaign to see its available lifetime lead count, status, offer, and your linked Ad Builder & Manager campaigns. |
+| Campaign Reporting | Select a LeadRouter campaign to see its available lifetime lead count, status, offer, and your linked Ad Studio campaigns. |
 | Help & API Docs | Download this guide and the current OpenAPI contract for API automation. |
 
 Product defaults take precedence over brand defaults. Applying a default in a creative brief is explicit and does not overwrite the offer until you select Use LeadRouter offer in brief. Save a new brand/product before assigning its native default. Campaign strategy presets remain reusable independently of your personal LeadRouter connection.
@@ -36,11 +36,11 @@ Only active campaigns can be saved as defaults or linked during publication. Rep
 
 Opening an expanded picker or the reporting page requests campaign pages from LeadRouter. Refresh campaigns requests them again. There is no background timer, scheduled polling, or automatic lead delivery. The UI displays the last fetched time. The searchable catalog supports up to 10,000 campaigns; larger accounts need a key with narrower campaign access.
 
-The API exposes only campaign identifiers, names, offer/vertical labels, status, and available lifetime lead counts. Posting keys, private specification tokens, lead records, and other provider fields are excluded. Lead counts are not filtered to a date range or attributed to an individual Ad Builder & Manager ad. A campaign association alone does not calculate conversions, revenue, or ROAS.
+The API exposes only campaign identifiers, names, offer/vertical labels, status, and available lifetime lead counts. Posting keys, private specification tokens, lead records, and other provider fields are excluded. Lead counts are not filtered to a date range or attributed to an individual Ad Studio ad. A campaign association alone does not calculate conversions, revenue, or ROAS.
 
 ## Use with Claude Code or another API client
 
-Connect LeadRouter once in your Ad Builder & Manager browser session. Then use a Ad Builder & Manager user API key in the Bearer header against these Ad Builder & Manager routes:
+Connect LeadRouter once in your Ad Studio browser session. Then use a Ad Studio user API key in the Bearer header against these Ad Studio routes:
 
 | Method | Path under /api/v1 | Purpose |
 | --- | --- | --- |
@@ -52,9 +52,9 @@ Connect LeadRouter once in your Ad Builder & Manager browser session. Then use a
 | GET | /leadrouter/defaults/resolve?brandId={brand_id} | Personal brand default. |
 | GET, PUT, DELETE | /leadrouter/defaults/{resource_type}/{resource_id} | Read, save, or remove a brand, product, or campaign association. |
 
-PUT accepts `{ "connectionId": "<connection UUID>", "campaignId": "<LeadRouter campaign UUID>" }`. `resource_type` is `brand`, `product`, or `campaign`; `resource_id` is an existing Ad Builder & Manager record identifier, not a LeadRouter identifier. PUT revalidates ownership of the connection and current upstream campaign access. Lists use `{ data, pagination: { total, limit, offset, hasMore } }`. Errors use `{ error: { code, message, details } }`.
+PUT accepts `{ "connectionId": "<connection UUID>", "campaignId": "<LeadRouter campaign UUID>" }`. `resource_type` is `brand`, `product`, or `campaign`; `resource_id` is an existing Ad Studio record identifier, not a LeadRouter identifier. PUT revalidates ownership of the connection and current upstream campaign access. Lists use `{ data, pagination: { total, limit, offset, hasMore } }`. Errors use `{ error: { code, message, details } }`.
 
-Read keys can read the owner's native metadata and campaign catalog. Read/write keys can also save/remove the owner's associations. Browser sessions are required for PUT/DELETE `/leadrouter/connection`. The LeadRouter key and Ad Builder & Manager API key are separate credentials with separate purposes.
+Read keys can read the owner's native metadata and campaign catalog. Read/write keys can also save/remove the owner's associations. Browser sessions are required for PUT/DELETE `/leadrouter/connection`. The LeadRouter key and Ad Studio API key are separate credentials with separate purposes.
 
 ## Deliver leads and preserve tracking
 

--- a/backend/app/docs/performance.md
+++ b/backend/app/docs/performance.md
@@ -1,6 +1,6 @@
 # Performance Reports and Dashboard
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
 Open Performance Reports → Overview to inspect available connected-provider performance. The overview combines provider rows and reports provider errors separately; one unavailable integration does not imply that every other provider failed. Check the selected date range and account context.
 

--- a/backend/app/docs/plugin-service-api.md
+++ b/backend/app/docs/plugin-service-api.md
@@ -1,6 +1,6 @@
 # Plugin package and service API
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
 All URLs below are relative to the backend origin. Package uploads are JSON requests, not executable archives. The UI and API use the same private installation and run records. Reference the running OpenAPI document at `/api/v1/openapi.json` for field types and status codes.
 

--- a/backend/app/docs/plugins.md
+++ b/backend/app/docs/plugins.md
@@ -1,8 +1,8 @@
 # Plugins: local packages and connected services
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
-Open Plugins to import a package file, use an included example, or run an installed plugin. Installations, configuration and run history are private to your Ad Builder & Manager user. Every installed plugin can also be run through the same API using a Ad Builder & Manager read/write user key.
+Open Plugins to import a package file, use an included example, or run an installed plugin. Installations, configuration and run history are private to your Ad Studio user. Every installed plugin can also be run through the same API using a Ad Studio read/write user key.
 
 ## Import and run a local package
 
@@ -14,9 +14,9 @@ Outputs appear in run history and can be copied or downloaded. Export package do
 
 Import the service operator's package, or install Service Starter to try the protocol. A service package declares inputs and nonsecret configuration. Under Service connection, create a worker key and provide it securely to that service. The plaintext key appears once and is not included in exported packages or ordinary reads. The service uses the documented job API to claim and complete jobs for this installation only.
 
-A worker can run on a company server or your own computer. It polls Ad Builder & Manager over outbound HTTPS; the application does not need access to localhost or an inbound port. An existing arbitrary vendor API needs a small adapter implementing this protocol. The example worker is a connection demonstration; the vendor supplies its own processing logic and manages its own provider credentials.
+A worker can run on a company server or your own computer. It polls Ad Studio over outbound HTTPS; the application does not need access to localhost or an inbound port. An existing arbitrary vendor API needs a small adapter implementing this protocol. The example worker is a connection demonstration; the vendor supplies its own processing logic and manages its own provider credentials.
 
-The service receives only the inputs and configuration you submit for its jobs. It has no automatic access to your brands, ad accounts, performance data, LeadRouter key, platform key or provider OAuth credentials. Do not place credentials or unnecessary personal data in plugin inputs/configuration. Review the operator's terms and handling of the submitted data before connecting a service. Any external usage fees are arranged with that operator; Ad Builder & Manager does not collect plugin fees in this release.
+The service receives only the inputs and configuration you submit for its jobs. It has no automatic access to your brands, ad accounts, performance data, LeadRouter key, platform key or provider OAuth credentials. Do not place credentials or unnecessary personal data in plugin inputs/configuration. Review the operator's terms and handling of the submitted data before connecting a service. Any external usage fees are arranged with that operator; Ad Studio does not collect plugin fees in this release.
 
 ## Configuration, runs and history
 

--- a/backend/app/docs/research.md
+++ b/backend/app/docs/research.md
@@ -1,6 +1,6 @@
 # Research and saved searches
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
 Open Research. Create a search with a keyword, country, result limit, and optional negative keywords or vertical. Start the search and monitor its status. Filter results to find reusable references; inspect media, copy, platform, and dates before using an ad as inspiration.
 

--- a/backend/app/docs/settings-users.md
+++ b/backend/app/docs/settings-users.md
@@ -1,6 +1,6 @@
 # Settings and User Management
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
 Settings includes Ad Styles and Prompts used by the creative workflows. Inspect and edit the controls available for the selected item. Some style edits and the AI-style-generation demo currently affect frontend state only; General Settings is unfinished. Do not assume those demo controls persist or contact an AI service. Use the documented /api/v1/ad-styles and /api/v1/prompts operations for server-backed automation and verify the resulting record.
 

--- a/backend/app/docs/telemetry.md
+++ b/backend/app/docs/telemetry.md
@@ -1,4 +1,4 @@
-# Debugging Ad Builder & Manager with an agent
+# Debugging Ad Studio with an agent
 
 Telemetry connects browser activity, API requests, database timings, provider calls, background work and feedback. An active administrator can create a key at `/settings/api-keys` with **Diagnostics and feedback** access. Give an agent that key through its credential store and this API base:
 

--- a/backend/app/docs/themes.md
+++ b/backend/app/docs/themes.md
@@ -1,8 +1,8 @@
 # Theme Library and GitHub skins
 
-theLeadRouter — Ad Builder & Manager
+theLeadRouter — Ad Studio
 
-Open Themes. Workflow is the default blue skin based on the workflow prototype. Ad Builder & Manager Classic restores the earlier warm palette; Forest provides a green alternative. Apply a built-in theme immediately, or Customize it to save a private copy. The top-bar appearance switch still chooses light, dark, or system mode.
+Open Themes. Workflow is the default blue skin based on the workflow prototype. Ad Studio Classic restores the earlier warm palette; Forest provides a green alternative. Apply a built-in theme immediately, or Customize it to save a private copy. The top-bar appearance switch still chooses light, dark, or system mode.
 
 ## Build and manage a skin
 Choose Create theme, enter a name, and edit both palettes. Each palette defines canvas, panel, text, muted, accent, accentText, accentInk, and border as six-digit hex colors. Save validates readable text and button contrast of at least 4.5:1. Theme files contain colors only, not CSS, scripts, fonts, or arbitrary HTML.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,5 @@
 """
-theLeadRouter — Ad Builder & Manager API
+theLeadRouter — Ad Studio API
 
 Created by Jason Akatiff
 iSCALE.com | A4D.com

--- a/backend/app/plugin_examples/plugin-worker.py
+++ b/backend/app/plugin_examples/plugin-worker.py
@@ -1,4 +1,4 @@
-"""Example Ad Builder & Manager service worker. Reads process environment; never saves credentials."""
+"""Example Ad Studio service worker. Reads process environment; never saves credentials."""
 
 import argparse
 import json
@@ -93,7 +93,7 @@ def run_once(origin, key):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Ad Builder & Manager plugin connection demonstration"
+        description="Ad Studio plugin connection demonstration"
     )
     parser.add_argument(
         "--once", action="store_true", help="Process at most one queued job"

--- a/backend/tests/unit/test_user_api_keys.py
+++ b/backend/tests/unit/test_user_api_keys.py
@@ -179,7 +179,7 @@ def test_openapi_and_docs_bundle_are_machine_readable(client):
     response = client.get("/api/v1/openapi.json")
     assert response.status_code == 200
     schema = response.json()
-    assert schema["info"]["title"] == "theLeadRouter — Ad Builder & Manager API"
+    assert schema["info"]["title"] == "theLeadRouter — Ad Studio API"
     assert (
         schema["components"]["securitySchemes"]["BreadWinnerBearer"]["scheme"]
         == "bearer"

--- a/docs/brand-guidelines.md
+++ b/docs/brand-guidelines.md
@@ -1,21 +1,21 @@
-# theLeadRouter — Ad Builder & Manager
+# theLeadRouter — Ad Studio
 
-The public v2 product name is **theLeadRouter — Ad Builder & Manager**. It covers the ad workspace: research, creative generation, campaign launching, reporting, and management.
+The public v2 product name is **theLeadRouter — Ad Studio**. It covers the ad workspace: research, creative generation, campaign launching, reporting, and management.
 
 - Brand wordmark: `theLeadRouter`.
-- Product descriptor: `Ad Builder & Manager`.
-- Full title: `theLeadRouter — Ad Builder & Manager`.
-- Version: `2.0.0-rc.1`, an unreleased v2 candidate.
-- Short references: `Ad Builder & Manager` or `your ad workspace`.
+- Product descriptor: `Ad Studio`.
+- Full title: `theLeadRouter — Ad Studio`.
+- Version: `2.0.0-rc.1`, the public v2 release candidate.
+- Short references: `Ad Studio` or `your ad workspace`.
 - LeadRouter integration credentials and ad workspace API keys are separate. Use `LeadRouter connection key` and `workspace API key` in instructions.
 
 Use the existing blue theme and configurable workspace branding. Existing `VITE_APP_*` and `BRAND_NAME` settings remain supported. Stored identifiers, API routes, credential prefixes, environment keys, deployment service names, and historical release records keep their existing values for compatibility.
 
-Public source remains at `jasonakatiff/iscale-facebook-ad-builder`. The [public v2 release](deployment/v2-railway-release.md) connects this repository to the Railway one-click template. Repository renaming and marketplace publication are separate decisions.
+Public source is `jasonakatiff/theleadrouter-ad-studio`. The [public v2 release](deployment/v2-railway-release.md) connects this repository to the Railway one-click template. The owner selected Ad Studio for the product, repository, and Railway naming. Marketplace publication remains a separate release decision.
 
 Verification covers the existing branding and frontend suites, the production frontend build, scoped lint, and desktop/mobile browser rendering. Naming changes do not require new database migrations or live advertising calls.
 
-## Verification
+## Previous v2 branding verification
 
 - 85 existing frontend tests passed, including configured workspace-name/logo overrides.
 - 12 backend API-key/documentation tests passed using an isolated PostgreSQL database on Python 3.12; the database was removed after testing.

--- a/docs/deployment/install-on-railway.md
+++ b/docs/deployment/install-on-railway.md
@@ -1,12 +1,12 @@
-# Install theLeadRouter — Ad Builder & Manager
+# Install theLeadRouter — Ad Studio
 
-[Deploy Ad Builder & Manager on Railway — preview](https://railway.com/deploy/rNhJ3h)
+[Deploy Ad Studio on Railway — preview](https://railway.com/deploy/rNhJ3h)
 
 The unlisted preview has passed a fresh Railway installation, owner login, independent credential generation, and database/media persistence checks. Live paid AI generation and nontechnical pilot acceptance remain unverified. The template is not listed in the Railway marketplace.
 
 Install your preview:
 
-1. Open the **Deploy Ad Builder & Manager on Railway** link above, sign in to Railway, and select your workspace. Your Railway account pays for hosting, database storage, and saved creative files. Check [Railway pricing](https://railway.com/pricing) before deploying.
+1. Open the **Deploy Ad Studio on Railway** link above, sign in to Railway, and select your workspace. Your Railway account pays for hosting, database storage, and saved creative files. Check [Railway pricing](https://railway.com/pricing) before deploying.
 2. Configure **Backend** with `ADMIN_EMAIL` (your owner email) and `ADMIN_PASSWORD` (your owner password), then choose **Deploy**. These are the only two required inputs. The password needs at least 12 characters and at most 72 UTF-8 bytes. Save it in your password manager.
 3. When deployment finishes, open **Frontend** and its website link. Sign in with your owner credentials.
 4. In the setup wizard, connect **Google Gemini** for copy and **fal.ai** for images. Each card includes instructions and a link to get a key. Your providers bill your own accounts. Saving a key does not use generation credits. Gemini offers a connection check; fal.ai verifies its generation key when you create the first image.
@@ -36,4 +36,4 @@ Enable scheduled backups for both the database and creative-media volumes in Rai
 
 Apply template updates only after checking the release notes and taking backups. Media storage uses one backend instance; updates can briefly interrupt access. Increasing traffic or storage needs is a separate capacity decision.
 
-Report installation problems through [the project issue tracker](https://github.com/jasonakatiff/iscale-facebook-ad-builder/issues). Include the failing step and displayed message. Never include API keys, passwords, tokens, or database URLs.
+Report installation problems through [the project issue tracker](https://github.com/jasonakatiff/theleadrouter-ad-studio/issues). Include the failing step and displayed message. Never include API keys, passwords, tokens, or database URLs.

--- a/docs/deployment/railway-template-maintainer.md
+++ b/docs/deployment/railway-template-maintainer.md
@@ -4,7 +4,7 @@ The [unlisted preview template](https://railway.com/deploy/rNhJ3h) is available.
 
 ## Source and configuration
 
-- Public repository: `jasonakatiff/iscale-facebook-ad-builder`, branch `main` (v2 release source).
+- Public repository: `jasonakatiff/theleadrouter-ad-studio`, branch `main` (v2 release source).
 - Previous preview runtime revision: `e4c64143404b4389d39d2a66a4e24ee74bae92b2`.
 - Template ID: `fddb5b7e-1e34-421e-85c4-832c90182a50`; code `rNhJ3h`.
 - [serialized-template.json](../../.railway/serialized-template.json) is the API-accepted template definition. It contains symbolic references, generators, and two blank owner fields, with no resolved secrets.

--- a/docs/deployment/v2-railway-release.md
+++ b/docs/deployment/v2-railway-release.md
@@ -1,12 +1,12 @@
 # Public v2 and Railway installer
 
-Status: release integration in progress.
+Status: public v2 merged in PR #36; Ad Studio rename in progress; hosted Railway template synchronization requires workspace credentials.
 
-The public product is **theLeadRouter — Ad Builder & Manager**. A recipient opens one Railway link, supplies an owner email/password, and receives an isolated ad workspace with a guided setup flow. Existing public installer PR #36 and template `rNhJ3h` provide the release base.
+The public product is **theLeadRouter — Ad Studio**. A recipient opens one Railway link, supplies an owner email/password, and receives an isolated ad workspace with a guided setup flow. Existing public installer PR #36 and template `rNhJ3h` provide the release base.
 
 ## Acceptance
 
-- Public repository `jasonakatiff/iscale-facebook-ad-builder` contains the branded v2 application and current installer fixes without private Git ancestry.
+- Public repository `jasonakatiff/theleadrouter-ad-studio` contains the branded v2 application and current installer fixes without private Git ancestry.
 - Public README and customer guide link to `https://railway.com/deploy/rNhJ3h`.
 - Hosted template uses the same product name and reviewed public source, with four services, two volumes, two owner inputs, generated private credentials, and credential preservation during updates.
 - Public release CI passes. An isolated template deployment verifies the source revision, branded frontend, API readiness, owner login/setup, and worker heartbeat.
@@ -34,3 +34,11 @@ The initial check failed because the template still targeted `codex/railway-inst
 ## Deployment verification scope
 
 The public repository's existing `BACKEND_URL` and `FRONTEND_URL` variables target the private BreadWinner installation, which deploys from a different repository. Removed automatic push triggering from Post-Deploy Verification. Maintainers can dispatch it after configuring the intended deployment URLs and test credentials. Public release CI verifies disposable containers and an isolated installation journey.
+
+## Ad Studio naming
+
+The owner selected **theLeadRouter — Ad Studio** and repository `jasonakatiff/theleadrouter-ad-studio`. Update product titles, downloadable filenames, docs, public repository metadata, Git remotes, and the three template GitHub sources together. Keep the current installer branch synchronized until the hosted template can move to `main`. Verify Git access through both repository URLs after renaming.
+
+The Railway project and hosted template are separate resources. Verify their names independently; checked-in template files do not rename either hosted resource. No schema, credential, service, or domain change is required for naming.
+
+The GitHub repository was renamed successfully; Git access through both the new URL and the former `iscale-facebook-ad-builder` URL resolved to the same commit. The Railway API rejected the project-name update with `Not Authorized` for the available project token. Both hosted naming updates require a workspace credential.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,8 +8,8 @@
   <script src="/theme-init.js"></script>
   <meta http-equiv="Content-Security-Policy"
     content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https: http://localhost:8000 https://*.railway.app https://*.facebook.com https://*.fbcdn.net https://*.r2.dev; media-src 'self' data: blob: https: http://localhost:8000 https://*.railway.app https://*.facebook.com https://*.fbcdn.net https://*.r2.dev; worker-src 'self' blob:; connect-src 'self' blob: https://generativelanguage.googleapis.com https://graph.facebook.com http://localhost:8000 https://*.railway.app;">
-  <meta name="description" content="theLeadRouter — Ad Builder &amp; Manager. Research, create, launch, and manage ad campaigns from one workspace." />
-  <title>theLeadRouter — Ad Builder &amp; Manager</title>
+  <meta name="description" content="theLeadRouter — Ad Studio. Research, create, launch, and manage ad campaigns from one workspace." />
+  <title>theLeadRouter — Ad Studio</title>
 </head>
 
 <body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "leadrouter-ad-builder-manager",
+  "name": "theleadrouter-ad-studio",
   "version": "2.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "leadrouter-ad-builder-manager",
+      "name": "theleadrouter-ad-studio",
       "version": "2.0.0-rc.1",
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "leadrouter-ad-builder-manager",
+  "name": "theleadrouter-ad-studio",
   "private": true,
   "version": "2.0.0-rc.1",
-  "description": "theLeadRouter — Ad Builder & Manager: research, create, launch, and manage ad campaigns",
+  "description": "theLeadRouter — Ad Studio: research, create, launch, and manage ad campaigns",
   "author": "Jason Akatiff <jason@jasonakatiff.com> (https://iscale.com)",
   "license": "MIT",
   "type": "module",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 /**
- * theLeadRouter — Ad Builder & Manager - Frontend
+ * theLeadRouter — Ad Studio - Frontend
  *
  * Created by Jason Akatiff
  * iSCALE.com | A4D.com

--- a/frontend/src/lib/branding.js
+++ b/frontend/src/lib/branding.js
@@ -4,7 +4,7 @@ export const APP_NAME = import.meta.env.VITE_APP_NAME || 'theLeadRouter';
 export const APP_LOGO =
     import.meta.env.VITE_APP_LOGO || '/leadrouter-mark.svg';
 export const APP_TAGLINE =
-    import.meta.env.VITE_APP_TAGLINE || 'Ad Builder & Manager';
+    import.meta.env.VITE_APP_TAGLINE || 'Ad Studio';
 export const APP_OPERATOR =
     import.meta.env.VITE_APP_OPERATOR || 'theLeadRouter.com';
 export const APP_OPERATOR_URL =

--- a/frontend/src/pages/Help.jsx
+++ b/frontend/src/pages/Help.jsx
@@ -116,7 +116,7 @@ export default function Help() {
                     className="studio-button primary"
                     disabled={busy}
                     onClick={() =>
-                        download('/help/download', 'leadrouter-ad-builder-manager-docs.zip')
+                        download('/help/download', 'theleadrouter-ad-studio-docs.zip')
                     }
                 >
                     <Download size={16} />

--- a/frontend/src/pages/Themes.jsx
+++ b/frontend/src/pages/Themes.jsx
@@ -104,7 +104,7 @@ export default function Themes() {
             new Blob([JSON.stringify(themeDocument(theme), null, 2) + '\n'], {
                 type: 'application/json',
             }),
-            'leadrouter-ad-builder-manager-theme.json',
+            'theleadrouter-ad-studio-theme.json',
         );
     const refresh = async (theme) => {
         if (pending) return;

--- a/frontend/tests/e2e/platform-tools.spec.js
+++ b/frontend/tests/e2e/platform-tools.spec.js
@@ -25,7 +25,7 @@ test('user keys, theme library, and downloadable API docs work together', async 
     let jwt, refreshToken, keyId, themeId;
     try {
         await page.goto('/login');
-        await expect(page).toHaveTitle('theLeadRouter — Ad Builder & Manager');
+        await expect(page).toHaveTitle('theLeadRouter — Ad Studio');
         await expect(
             page.getByText('Powered by', { exact: false }).first(),
         ).toBeVisible();
@@ -150,7 +150,7 @@ test('user keys, theme library, and downloadable API docs work together', async 
             .getByRole('button', { name: `Download ${themeName}` })
             .click();
         expect((await exported).suggestedFilename()).toBe(
-            'leadrouter-ad-builder-manager-theme.json',
+            'theleadrouter-ad-studio-theme.json',
         );
         await page.goto('/help');
         await expect(
@@ -158,7 +158,7 @@ test('user keys, theme library, and downloadable API docs work together', async 
         ).toBeVisible();
         await expect(
             page.getByRole('heading', {
-                name: 'Use Ad Builder & Manager from Claude Code',
+                name: 'Use Ad Studio from Claude Code',
                 exact: true,
             }),
         ).toBeVisible();
@@ -174,7 +174,7 @@ test('user keys, theme library, and downloadable API docs work together', async 
             .getByRole('button', { name: 'Download all docs', exact: true })
             .click();
         expect((await docsDownload).suggestedFilename()).toBe(
-            'leadrouter-ad-builder-manager-docs.zip',
+            'theleadrouter-ad-studio-docs.zip',
         );
         const schema = await request.get(`${api}/openapi.json`);
         expect((await schema.json()).paths['/api/v1/api-keys']).toBeTruthy();

--- a/frontend/tests/smoke/platform-tools.spec.js
+++ b/frontend/tests/smoke/platform-tools.spec.js
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 
 test('public login shows the product branding', async ({ page }) => {
     await page.goto('/login');
-    await expect(page).toHaveTitle('theLeadRouter — Ad Builder & Manager');
+    await expect(page).toHaveTitle('theLeadRouter — Ad Studio');
     await expect(
         page.getByRole('button', { name: 'Sign In', exact: true }),
     ).toBeVisible();


### PR DESCRIPTION
Rename the public product to **theLeadRouter — Ad Studio**. Update the app and API titles, help guides, download filenames, package metadata, README, and Railway template sources to `jasonakatiff/theleadrouter-ad-studio`. Keep configurable workspace branding and existing credential identifiers compatible.

The GitHub repository and local remote have been renamed; Git access through both repository URLs resolves successfully. Hosted Railway project/template naming is separate: the available project credential returned `Not Authorized` for the project-name update. After merge, synchronize the existing installer branch so the hosted template continues receiving the renamed application until its configuration can move to `main`.

Validation: 85 frontend unit tests, production build, scoped ESLint, Railway TypeScript/configuration checks, Python parsing, secret scan, public login smoke, and desktop/mobile branding passed. Two browser tests requiring authenticated API fixtures were skipped locally; the full isolated release CI runs on this PR. No local test server remains running.
