### PR TITLE
fix: block unsafe media uploads and harden Graph reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
   legacy video requests carry access tokens in headers.
 - Telemetry redaction avoids excessive regex backtracking on hostile strings.
 - [Plan and test status](docs/plans/security-codeql-findings.md): 139 focused tests
-  passed; backend suite passed 504 tests with one existing XPASS; GitHub CI pending. Includes evidence-based
+  passed; GitHub CI passed 505 backend tests with one existing XPASS, plus
+  frontend, installation, container persistence, and CodeQL checks. Includes evidence-based
   triage of all 17 critical/high CodeQL findings.
 
 ## README installation paths — 2026-09-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Security: media uploads and Graph reads — 2026-09-08
+
+- Facebook uploads reject private network destinations and server file paths,
+  reuse DNS-pinned bounded downloads, and clean up temporary files on failure.
+- Graph video and delivery reads validate resource paths and reject redirects;
+  legacy video requests carry access tokens in headers.
+- Telemetry redaction avoids excessive regex backtracking on hostile strings.
+- [Plan and test status](docs/plans/security-codeql-findings.md): 139 focused tests
+  passed; backend suite passed 504 tests with one existing XPASS; GitHub CI pending. Includes evidence-based
+  triage of all 17 critical/high CodeQL findings.
+
 ## README installation paths — 2026-09-08
 
 Make the Railway one-click preview the Quick Start and Deployment path for **theLeadRouter — Ad Studio**. Label local development separately, add the missing documentation navigation target, and document Render, Northflank, DigitalOcean, and Coolify as future installation options with official sources. Railway remains the only published installer. Verification: GitHub Markdown rendering, README anchors and relative links, and the Railway configuration check passed.

