### PR TITLE
fix: default Instagram to page identity; honest Gemini analysis errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Instagram page identity default and honest Gemini analysis errors — 2026-09-10
+
+Ads no longer require a linked Instagram account when Instagram placements are on:
+the creative step defaults to "Use Facebook Page (default)", the wizard and the
+publish preflight accept the page identity, and the creative sets
+`use_page_actor_override` so Meta runs Instagram placements under the Page
+(issue #19).
+
+Creative analysis failures now report their real cause instead of pointing every
+failure at Settings → Integrations: provider safety blocks and rejected requests
+surface per-creative messages, rate limits retry once and then say to wait, and
+only key-level failures (401/403/402) change the stored connection status
+(issue #58).
+
+Tests: 12 backend unit tests passed (6 new for the provider boundary), 98
+frontend unit tests and the frontend build passed locally.
+
 ## Creative analytics and public production alignment — 2026-09-08
 
 Bring creative provenance, external uploads, Google/TikTok analytics, metadata patterns, request-volume settings, and posting recovery into the public release. Preserve installer setup, encrypted provider settings, current branding, and the public security fixes. Join both released database histories with an additive merge and retain existing users, credentials, and ads.

--- a/backend/app/api/v1/campaign_settings.py
+++ b/backend/app/api/v1/campaign_settings.py
@@ -424,16 +424,13 @@ def preflight(
                 "Select an accessible Facebook Page for this ad account."
             )
         instagram_id = creative.get("instagramId")
-        if "instagram" in adset_review["targeting"].get(
-            "publisher_platforms", ["instagram"]
-        ):
-            if not instagram_id or instagram_id not in {
-                row["id"]
-                for row in service.get_instagram_accounts(payload.ad_account_id)
-            }:
-                raise CampaignValidationError(
-                    "Select an accessible Instagram account or remove Instagram placements."
-                )
+        if instagram_id and instagram_id not in {
+            row["id"]
+            for row in service.get_instagram_accounts(payload.ad_account_id)
+        }:
+            raise CampaignValidationError(
+                "Select an accessible Instagram account, or leave it on the Facebook Page identity."
+            )
         url = urlparse(creative.get("websiteUrl", ""))
         if url.scheme not in ("http", "https") or not url.netloc:
             raise CampaignValidationError("A valid Website URL is required.")

--- a/backend/app/services/facebook_service.py
+++ b/backend/app/services/facebook_service.py
@@ -468,6 +468,10 @@ class FacebookService:
             'url_tags': creative_data.get('urlParameters') or creative_data.get('url_tags') or '',
             AdCreative.Field.object_story_spec: object_story_spec,
         }
+        if not instagram_id:
+            # Mirrors Ads Manager's "Use Facebook Page": Instagram placements run
+            # under the Page identity without requiring a linked Instagram account.
+            params['use_page_actor_override'] = True
 
         return account.create_ad_creative(params=params)
 

--- a/backend/app/services/generation_provider.py
+++ b/backend/app/services/generation_provider.py
@@ -1,6 +1,7 @@
 """Provider clients with request-scoped keys and redacted failures."""
 from app.telemetry.runtime import redact_values
 from datetime import datetime, timezone
+import asyncio
 import hmac
 import logging
 from sqlalchemy.exc import SQLAlchemyError
@@ -30,15 +31,34 @@ def record_result(provider, key, status):
         logging.getLogger(__name__).warning("Provider status could not be recorded; preserving the generation result.")
 
 
-def generation_failure(provider, key, status_code=None):
-    state = {401: "invalid", 403: "invalid", 402: "insufficient_credit"}.get(status_code, "temporarily_unavailable")
-    record_result(provider, key, state)
+def generation_failure(provider, key, status_code=None, provider_message=None):
+    state = {401: "invalid", 403: "invalid", 402: "insufficient_credit",
+             400: "request_rejected", 429: "rate_limited"}.get(status_code, "temporarily_unavailable")
+    if state in ("invalid", "insufficient_credit"):
+        # Only key-level failures may change the connection status; a per-request
+        # failure must not flip the Settings banner to "check this connection".
+        record_result(provider, key, state)
     messages = {
         "invalid": "The provider rejected this key. Replace it in Settings → Integrations.",
         "insufficient_credit": "Your provider account needs generation credits. Add credits before retrying.",
+        "request_rejected": "The provider rejected this request — usually the image or prompt, not your settings. Try a different creative.",
+        "rate_limited": "The provider is rate-limiting requests right now. Wait a minute and retry — no settings change is needed.",
         "temporarily_unavailable": "The provider did not complete this request. Check its request history before generating again; a timed-out request can still incur a charge.",
     }
-    return InstallationError("provider_failed", messages[state], 502, {"provider": provider, "status": state})
+    message = messages[state]
+    if state == "request_rejected" and provider_message:
+        message = f"The provider rejected this request: {provider_message[:200]} — usually the image or prompt, not your settings."
+    return InstallationError("provider_failed", message, 502, {"provider": provider, "status": state})
+
+
+BLOCKED_FINISH_REASONS = ("SAFETY", "IMAGE_SAFETY", "PROHIBITED_CONTENT", "RECITATION", "BLOCKLIST")
+
+
+def provider_error_message(response):
+    try:
+        return str(response.json()["error"]["message"])
+    except (ValueError, KeyError, TypeError):
+        return None
 
 
 async def generate_gemini_text(prompt, db=None, image_part=None):
@@ -49,15 +69,32 @@ async def generate_gemini_text(prompt, db=None, image_part=None):
     try:
         with redact_values(key):
             async with httpx.AsyncClient(timeout=90, follow_redirects=False) as client:
-                response = await client.post(
-                    "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent",
-                    headers={"x-goog-api-key": key},
-                    json={"contents": [{"parts": parts}]},
-                )
+                for attempt in (1, 2):
+                    response = await client.post(
+                        "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent",
+                        headers={"x-goog-api-key": key},
+                        json={"contents": [{"parts": parts}]},
+                    )
+                    if response.status_code in (429, 500, 502, 503) and attempt == 1:
+                        await asyncio.sleep(2)
+                        continue
+                    break
         if not response.is_success:
-            raise generation_failure("gemini", key, response.status_code)
+            raise generation_failure("gemini", key, response.status_code, provider_error_message(response))
         body = response.json()
-        value = "".join(part.get("text", "") for part in body["candidates"][0]["content"]["parts"])
+        candidates = body.get("candidates") or []
+        block_reason = (body.get("promptFeedback") or {}).get("blockReason")
+        finish_reason = candidates[0].get("finishReason") if candidates else None
+        if block_reason or finish_reason in BLOCKED_FINISH_REASONS or not candidates:
+            # The key works; the provider declined this specific content.
+            record_result("gemini", key, "connected")
+            raise InstallationError(
+                "generation_blocked",
+                "The provider declined to process this content"
+                f" ({block_reason or finish_reason or 'no result returned'})."
+                " Try a different creative — no settings change is needed.",
+                422, {"provider": "gemini", "status": "blocked"})
+        value = "".join(part.get("text", "") for part in candidates[0]["content"]["parts"])
         if not value:
             raise ValueError("Empty provider response")
         record_result("gemini", key, "connected")

--- a/backend/tests/unit/test_generation_provider.py
+++ b/backend/tests/unit/test_generation_provider.py
@@ -1,0 +1,107 @@
+"""Gemini failures map to honest, per-request errors; only key failures touch status."""
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core.installation import InstallationError
+from app.services import generation_provider as gp
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, body=None):
+        self.status_code = status_code
+        self.is_success = status_code < 400
+        self._body = body or {}
+
+    def json(self):
+        return self._body
+
+
+class FakeClient:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def post(self, *args, **kwargs):
+        self.calls += 1
+        return self._responses.pop(0)
+
+
+@pytest.fixture(autouse=True)
+def quiet_provider(monkeypatch):
+    monkeypatch.setattr(gp, "require_provider_key", lambda provider, db=None: "test-gemini-key")
+    recorded = []
+    monkeypatch.setattr(gp, "record_result", lambda provider, key, status: recorded.append(status))
+    monkeypatch.setattr(gp.asyncio, "sleep", AsyncMock())
+    return recorded
+
+
+def run_with(monkeypatch, responses):
+    client = FakeClient(responses)
+    monkeypatch.setattr(gp.httpx, "AsyncClient", lambda **kwargs: client)
+    return client, asyncio.new_event_loop().run_until_complete(gp.generate_gemini_text("test-prompt"))
+
+
+def run_error(monkeypatch, responses):
+    client = FakeClient(responses)
+    monkeypatch.setattr(gp.httpx, "AsyncClient", lambda **kwargs: client)
+    with pytest.raises(InstallationError) as excinfo:
+        asyncio.new_event_loop().run_until_complete(gp.generate_gemini_text("test-prompt"))
+    return client, excinfo.value
+
+
+def gemini_ok(text="test-analysis"):
+    return FakeResponse(200, {"candidates": [{"content": {"parts": [{"text": text}]}, "finishReason": "STOP"}]})
+
+
+def test_success_returns_text_and_marks_connected(monkeypatch, quiet_provider):
+    client, value = run_with(monkeypatch, [gemini_ok()])
+    assert value == "test-analysis"
+    assert quiet_provider == ["connected"]
+
+
+def test_safety_block_is_per_creative_and_keeps_connection_healthy(monkeypatch, quiet_provider):
+    blocked = FakeResponse(200, {"promptFeedback": {"blockReason": "SAFETY"}, "candidates": []})
+    client, error = run_error(monkeypatch, [blocked])
+    assert error.code == "generation_blocked"
+    assert "no settings change" in error.message.lower()
+    assert quiet_provider == ["connected"]
+
+
+def test_rate_limit_retries_then_reports_without_settings_prompt(monkeypatch, quiet_provider):
+    client, error = run_error(monkeypatch, [FakeResponse(429), FakeResponse(429)])
+    assert client.calls == 2
+    assert error.details["status"] == "rate_limited"
+    assert "settings" not in error.message.lower() or "no settings change" in error.message.lower()
+    assert quiet_provider == []
+
+
+def test_rate_limit_then_success_recovers(monkeypatch, quiet_provider):
+    client, value = run_with(monkeypatch, [FakeResponse(429), gemini_ok()])
+    assert client.calls == 2
+    assert value == "test-analysis"
+    assert quiet_provider == ["connected"]
+
+
+def test_bad_request_surfaces_provider_reason_not_settings(monkeypatch, quiet_provider):
+    bad = FakeResponse(400, {"error": {"message": "Image exceeds the maximum allowed size."}})
+    client, error = run_error(monkeypatch, [bad])
+    assert error.details["status"] == "request_rejected"
+    assert "Image exceeds the maximum allowed size." in error.message
+    assert "Settings" not in error.message
+    assert quiet_provider == []
+
+
+def test_invalid_key_still_points_at_settings(monkeypatch, quiet_provider):
+    client, error = run_error(monkeypatch, [FakeResponse(401)])
+    assert error.details["status"] == "invalid"
+    assert "Settings" in error.message
+    assert quiet_provider == ["invalid"]