--- a/backend/app/api/v1/facebook.py
+++ b/backend/app/api/v1/facebook.py
@@ -538,6 +538,10 @@ def upload_image(
             raise HTTPException(status_code=400, detail="image_url is required")
         image_hash = service.upload_image(image_url, ad_account_id)
         return {"image_hash": image_hash}
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from None
     except Exception as e:
         capture_exception(e, "facebook.upload_image")
         raise HTTPException(status_code=500, detail=str(e))
@@ -578,6 +582,8 @@ def upload_video(
         return result
     except HTTPException:
         raise
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from None
     except Exception as e:
         capture_exception(e, "facebook.upload_video")
         raise HTTPException(status_code=500, detail=str(e))
@@ -597,6 +603,8 @@ def get_video_status(
     """
     try:
         return service.get_video_status(video_id)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from None
     except Exception as e:
         capture_exception(e, "facebook.get_video_status")
         raise HTTPException(status_code=500, detail=str(e))
@@ -615,6 +623,8 @@ def get_video_thumbnails(
     try:
         thumbnails = service.get_video_thumbnails(video_id)
         return {"thumbnails": thumbnails}
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from None
     except Exception as e:
         capture_exception(e, "facebook.get_video_thumbnails")
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/delivery/provider.py
+++ b/backend/app/delivery/provider.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from decimal import Decimal, InvalidOperation
 
 import requests
@@ -116,6 +117,10 @@ class DeliveryProvider(FacebookService):
         raise ProviderError("Ad lookup exceeded its page limit")
 
     def read(self, path, params=None):
+        if not isinstance(path, str) or (
+            path and not re.fullmatch(r"(?:act_)?[0-9]+(?:/(?:ads|insights|thumbnails))?", path)
+        ):
+            raise ProviderError("Invalid Facebook resource path")
         if not self.access_token:
             raise ProviderError(
                 "Facebook access token is missing; an administrator must configure it"
@@ -126,9 +131,12 @@ class DeliveryProvider(FacebookService):
                 headers={"Authorization": "Bearer " + self.access_token},
                 params=params,
                 timeout=(5, 30),
+                allow_redirects=False,
             )
         except (requests.Timeout, requests.ConnectionError):
             raise ProviderError("Facebook connection failed", retryable=True) from None
+        if 300 <= response.status_code < 400:
+            raise ProviderError("Facebook returned an unexpected redirect")
         try:
             data = response.json()
         except ValueError:

--- a/backend/app/services/facebook_service.py
+++ b/backend/app/services/facebook_service.py
@@ -1,5 +1,6 @@
 from app.telemetry.runtime import capture_exception
 import os
+import re
 from facebook_business.api import FacebookAdsApi
 from facebook_business.adobjects.adaccount import AdAccount
 from facebook_business.adobjects.campaign import Campaign
@@ -16,6 +17,7 @@ import threading
 import hashlib
 from copy import deepcopy
 from app.services.campaign_validation import campaign_params, adset_params
+from app.delivery.media import download_media
 
 # Load .env from project root (parent of backend)
 env_path = Path(__file__).resolve().parent.parent.parent.parent / '.env'
@@ -257,122 +259,40 @@ class FacebookService:
         return account.create_ad_set(params=params)
 
     def upload_image(self, image_path_or_url, ad_account_id=None):
-        """Upload an image to the ad library."""
-        import tempfile
-        import requests
-
+        """Upload an image from a public URL to the ad library."""
         account = self._get_account(ad_account_id)
-
-        # Check if it's a URL or local file path
-        if image_path_or_url.startswith('http://') or image_path_or_url.startswith('https://'):
-            # Download the image to a temp file
-            response = requests.get(image_path_or_url, timeout=30)
-            response.raise_for_status()
-
-            # Get file extension from URL or default to .jpg
-            ext = '.jpg'
-            if '.' in image_path_or_url.split('/')[-1]:
-                ext = '.' + image_path_or_url.split('.')[-1].split('?')[0]
-
-            with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmp:
-                tmp.write(response.content)
-                local_path = tmp.name
-
+        with download_media(image_path_or_url) as local_path:
             image = AdImage(parent_id=account.get_id_assured(), api=self.api)
             image[AdImage.Field.filename] = local_path
-            image.remote_create()
-
-            # Clean up temp file
-            try:
-                os.remove(local_path)
-            except:
-                pass
-
-            return image[AdImage.Field.hash]
-        else:
-            # Local file path
-            image = AdImage(parent_id=account.get_id_assured(), api=self.api)
-            image[AdImage.Field.filename] = image_path_or_url
             image.remote_create()
             return image[AdImage.Field.hash]
 
     def upload_video(self, video_path_or_url, ad_account_id=None, wait_for_ready=True, timeout=600):
-        """Upload a video to the ad library.
-
-        Args:
-            video_path_or_url: Local file path or URL to video
-            ad_account_id: Optional ad account ID
-            wait_for_ready: Whether to wait for video processing to complete
-            timeout: Max seconds to wait for processing (default 10 min)
-
-        Returns:
-            dict with video_id, status, and thumbnails (if ready)
-        """
-        import tempfile
-        import requests
-
+        """Upload a public video URL and optionally wait for processing."""
         account = self._get_account(ad_account_id)
-
-        # Check if it's a URL or local file path
-        if video_path_or_url.startswith('http://') or video_path_or_url.startswith('https://'):
-            # Download the video to a temp file
-            print(f"Downloading video from URL: {video_path_or_url[:100]}...")
-            response = requests.get(video_path_or_url, timeout=120, stream=True)
-            response.raise_for_status()
-
-            # Get file extension from URL or default to .mp4
-            ext = '.mp4'
-            if '.' in video_path_or_url.split('/')[-1]:
-                url_ext = video_path_or_url.split('.')[-1].split('?')[0].lower()
-                if url_ext in ['mp4', 'mov', 'avi', 'webm']:
-                    ext = '.' + url_ext
-
-            with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmp:
-                for chunk in response.iter_content(chunk_size=8192):
-                    tmp.write(chunk)
-                local_path = tmp.name
-
-            print(f"Video downloaded to temp file: {local_path}")
-        else:
-            local_path = video_path_or_url
-
-        try:
-            # Create and upload video
+        with download_media(video_path_or_url, video=True) as local_path:
             video = AdVideo(parent_id=account.get_id_assured(), api=self.api)
             video[AdVideo.Field.filepath] = local_path
             video.remote_create()
-
             video_id = video['id']
-            print(f"Video uploaded with ID: {video_id}")
 
-            if wait_for_ready:
-                # Wait for video processing to complete
-                status = self.wait_for_video_ready(video_id, timeout=timeout)
-            else:
-                status = self.get_video_status(video_id)
+        if wait_for_ready:
+            status = self.wait_for_video_ready(video_id, timeout=timeout)
+        else:
+            status = self.get_video_status(video_id)
 
-            # Get thumbnails if video is ready
-            thumbnails = []
-            if status.get('status') == 'ready':
-                try:
-                    thumbnails = self.get_video_thumbnails(video_id)
-                except Exception as e:
-                    capture_exception(e, "facebook_service.upload_video")
-                    print(f"Warning: Could not fetch thumbnails: {e}")
+        thumbnails = []
+        if status.get('status') == 'ready':
+            try:
+                thumbnails = self.get_video_thumbnails(video_id)
+            except Exception as e:
+                capture_exception(e, "facebook_service.upload_video")
 
-            return {
-                'video_id': video_id,
-                'status': status.get('status', 'processing'),
-                'thumbnails': thumbnails
-            }
-
-        finally:
-            # Clean up temp file if we downloaded it
-            if video_path_or_url.startswith('http'):
-                try:
-                    os.remove(local_path)
-                except:
-                    pass
+        return {
+            'video_id': video_id,
+            'status': status.get('status', 'processing'),
+            'thumbnails': thumbnails,
+        }
 
     def get_video_status(self, video_id):
         """Check the processing status of a video.
@@ -382,13 +302,22 @@ class FacebookService:
         """
         import requests
 
+        if not isinstance(video_id, str) or not re.fullmatch(r"[0-9]+", video_id):
+            raise ValueError("Facebook video ID must contain only digits")
         url = f"https://graph.facebook.com/v21.0/{video_id}"
         params = {
-            'fields': 'id,status,length,source',
-            'access_token': self.access_token
+            'fields': 'id,status,length,source'
         }
 
-        response = requests.get(url, params=params, timeout=30)
+        response = requests.get(
+            url,
+            params=params,
+            headers={"Authorization": "Bearer " + self.access_token},
+            timeout=30,
+            allow_redirects=False,
+        )
+        if 300 <= response.status_code < 400:
+            raise ValueError("Facebook returned an unexpected redirect")
         data = response.json()
 
         if 'error' in data:
@@ -442,12 +371,20 @@ class FacebookService:
         """
         import requests
 
+        if not isinstance(video_id, str) or not re.fullmatch(r"[0-9]+", video_id):
+            raise ValueError("Facebook video ID must contain only digits")
         url = f"https://graph.facebook.com/v21.0/{video_id}/thumbnails"
-        params = {
-            'access_token': self.access_token
-        }
+        params = {}
 
-        response = requests.get(url, params=params, timeout=30)
+        response = requests.get(
+            url,
+            params=params,
+            headers={"Authorization": "Bearer " + self.access_token},
+            timeout=30,
+            allow_redirects=False,
+        )
+        if 300 <= response.status_code < 400:
+            raise ValueError("Facebook returned an unexpected redirect")
         data = response.json()
 
         if 'error' in data:

--- a/backend/app/telemetry/runtime.py
+++ b/backend/app/telemetry/runtime.py
@@ -29,6 +29,20 @@ _ASSIGNMENT = re.compile(
     r"""(?i)((?:password|passwd|secret|token|access_token|api[_-]?key|worker[_-]?key|authorization|cookie)["']?\s*[=:]\s*)["']?[^\s,;}"']+["']?"""
 )
 
+_EMAIL = re.compile(
+    r"(?<![A-Za-z0-9._%+-])[A-Za-z0-9._%+-]++@[A-Za-z0-9.-]++"
+)
+_URL = re.compile(r"https?://[^\s]++")
+
+
+def _redact_url(match):
+    url = match.group().split("?", 1)[0].split("#", 1)[0]
+    scheme, _, target = url.partition("://")
+    authority, slash, path = target.partition("/")
+    if "@" in authority:
+        authority = "[REDACTED]@" + authority.rsplit("@", 1)[1]
+    return scheme + "://" + authority + slash + path
+
 
 @contextmanager
 def redact_values(*values):
@@ -66,9 +80,8 @@ def sanitize(value, depth=0):
     text = re.sub(
         r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+", "[REDACTED]", text
     )
-    text = re.sub(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}", "[EMAIL]", text)
-    text = re.sub(r"(https?://)[^/\s@]+@", r"\1[REDACTED]@", text)
-    text = re.sub(r"(https?://[^\s?#]+)[?#][^\s]*", r"\1", text)
+    text = _URL.sub(_redact_url, text)
+    text = _EMAIL.sub("[EMAIL]", text)
     text = _ASSIGNMENT.sub(r"\1[REDACTED]", text)
     return text[:4000]
 

--- a/backend/tests/security/test_codeql_regressions.py
+++ b/backend/tests/security/test_codeql_regressions.py
@@ -1,0 +1,255 @@
+"""Boundary regressions for the September CodeQL findings; no live providers."""
+
+import signal
+import socket
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock, Mock
+
+import pytest
+import requests
+
+from app.delivery import media
+from app.delivery.provider import DeliveryProvider, ProviderError
+from app.services.facebook_service import FacebookService
+from app.telemetry.runtime import sanitize
+
+
+@pytest.fixture
+def service(monkeypatch):
+    value = FacebookService.__new__(FacebookService)
+    value.api = MagicMock()
+    value.access_token = "test-provider-token"
+    value.account = MagicMock()
+    value.account.get_id_assured.return_value = "act_123"
+    monkeypatch.setattr(
+        requests, "get", Mock(side_effect=AssertionError("Unprotected network request"))
+    )
+    return value
+
+
+@pytest.mark.parametrize("method", ["upload_image", "upload_video"])
+@pytest.mark.parametrize(
+    "source",
+    [
+        "http://127.0.0.1/test",
+        "http://169.254.169.254/latest/meta-data",
+        "http://[::1]/test",
+        "file:///test-private.txt",
+        "/test-private.txt",
+        "../test-private.txt",
+    ],
+)
+def test_legacy_upload_rejects_untrusted_sources(service, method, source, monkeypatch):
+    provider = MagicMock()
+    monkeypatch.setattr("app.services.facebook_service.AdImage", provider)
+    monkeypatch.setattr("app.services.facebook_service.AdVideo", provider)
+    with pytest.raises(ValueError):
+        getattr(service, method)(source)
+    provider.assert_not_called()
+
+
+@pytest.mark.parametrize("kind", ["image", "video"])
+def test_upload_api_reports_unsafe_source_as_validation_error(
+    client, auth_headers, service, kind
+):
+    from app.main import app
+    from app.api.v1.facebook import get_facebook_service
+
+    app.dependency_overrides[get_facebook_service] = lambda: service
+    try:
+        result = client.post(
+            f"/api/v1/facebook/upload-{kind}",
+            headers=auth_headers,
+            json={f"{kind}_url": "/test-private.txt"},
+        )
+        assert result.status_code == 422
+        assert "public HTTP or HTTPS URL" in result.json()["detail"]
+    finally:
+        app.dependency_overrides.pop(get_facebook_service, None)
+
+
+@pytest.mark.parametrize(
+    "method,video", [("upload_image", False), ("upload_video", True)]
+)
+@pytest.mark.parametrize("fails", [False, True])
+def test_legacy_upload_uses_managed_download_and_cleans_up(
+    service, monkeypatch, tmp_path, method, video, fails
+):
+    import app.services.facebook_service as facebook
+
+    path = tmp_path / "test-media"
+    download_calls = []
+
+    @contextmanager
+    def download(url, video=False):
+        download_calls.append((url, video))
+        path.write_bytes(b"test-media")
+        try:
+            yield str(path)
+        finally:
+            path.unlink()
+
+    monkeypatch.setattr(facebook, "download_media", download, raising=False)
+    asset = MagicMock()
+    asset.__getitem__.return_value = "123"
+    asset.remote_create.side_effect = (
+        RuntimeError("test-provider-failure") if fails else None
+    )
+    monkeypatch.setattr(
+        facebook, "AdVideo" if video else "AdImage", Mock(return_value=asset)
+    )
+    monkeypatch.setattr(service, "get_video_status", lambda _: {"status": "processing"})
+    arguments = {"wait_for_ready": False} if video else {}
+    if fails:
+        with pytest.raises(RuntimeError, match="test-provider-failure"):
+            getattr(service, method)("https://media.example/test", **arguments)
+    else:
+        getattr(service, method)("https://media.example/test", **arguments)
+    assert download_calls == [("https://media.example/test", video)]
+    assert not path.exists()
+    assert str(path) in [call.args[1] for call in asset.__setitem__.call_args_list]
+
+
+def test_downloader_pins_public_dns_and_preserves_tls_hostname(monkeypatch):
+    dns = Mock(
+        return_value=[
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))
+        ]
+    )
+    monkeypatch.setattr(media.socket, "getaddrinfo", dns)
+    response = Mock(status=200, headers={"Content-Type": "image/png"})
+    response.stream.return_value = iter([b"test-image"])
+    pool = Mock()
+    pool.urlopen.return_value = response
+    constructor = Mock(return_value=pool)
+    monkeypatch.setattr(media.urllib3, "HTTPSConnectionPool", constructor)
+    with media.download_media("https://media.example/test.png") as path:
+        assert Path(path).read_bytes() == b"test-image"
+    assert not Path(path).exists()
+    dns.assert_called_once()
+    assert constructor.call_args.args == ("93.184.216.34",)
+    assert constructor.call_args.kwargs["assert_hostname"] == "media.example"
+    assert constructor.call_args.kwargs["server_hostname"] == "media.example"
+    assert pool.urlopen.call_args.kwargs["headers"]["Host"] == "media.example"
+    assert pool.urlopen.call_args.kwargs["redirect"] is False
+    response.close.assert_called_once()
+    pool.close.assert_called_once()
+
+
+def test_downloader_revalidates_redirect_before_connecting(monkeypatch):
+    def resolve(host, port, **kwargs):
+        address = "93.184.216.34" if host == "media.example" else "127.0.0.1"
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, port))]
+
+    monkeypatch.setattr(media.socket, "getaddrinfo", resolve)
+    response = Mock(status=302, headers={"Location": "http://private.example/test"})
+    pool = Mock()
+    pool.urlopen.return_value = response
+    constructor = Mock(return_value=pool)
+    monkeypatch.setattr(media.urllib3, "HTTPSConnectionPool", constructor)
+    insecure_pool = Mock(side_effect=AssertionError("Private connection attempted"))
+    monkeypatch.setattr(media.urllib3, "HTTPConnectionPool", insecure_pool)
+    with pytest.raises(ValueError, match="public addresses"):
+        with media.download_media("https://media.example/test.png"):
+            pytest.fail("Unsafe redirect accepted")
+    insecure_pool.assert_not_called()
+
+
+@pytest.mark.parametrize("method", ["get_video_status", "get_video_thumbnails"])
+@pytest.mark.parametrize(
+    "video_id",
+    [
+        "../123/picture",
+        "123?redirect=true",
+        "123#ignored",
+        "https://evil.example",
+        "%2e%2e%2f123",
+        "１２３",
+    ],
+)
+def test_graph_video_ids_reject_path_and_query_injection(service, method, video_id):
+    with pytest.raises(ValueError):
+        getattr(service, method)(video_id)
+
+
+@pytest.mark.parametrize("method", ["get_video_status", "get_video_thumbnails"])
+def test_graph_video_reads_disable_redirects(service, method, monkeypatch):
+    response = Mock(status_code=302, headers={"Location": "http://127.0.0.1/private"})
+    response.json.return_value = {}
+    request = Mock(return_value=response)
+    monkeypatch.setattr(requests, "get", request)
+    with pytest.raises(ValueError, match="redirect"):
+        getattr(service, method)("123")
+    assert request.call_args.kwargs["allow_redirects"] is False
+    assert "access_token" not in request.call_args.kwargs.get("params", {})
+    assert (
+        request.call_args.kwargs["headers"]["Authorization"]
+        == "Bearer test-provider-token"
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "../123",
+        "123/picture",
+        "123?fields=secret",
+        "123#other",
+        "//evil.example",
+        "act_123/../../me",
+    ],
+)
+def test_delivery_rejects_unapproved_graph_paths(path, monkeypatch):
+    provider = DeliveryProvider.__new__(DeliveryProvider)
+    provider.access_token = "test-private-token"
+    request = Mock(side_effect=AssertionError("Invalid path reached transport"))
+    monkeypatch.setattr(requests, "get", request)
+    with pytest.raises(ProviderError):
+        provider.read(path)
+    request.assert_not_called()
+
+
+def test_delivery_rejects_graph_redirect(monkeypatch):
+    provider = DeliveryProvider.__new__(DeliveryProvider)
+    provider.access_token = "test-private-token"
+    response = Mock(
+        status_code=302, ok=True, headers={"Location": "http://127.0.0.1/private"}
+    )
+    response.json.return_value = {}
+    request = Mock(return_value=response)
+    monkeypatch.setattr(requests, "get", request)
+    with pytest.raises(ProviderError) as error:
+        provider.read("act_123/insights")
+    assert error.value.retryable is False
+    assert request.call_args.kwargs["allow_redirects"] is False
+
+
+@pytest.mark.skipif(not hasattr(signal, "setitimer"), reason="POSIX deadline")
+def test_redaction_hostile_inputs_have_bounded_cpu_cost():
+    def expired(*_):
+        raise AssertionError("Redaction exceeded its CPU deadline")
+
+    previous = signal.signal(signal.SIGALRM, expired)
+    signal.setitimer(signal.ITIMER_REAL, 0.5)
+    try:
+        for _ in range(8):
+            sanitize("a" * 8000)
+            sanitize("https://" * 1000)
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous)
+
+
+@pytest.mark.parametrize(
+    "text,secret",
+    [
+        ("Contact test-owner+tag@example.com now", "test-owner+tag@example.com"),
+        ("https://user:pass@host.test/path?token=test-private#fragment", "user:pass"),
+        ("https://test-owner:test-password@host.test/path", "test-owner"),
+        ("https://host.test/path?token=test-private#fragment", "test-private"),
+        ("https://host.test/path#test-private", "test-private"),
+    ],
+)
+def test_redaction_keeps_email_credentials_and_queries_private(text, secret):
+    assert secret not in sanitize(text)

--- a/backend/tests/test_video_upload.py
+++ b/backend/tests/test_video_upload.py
@@ -1,8 +1,7 @@
 """Tests for video upload functionality."""
 import pytest
-from unittest.mock import MagicMock, patch, mock_open
-import tempfile
-import os
+from unittest.mock import MagicMock, patch
+from contextlib import nullcontext
 
 
 class TestFacebookServiceVideo:
@@ -20,16 +19,11 @@ class TestFacebookServiceVideo:
             service.account = MagicMock()
             service.account.get_id_assured.return_value = "act_123456"
 
-            # Mock requests.get for URL download
-            mock_response = MagicMock()
-            mock_response.iter_content.return_value = [b"fake video content"]
-            mock_response.raise_for_status = MagicMock()
-
             # Mock AdVideo
             mock_video = MagicMock()
-            mock_video.__getitem__ = MagicMock(return_value="video_123")
+            mock_video.__getitem__ = MagicMock(return_value="123456")
 
-            with patch('requests.get', return_value=mock_response):
+            with patch('app.services.facebook_service.download_media', return_value=nullcontext('/test-managed-video.mp4')):
                 with patch('app.services.facebook_service.AdVideo', return_value=mock_video):
                     with patch.object(service, 'wait_for_video_ready', return_value={'status': 'ready'}):
                         with patch.object(service, 'get_video_thumbnails', return_value=['thumb1.jpg']):