--- a/frontend/src/components/AdCreativeStep.jsx
+++ b/frontend/src/components/AdCreativeStep.jsx
@@ -34,9 +34,6 @@ export default function AdCreativeStep({ onNext, onBack }) {
     const [retry, setRetry] = useState(0);
     const update = (field, value) =>
         setCreativeData((previous) => ({ ...previous, [field]: value }));
-    const needsInstagram =
-        !adsetData.targeting.publisher_platforms ||
-        adsetData.targeting.publisher_platforms.includes('instagram');
     useEffect(() => {
         let active = true;
         Promise.allSettled([
@@ -159,10 +156,9 @@ export default function AdCreativeStep({ onNext, onBack }) {
                     <SearchableSelect
                         label="Instagram account"
                         value={creativeData.instagramId || ''}
-                        options={instagram}
+                        options={[{ id: '', name: 'Use Facebook Page (default)' }, ...instagram]}
                         onChange={(id) => update('instagramId', id || null)}
                         loading={loading}
-                        required={needsInstagram}
                         error={
                             errors.find((error) => error.field === 'creativeData.instagramId')
                                 ?.message

--- a/frontend/src/lib/campaignWizard.js
+++ b/frontend/src/lib/campaignWizard.js
@@ -322,15 +322,6 @@ export function validateWizard(state, step = null) {
         if (!creative.headlines?.some((v) => v.trim()))
             add('creativeData.headlines', 'A headline is required.');
         if (!creative.pageId) add('creativeData.pageId', 'Select a Facebook Page.');
-        if (
-            (!adset.targeting.publisher_platforms ||
-                adset.targeting.publisher_platforms.includes('instagram')) &&
-            !creative.instagramId
-        )
-            add(
-                'creativeData.instagramId',
-                'Select an Instagram account or remove Instagram placements.',
-            );
         try {
             if (!['http:', 'https:'].includes(new URL(creative.websiteUrl).protocol))
                 throw new Error();


### PR DESCRIPTION
Fixes #19. Fixes #58. Follow-ups from the 9/10 media-team QA pass.

## Instagram: Use Facebook Page by default (#19)
- Creative step's Instagram selector now offers **Use Facebook Page (default)** and is no longer required; the wizard no longer blocks with *'Select an Instagram account or remove Instagram placements.'*
- Publish preflight accepts the page identity and only validates an Instagram account when one is actually chosen.
- `create_ad_creative` sets `use_page_actor_override` when no Instagram account is picked — same behavior as Ads Manager's 'Use Facebook Page', so Instagram placements run under the Page identity even without a linked Instagram account.

## Gemini creative analysis: real causes, not settings prompts (#58)
- Safety-blocked content raises a 422 `generation_blocked` with the provider's block reason ('no settings change is needed').
- 400s surface the provider's own message (e.g. oversized image) instead of a generic failure.
- 429/5xx retry once after 2s; a persistent 429 reports a rate limit, not a settings problem.
- Only key-level failures (401/403/402) update the stored provider status, so a transient per-creative failure no longer flips the Settings → Integrations banner that non-admins can't act on.

## Tests
- `backend/tests/unit/test_generation_provider.py` (new, 6 cases: success, safety block, 429→retry→fail, 429→retry→success, 400 with provider message, 401) — passing against an isolated local Postgres.
- Existing `test_copy_generation.py` (6) passing; frontend `npm run test:unit` 98/98 and `npm run build` passing.

Note for QA: geo location search/exclude (#8/#27) needs no code change — it's already on `main` (`LocationPicker` in the ad set step); retest after the next deploy.

https://claude.ai/code/session_01Utp81VpNYzXLCVmKHiBhGB