@@ -38,33 +32,22 @@ class TestFacebookServiceVideo:
                                 ad_account_id="123456"
                             )
 
-            assert result['video_id'] == "video_123"
+            assert result['video_id'] == "123456"
             assert result['status'] == 'ready'
             assert 'thumbnails' in result
 
-    def test_upload_video_from_local_file(self):
-        """Test uploading video from local file path."""
+    def test_upload_video_rejects_local_file(self):
+        """Only public URLs are accepted from upload callers."""
         from app.services.facebook_service import FacebookService
 
         with patch.object(FacebookService, 'initialize'):
             service = FacebookService()
             service.api = MagicMock()
-            service.access_token = "test_token"
             service.account = MagicMock()
-            service.account.get_id_assured.return_value = "act_123456"
-
-            mock_video = MagicMock()
-            mock_video.__getitem__ = MagicMock(return_value="video_456")
-
-            with patch('app.services.facebook_service.AdVideo', return_value=mock_video):
-                with patch.object(service, 'wait_for_video_ready', return_value={'status': 'ready'}):
-                    with patch.object(service, 'get_video_thumbnails', return_value=[]):
-                        result = service.upload_video(
-                            "/path/to/video.mp4",
-                            wait_for_ready=True
-                        )
-
-            assert result['video_id'] == "video_456"
+            with patch('app.services.facebook_service.AdVideo') as video:
+                with pytest.raises(ValueError, match="public HTTP or HTTPS URL"):
+                    service.upload_video("/test-private-video.mp4")
+                video.assert_not_called()
 
     def test_get_video_status_ready(self):
         """Test getting video status when ready."""
@@ -74,18 +57,18 @@ class TestFacebookServiceVideo:
             service = FacebookService()
             service.access_token = "test_token"
 
-            mock_response = MagicMock()
+            mock_response = MagicMock(status_code=200)
             mock_response.json.return_value = {
-                'id': 'video_123',
+                'id': '123456',
                 'status': {'video_status': 'ready'},
                 'length': 30.5
             }
 
             with patch('requests.get', return_value=mock_response):
-                result = service.get_video_status("video_123")
+                result = service.get_video_status("123456")
 
             assert result['status'] == 'ready'
-            assert result['video_id'] == 'video_123'
+            assert result['video_id'] == '123456'
             assert result['length'] == 30.5
 
     def test_get_video_status_processing(self):
@@ -96,14 +79,14 @@ class TestFacebookServiceVideo:
             service = FacebookService()
             service.access_token = "test_token"
 
-            mock_response = MagicMock()
+            mock_response = MagicMock(status_code=200)
             mock_response.json.return_value = {
-                'id': 'video_123',
+                'id': '123456',
                 'status': {'video_status': 'processing'}
             }
 
             with patch('requests.get', return_value=mock_response):
-                result = service.get_video_status("video_123")
+                result = service.get_video_status("123456")
 
             assert result['status'] == 'processing'
 
@@ -115,13 +98,13 @@ class TestFacebookServiceVideo:
             service = FacebookService()
             service.access_token = "test_token"
 
-            mock_response = MagicMock()
+            mock_response = MagicMock(status_code=200)
             mock_response.json.return_value = {
                 'error': {'message': 'Video not found'}
             }
 
             with patch('requests.get', return_value=mock_response):
-                result = service.get_video_status("invalid_id")
+                result = service.get_video_status("999999")
 
             assert result['status'] == 'error'
             assert 'Video not found' in result['error']
@@ -134,7 +117,7 @@ class TestFacebookServiceVideo:
             service = FacebookService()
             service.access_token = "test_token"
 
-            mock_response = MagicMock()
+            mock_response = MagicMock(status_code=200)
             mock_response.json.return_value = {
                 'data': [
                     {'uri': 'https://example.com/thumb1.jpg'},
@@ -143,7 +126,7 @@ class TestFacebookServiceVideo:
             }
 
             with patch('requests.get', return_value=mock_response):
-                result = service.get_video_thumbnails("video_123")
+                result = service.get_video_thumbnails("123456")
 
             assert len(result) == 2
             assert 'thumb1.jpg' in result[0]
@@ -163,7 +146,7 @@ class TestFacebookServiceVideo:
                     {'status': 'ready'}
                 ]
                 with patch('time.sleep'):  # Skip actual sleeping
-                    result = service.wait_for_video_ready("video_123", timeout=60, interval=1)
+                    result = service.wait_for_video_ready("123456", timeout=60, interval=1)
 
             assert result['status'] == 'ready'
 
@@ -180,7 +163,7 @@ class TestFacebookServiceVideo:
                         # Simulate timeout by returning increasing times
                         mock_time.side_effect = [0, 100, 200]
                         with pytest.raises(Exception, match="timeout"):
-                            service.wait_for_video_ready("video_123", timeout=1)
+                            service.wait_for_video_ready("123456", timeout=1)
 
     def test_create_creative_with_video(self):
         """Test creating ad creative with video."""

--- a/docs/plans/security-codeql-findings.md
+++ b/docs/plans/security-codeql-findings.md
@@ -1,6 +1,6 @@
 # CodeQL security findings — 2026-09-08
 
-Status: in-progress
+Status: implementation verified; merge pending
 
 ## Outcome
 
@@ -29,7 +29,7 @@ unrelated dependency PR merges are included.
   bounded hostile inputs within a regression-test deadline.
 - [x] Each of the 17 critical/high alerts has a fix or an evidence-backed
   non-exploitable classification. No security alert is silently dismissed.
-- [ ] Focused regressions, the backend suite, and required GitHub checks pass.
+- [x] Focused regressions, the backend suite, and required GitHub checks pass.
 
 ## Phase 0: Tests
 
@@ -56,7 +56,17 @@ failures. After fixes, 139 focused tests passed (including an added URL-userinfo
 database tests use real local PostgreSQL. No browser UI behavior is being changed.
 The full backend suite passed: 504 passed and one pre-existing XPASS in 131.48 seconds.
 That run preceded the final redaction-order change; the affected 139-test group was
-then rerun successfully. GitHub CI will run the complete final revision.
+then rerun successfully. GitHub CI passed on implementation commit
+`d01b68ec4939e71fc48a75131d16e35602e8a447`: 505 backend tests passed with one
+pre-existing XPASS; frontend tests/build, installation journey, container
+startup/persistence, and CodeQL all passed. CodeQL reported zero new PR findings.
+Gitleaks and GitGuardian found no secrets in the patch. The optional Codecov upload
+failed because tokenless uploads are not enabled; it did not affect test execution.
+
+[PR #48 checks](https://github.com/jasonakatiff/theleadrouter-ad-studio/pull/48/checks)
+report the current revision's status. Implementation is verified; merging and
+production deployment have not been performed. Three task-owned local PostgreSQL
+databases were removed and their absence verified; no dev server remains.
 
 Detailed per-alert evidence is in
 [CodeQL triage](../security/codeql-triage-2026-09-08.md).

--- a/docs/plans/security-codeql-findings.md
+++ b/docs/plans/security-codeql-findings.md
@@ -1,0 +1,77 @@
+# CodeQL security findings — 2026-09-08
+
+Status: in-progress
+
+## Outcome
+
+Prevent campaign writers from fetching private network resources or uploading
+server files through Facebook media uploads. Constrain Facebook Graph reads and
+keep telemetry redaction responsive for hostile input. Classify all six critical
+and eleven high alerts against current code with reproducible evidence.
+
+## Scope and authorization
+
+Jason authorized validation and fixes after the GitHub security setup. Target:
+`jasonakatiff/theleadrouter-ad-studio`, base `cd83d131301b44548bf1e1b0261661df034f485c`,
+branch `fix/security-codeql-findings`. Prepare a pull request and run CI. No
+production application deployment, provider writes, database migrations, or
+unrelated dependency PR merges are included.
+
+## Acceptance criteria
+
+- [x] Facebook image/video uploads reject private addresses, unsafe redirects,
+  non-HTTP schemes, and all caller-supplied filesystem paths before provider upload.
+- [x] Public media uses the existing DNS-pinned downloader with byte/time limits;
+  temporary files close on success and provider failure.
+- [x] Graph reads reject path/query injection and HTTP redirects while preserving
+  supported account, ad, insight, video, and thumbnail reads.
+- [x] Telemetry redaction preserves credential/email/query removal and completes
+  bounded hostile inputs within a regression-test deadline.
+- [x] Each of the 17 critical/high alerts has a fix or an evidence-backed
+  non-exploitable classification. No security alert is silently dismissed.
+- [ ] Focused regressions, the backend suite, and required GitHub checks pass.
+
+## Phase 0: Tests
+
+- `backend/tests/security/test_codeql_regressions.py`: public media boundaries,
+  redirect/DNS rebinding resistance, local-file rejection, cleanup, Graph paths,
+  and telemetry redaction timing.
+- Existing `tests/posting/test_media.py`, `tests/posting/test_provider.py`,
+  `tests/test_video_upload.py`, `tests/unit/test_theme_library.py`, OAuth/key and
+  telemetry tests cover compatibility and existing mitigations.
+- Run with the existing Python 3.12 environment and a new localhost
+  `test_delivery_security_20260908` database. No shared database or live Meta call.
+
+## Implementation
+
+1. Reuse `app.delivery.media.download_media` in legacy Facebook upload methods.
+2. Validate Graph IDs/edges and disable redirects on the three flagged readers.
+3. Replace ambiguous email/URL redaction regexes with bounded token processing.
+4. Record the full alert triage, update the changelog, and prepare the PR.
+
+## Verification
+
+Phase 0 reproduced 38 failures with 6 baseline passes, then two API validation
+failures. After fixes, 139 focused tests passed (including an added URL-userinfo regression). Outbound provider calls are mocked;
+database tests use real local PostgreSQL. No browser UI behavior is being changed.
+The full backend suite passed: 504 passed and one pre-existing XPASS in 131.48 seconds.
+That run preceded the final redaction-order change; the affected 139-test group was
+then rerun successfully. GitHub CI will run the complete final revision.
+
+Detailed per-alert evidence is in
+[CodeQL triage](../security/codeql-triage-2026-09-08.md).
+
+## Initial triage
+
+- #16/#17: arbitrary URLs and local paths reach legacy upload methods; confirmed.
+- #12/#13: caller-controlled temp suffix/removal and local-file upload paths;
+  resolved by the same managed downloader change.
+- #23/#24/#25: fixed Graph host; path and redirect validation need hardening.
+- #18: both theme import and refresh apply a strict GitHub URL validator;
+  redirects and environment proxies are already disabled.
+- #20/#21: overlapping unanchored redaction patterns require a timing regression.
+- #11/#14/#15/#19/#26/#27/#28: trace source and sink before classification.
+
+## Unresolved questions
+
+None for implementation. Production merge/deployment is outside this authorization.

--- a/docs/security/codeql-triage-2026-09-08.md
+++ b/docs/security/codeql-triage-2026-09-08.md
@@ -1,0 +1,54 @@
+# Critical/high CodeQL triage — 2026-09-08
+
+Scope: the 17 critical/high alerts on `main` at
+`cd83d131301b44548bf1e1b0261661df034f485c`. Findings below are based on source/caller
+inspection and isolated regression tests. No production penetration test or live
+Facebook write was performed. GitHub alerts have not been manually dismissed.
+
+## Fixed or hardened
+
+| Alerts | Finding and impact | Change and evidence |
+| --- | --- | --- |
+| #16, #17 — critical | Legacy image/video uploads accepted arbitrary destinations. A campaign writer could request localhost, cloud metadata addresses, or redirect to private services. The same methods accepted filesystem paths and passed them to the Facebook SDK. | Both methods now use the existing `download_media` context manager. Tests reject private IPv4/IPv6, metadata addresses, file URLs, absolute and relative filesystem paths. Existing downloader resolves all addresses, rejects non-public addresses, connects to a pinned IP with the original TLS hostname, and revalidates each redirect. |
+| #12, #13 — high | Temporary file creation/removal depended on URL-derived values; caller-supplied local files also reached the SDK. | The custom temp-file logic is removed. Downloader-owned filenames use fixed suffixes and are cleaned up on success and provider exceptions. Regression tests verify no leftover file and no provider upload for disallowed sources. |
+| #23, #24, #25 — critical | All three first requests had a fixed `graph.facebook.com` host, so arbitrary-host SSRF was not reproduced. Resource paths accepted traversal/query syntax and requests followed redirects by default. | Legacy video reads require ASCII decimal IDs. Delivery reads allow only IDs/account IDs and the three used edges (`ads`, `insights`, `thumbnails`), plus the existing root multi-ID lookup. All three disable and reject redirects. Video credentials now use an Authorization header. Invalid-path and redirect tests fail before a second request. |
+| #20, #21 — high | Unanchored, overlapping email/query regexes caused excessive backtracking. Repeated hostile strings exceeded the 500 ms regression deadline. | Email matching now has a start boundary and possessive quantifiers; URL matching consumes one token and strips userinfo/query/fragment with string operations. The same deadline test passes and credential/email/query redaction remains covered. Python 3.11+ is required, matching CI and the application runtime. |
+
+Public media remains supported. Local server paths are intentionally rejected at
+the API boundary and return HTTP 422. Provider success is mocked in these tests;
+temporary-file handling and DNS/redirect decision logic execute for real.
+
+## Non-exploitable under the current data flow
+
+| Alert | Evidence and classification |
+| --- | --- |
+| #18 — critical, theme importer | `GitHubImport.github_only` requires HTTPS and an exact `github.com` or `raw.githubusercontent.com` authority, rejects queries/fragments and invalid path characters, then constructs a fixed raw.githubusercontent.com URL. Both import and persisted-theme refresh run this validator. The HTTP client disables redirects and environment proxies and bounds response size. Existing tests verify arbitrary-host rejection, private-host redirects, 32 KB limits, timeout handling, import and refresh. No arbitrary-host SSRF identified. |
+| #11 — high, OAuth state cookie | The value is a signed HS256 CSRF state, containing user ID, provider, random nonce, purpose and a 10-minute expiry. It contains no provider access/refresh token or password. The cookie is HttpOnly and Secure by default; HTTP development uses the explicit insecure option. Callbacks require a matching cookie, verify signature/purpose/provider/expiry, and clear the cookie. Existing tests cover mismatch and absent cookie rejection and successful clearing. Encrypting this signed, non-confidential state would not fix an observed vulnerability. |
+| #14 — high, API-key hashing | The reported source is `test_user_api_keys.py` reading the newly generated `apiKey` response; CodeQL labels it a password. Production creates these values with `secrets.token_urlsafe(32)`. SHA-256 hashes a 256-bit random bearer key, not a human password. Human passwords use bcrypt. Existing lifecycle tests prove hash-only persistence, revoked-key rejection, and read/write scope enforcement. Replacing this hash would invalidate stored keys without a demonstrated benefit. |
+| #15 — high, telemetry-key test | This is an assertion that the database contains the SHA-256 digest of a generated random API key. It is not a production password-hashing operation; the same key generation described for #14 applies. |
+| #19 — high, upload test | The substring check is an assertion against a mocked R2 upload response, not a production URL validator. It grants no access and initiates no outbound request. |
+| #26 — high, prototype exporter | The regex extracts script references from the trusted Vite build artifact. It is not applied to user-submitted HTML and is not an HTML sanitization boundary. Both embedded JS and CSS are repository-controlled build output. No remotely controllable input reaches this exporter. |
+| #27, #28 — high, prototype media preview | The source is the user's file picker. The `src` value is created by `URL.createObjectURL(file)` and kept in component memory; no raw file content or attacker-provided URL is inserted as HTML. Preview sinks are `<img>` and `<video>`, and filenames are React text/attributes. No `innerHTML`, `document.write`, `iframe`, `object`, or `embed` sink exists in this flow. SVG image-context restrictions disable script execution. This is source inspection, not a new browser acceptance run. |
+
+These classifications are specific to the existing callers and sinks. New callers,
+weaker validators, different preview elements, or human-selected API keys require
+review. They do not establish that the entire application is vulnerability-free.
+
+## Verification
+
+- Phase 0: 38 failures and 6 passes reproduce missing upload/Graph protections and
+  slow redaction. Two additional API tests reproduced HTTP 500 instead of 422.
+- After implementation: 139 focused tests passed, including real local PostgreSQL
+  API/OAuth/key/telemetry tests. Outbound provider transports were mocked.
+- Full backend suite: 504 passed, one existing XPASS. The final redaction-order
+  correction passed the 139-test affected group. GitHub CI status is tracked in the
+  [implementation plan](../plans/security-codeql-findings.md).
+- This task does not resolve the separate Dependabot backlog or the existing
+  non-blocking Bandit/pip-audit/npm-audit workflow. Their alerts must not be treated
+  as addressed by this patch.
+
+## References
+
+- [OWASP SSRF prevention](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html): redirect handling and address validation.
+- [CodeQL hashing guidance](https://codeql.github.com/codeql-query-help/python/py-weak-sensitive-data-hashing/): SHA-2 for data outside limited-input-space password hashing.
+- [MDN SVG image contexts](https://developer.mozilla.org/en-US/docs/Web/SVG/Guides/SVG_as_an_image): script restrictions for images, distinct from embedded documents.

--- a/docs/security/codeql-triage-2026-09-08.md
+++ b/docs/security/codeql-triage-2026-09-08.md
@@ -40,8 +40,10 @@ review. They do not establish that the entire application is vulnerability-free.
   slow redaction. Two additional API tests reproduced HTTP 500 instead of 422.
 - After implementation: 139 focused tests passed, including real local PostgreSQL
   API/OAuth/key/telemetry tests. Outbound provider transports were mocked.
-- Full backend suite: 504 passed, one existing XPASS. The final redaction-order
-  correction passed the 139-test affected group. GitHub CI status is tracked in the
+- Local backend suite: 504 passed, one existing XPASS. The final redaction-order
+  correction passed the 139-test affected group. GitHub CI then passed 505 backend
+  tests, frontend tests/build, installation, container persistence, and CodeQL
+  (zero new PR findings). Exact implementation commit and links are tracked in the
   [implementation plan](../plans/security-codeql-findings.md).
 - This task does not resolve the separate Dependabot backlog or the existing
   non-blocking Bandit/pip-audit/npm-audit workflow. Their alerts must not be treated


### PR DESCRIPTION
Campaign writers could pass private-network URLs or server file paths to the legacy Facebook image/video upload APIs. Uploads now use the existing DNS-pinned, bounded downloader and managed temporary files; invalid sources return HTTP 422.

Graph video/delivery reads validate resource IDs and supported edges, reject redirects, and keep video access tokens in headers. Telemetry redaction avoids excessive regex backtracking and removes URL userinfo before email redaction.

Validation on implementation commit d01b68ec4939e71fc48a75131d16e35602e8a447: 505 backend tests passed with one existing XPASS; frontend tests/build, installation journey, container startup/persistence, CodeQL (zero new PR findings), and GitGuardian passed. Locally, 139 focused tests passed, including 47 new regression cases. Gitleaks found no secrets. The final follow-up commit records this evidence in documentation; its checks appear below. Optional Codecov upload could not publish without a token; tests and coverage generation completed.

The plan and triage document address all 17 critical/high CodeQL findings: nine receive fixes or hardening; eight have evidence-backed false-positive classifications. No GitHub alert was manually dismissed. The separate Dependabot backlog (102 alerts, including three critical) and non-blocking dependency audit workflow remain outside this patch. No production deployment or live Facebook write was performed. Task-owned local test databases are cleaned up.

- [Implementation plan](https://github.com/jasonakatiff/theleadrouter-ad-studio/blob/fix/security-codeql-findings/docs/plans/security-codeql-findings.md)
- [Per-alert triage](https://github.com/jasonakatiff/theleadrouter-ad-studio/blob/fix/security-codeql-findings/docs/security/codeql-triage-2026-09-08.md)
